### PR TITLE
docs: add Contributor License Grant (relicense optionality)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,22 @@
 
 Thanks for considering a contribution.
 
+## Contributor License Grant
+
+By submitting a pull request, comment with code suggestion, or any other contribution to this repository, you certify that:
+
+1. The contribution is your original work, **or** you have explicit permission from the rights holder to submit it.
+2. Your contribution is licensed under the [MIT License](./LICENSE), same as the rest of the project.
+3. You grant the project maintainer (Maxime Gagnon) and successors a **perpetual, irrevocable, worldwide, royalty-free right** to relicense your contribution under different terms in future versions of the project, including more restrictive or commercial licenses (e.g. BSL, AGPL, source-available, dual-license).
+
+### Why the relicense grant?
+
+The project is MIT today and is expected to stay MIT for the foreseeable future. The grant preserves the **option** to dual-license or pivot to a source-available license later if adoption sustains a commercial track. It does **not** change the terms under which you can use, fork, or redistribute the project as it exists today — all released versions remain MIT, forever.
+
+If your employer's IP policy or your own preference makes this grant unacceptable, please open an issue **before** opening a PR so we can discuss.
+
+This grant is on the same model used by Sentry, HashiCorp, and similar projects before they pivoted to source-available licenses. It is functionally a lightweight inbound-license-grant — no separate CLA signature required; acceptance is by act of contribution.
+
 ## Reporting bugs
 
 Open an issue with the "bug" template. Include the version (`essaim --version`) and a minimal reproduction (preset used, agent count, log output).


### PR DESCRIPTION
## Summary

Adds a **Contributor License Grant** clause to `CONTRIBUTING.md` that preserves the option to relicense future versions of the project, without affecting already-released versions (which remain MIT forever).

## What it does

When someone submits a PR, by act of submission they certify that:
1. The contribution is their original work (or they have permission).
2. The contribution is licensed under MIT (same as the project — this is the default per GitHub TOS anyway).
3. **They grant the maintainer a perpetual, irrevocable, royalty-free right to relicense the contribution under different terms in future versions** (e.g. BSL, AGPL, dual-license, commercial).

## Why now

The project is solo-authored today (single contributor: Maxime Gagnon). That means relicensing future versions is currently a 1-person decision. As soon as external contributors land code, that flexibility could vanish — UNLESS we have a license grant in place from the start.

This is the same lightweight inbound-license-grant model used by Sentry, HashiCorp, Elastic, MongoDB, Redis etc. **before** they pivoted to source-available licenses. By having it in place from the start, the project preserves the strategic option to monetize via license change later if adoption justifies it — without committing to that path now.

Mirrors the same clause added to `mcp-coordinator/CONTRIBUTING.md`.

## What it does NOT do

- It does NOT change the project's current license.
- It does NOT retroactively apply to past versions. All released code stays MIT, irrevocably.
- It does NOT require contributors to sign a separate CLA document.
- It does NOT prevent forking.

## Test plan

- [x] Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)