### PR TITLE
fix(hooks): normalize file_path to repo-relative before POST

### DIFF
--- a/scripts/pre_track_activity.sh
+++ b/scripts/pre_track_activity.sh
@@ -23,6 +23,17 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Normalize FILE_PATH to repo-relative, forward-slash form.
+# In team-mode the coordinator is on a different machine and cannot
+# resolve the agent's local repo root; only this client can.
+if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
+  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$REPO_ROOT" ] && [[ "$FILE_PATH" == "$REPO_ROOT"/* ]]; then
+    FILE_PATH="${FILE_PATH#$REPO_ROOT/}"
+  fi
+  FILE_PATH="${FILE_PATH//\\//}"
+fi
+
 curl -s --max-time 2 -X POST "$COORDINATOR_URL/api/working-files/start" \
   -H "Content-Type: application/json" \
   -d "$(jq -n \

--- a/scripts/track_activity.sh
+++ b/scripts/track_activity.sh
@@ -25,6 +25,17 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Normalize FILE_PATH to repo-relative, forward-slash form.
+# In team-mode the coordinator is on a different machine and cannot
+# resolve the agent's local repo root; only this client can.
+if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
+  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$REPO_ROOT" ] && [[ "$FILE_PATH" == "$REPO_ROOT"/* ]]; then
+    FILE_PATH="${FILE_PATH#$REPO_ROOT/}"
+  fi
+  FILE_PATH="${FILE_PATH//\\//}"
+fi
+
 # v0.6: include file content in the payload if under 256 KB
 SIZE=$(stat -c%s "$FILE_PATH" 2>/dev/null || stat -f%z "$FILE_PATH" 2>/dev/null || echo 999999)
 if [ "$SIZE" -lt 262144 ] && [ -f "$FILE_PATH" ]; then


### PR DESCRIPTION
## Summary

Fixes Layer 1 conflict-detection failure in mcp-coordinator team-mode.

Hooks were sending absolute paths like \`/home/alice/clone-1/src/foo.ts\`. Two agents in two different clones sent two different absolute paths for the same logical file → coordinator stored them as distinct → no conflict detected.

After this fix, both hooks resolve the local repo root via \`git rev-parse --show-toplevel\` and strip it before POSTing. Both agents now send \`src/foo.ts\` → coordinator correctly correlates them.

## Companion change

mcp-coordinator gets a complementary PR to defensively apply \`path-normalize.ts\` server-side (when \`COORDINATOR_REPO_ROOT\` is set) + document the contract in the MCP tool Zod schemas.

## Test plan

- [x] \`npm test\` — 302/303 baseline preserved (the 1 known Windows perms failure is unrelated)
- [ ] End-to-end smoke against a 2-clones coordinator setup