### PR TITLE
chore(deps): bump mcp-coordinator to ^0.13.0 + adopt ServerHandle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@swoofer/promptweave": "^0.1.0",
         "commander": "^14.0.3",
         "handlebars": "^4.7.0",
-        "mcp-coordinator": "^0.5.0",
+        "mcp-coordinator": "^0.13.0",
         "mqtt": "^5.15.0",
         "pino": "^10.3.1",
         "ws": "^8.20.0"
@@ -2903,16 +2903,18 @@
       }
     },
     "node_modules/mcp-coordinator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/mcp-coordinator/-/mcp-coordinator-0.5.0.tgz",
-      "integrity": "sha512-E3QmYC0bEiFVOkmwuQYZWARDuZkHPLtG2HNPvrHXCY9s0dWxqgbrlx+KX+Rf/X+57CJC8lWXsTzPUeKO/6e8Gg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/mcp-coordinator/-/mcp-coordinator-0.13.0.tgz",
+      "integrity": "sha512-797fKjfTkqTKuXMKoVgKUCLyvs3unpJkdOSTjV1jEmJJEXZu4TXvCGnikF5BE9uiG8bzGA24Z8lIN1RL6NIAgw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "aedes": "^1.0.2",
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
+        "cookie": "^1.0.2",
         "jose": "^6.2.2",
+        "lru-cache": "^11.0.2",
         "mqtt": "^5.15.0",
         "pino": "^10.3.1",
         "prom-client": "^15.1.3",
@@ -2939,13 +2941,32 @@
         "tree-sitter-php": "^0.22.0",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-ruby": "^0.21.0",
-        "tree-sitter-rust": "^0.21.2",
+        "tree-sitter-rust": "^0.21.0",
         "tree-sitter-swift": "^0.6.0",
         "tree-sitter-typescript": "^0.21.2"
       }
     },
-    "node_modules/mcp-coordinator/node_modules/tree-sitter-rust": {
-      "optional": true
+    "node_modules/mcp-coordinator/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mcp-coordinator/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/mcp-coordinator/node_modules/zod": {
       "version": "3.25.76",
@@ -4607,6 +4628,33 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tree-sitter-rust": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.21.0.tgz",
+      "integrity": "sha512-unVr73YLn3VC4Qa/GF0Nk+Wom6UtI526p5kz9Rn2iZSqwIFedyCZ3e0fKCEmUJLIPGrTb/cIEdu3ZUNGzfZx7A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-rust/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tree-sitter-swift": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@swoofer/promptweave": "^0.1.0",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
-    "mcp-coordinator": "^0.5.0",
+    "mcp-coordinator": "^0.13.0",
     "mqtt": "^5.15.0",
     "pino": "^10.3.1",
     "ws": "^8.20.0"

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { resolve } from "path";
 import { createLogger } from "../logger.js";
 import { startServer } from "mcp-coordinator";
+type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 const log = createLogger("orchestrator");
 
 let __filename: string;
@@ -61,17 +62,17 @@ export async function runProject(
   runOpts: RunProjectOptions = {},
 ): Promise<RunResult> {
   // Strategy A: start in-process coordinator unless caller provided an external URL.
-  // startServer() returns Promise<void> — no handle is exposed, so cleanup is
-  // implicit when the process exits. We track whether we started one so the
-  // finally block can log appropriately.
-  let inProcessCoordinatorStarted = false;
+  // mcp-coordinator >=0.13 returns a ServerHandle from startServer({...}); we
+  // hold onto it so the finally block can release the HTTP server, MQTT broker,
+  // SSE listeners, DB, and quota timer without waiting for process exit.
+  // registerSignalHandlers:false because essaim owns SIGTERM/SIGINT itself.
+  let coordinatorHandle: ServerHandle | null = null;
   if (mode === "with_coordinator" && !runOpts.coordinatorUrl) {
     const port = parseInt(process.env.PORT || "3100", 10);
     const dataDir = process.env.COORDINATOR_DATA_DIR || "./tmp-essaim/coordinator-data";
     log.info(`Starting in-process coordinator on port ${port} (dataDir: ${dataDir})`);
-    await startServer({ port, dataDir });
-    runOpts = { ...runOpts, coordinatorUrl: `http://localhost:${port}` };
-    inProcessCoordinatorStarted = true;
+    coordinatorHandle = await startServer({ port, dataDir, registerSignalHandlers: false });
+    runOpts = { ...runOpts, coordinatorUrl: `http://localhost:${coordinatorHandle.port}` };
     log.info(`In-process coordinator ready at ${runOpts.coordinatorUrl}`);
   }
 
@@ -82,12 +83,13 @@ export async function runProject(
   try {
     return await _runProjectBody(project, mode, cleanup, runOpts, effectiveCoordinatorUrl);
   } finally {
-    if (inProcessCoordinatorStarted) {
-      // startServer() does not expose a .close() handle; the HTTP server is
-      // released when the process exits. For CLI one-shot invocations this is
-      // fine. If long-lived embedding is needed, mcp-coordinator would need to
-      // expose a ServerHandle type from startServer.
-      log.info("In-process coordinator will stop on process exit");
+    if (coordinatorHandle) {
+      try {
+        await coordinatorHandle.stop();
+        log.info("In-process coordinator stopped");
+      } catch (err) {
+        log.warn("Failed to stop in-process coordinator cleanly", { err: err instanceof Error ? err.message : String(err) });
+      }
     }
   }
 }

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -6,28 +6,69 @@ import type {
   ConflictReport,
 } from "mcp-coordinator/types";
 
+// These tests guard against silent drift between essaim's expectations and
+// mcp-coordinator's exported unions. We use `satisfies Record<Union, true>`
+// so adding a new member upstream is a *compile error* here (the object
+// literal stops covering the union) — not a passing test we trust by mistake.
+// The earlier shape — `const xs: Union[] = [...]; expect(xs).toHaveLength(N)`
+// — never caught additions: `Union[]` is happy with a strict subset, and the
+// runtime length check just re-asserts the literal we wrote.
+
 describe("Types", () => {
   it("Thread status values are exhaustive", () => {
-    const statuses: Thread["status"][] = ["open", "resolving", "resolved", "cancelled"];
-    expect(statuses).toHaveLength(4);
+    const keys = {
+      open: true,
+      resolving: true,
+      resolved: true,
+      cancelled: true,
+      poisoned: true,
+    } as const satisfies Record<Thread["status"], true>;
+    expect(Object.keys(keys).sort()).toEqual(
+      ["cancelled", "open", "poisoned", "resolved", "resolving"],
+    );
   });
 
   it("MessageType values are exhaustive", () => {
-    const types: ThreadMessage["type"][] = ["context", "suggestion", "warning", "resolution", "approve", "contest"];
-    expect(types).toHaveLength(6);
+    const keys = {
+      context: true,
+      suggestion: true,
+      warning: true,
+      resolution: true,
+      approve: true,
+      contest: true,
+    } as const satisfies Record<ThreadMessage["type"], true>;
+    expect(Object.keys(keys)).toHaveLength(6);
   });
 
   it("EventType values are exhaustive", () => {
-    const types: CoordinatorEvent["type"][] = [
-      "agent_online", "agent_offline", "thread_opened", "message_posted",
-      "resolution_proposed", "thread_resolved", "thread_cancelled", "file_edited", "action_summary",
-    ];
-    expect(types).toHaveLength(9);
+    const keys = {
+      agent_online: true,
+      agent_offline: true,
+      thread_opened: true,
+      message_posted: true,
+      resolution_proposed: true,
+      thread_resolved: true,
+      thread_cancelled: true,
+      file_edited: true,
+      action_summary: true,
+      impact_scored: true,
+      introspection_requested: true,
+      introspection_completed: true,
+      agent_activity: true,
+      task_claimed: true,
+      token_usage: true,
+      quota_update: true,
+    } as const satisfies Record<CoordinatorEvent["type"], true>;
+    expect(Object.keys(keys)).toHaveLength(16);
   });
 
   it("ConflictReport types are exhaustive", () => {
-    const types: ConflictReport["type"][] = ["module_overlap", "api_contract", "file_overlap", "dependency_chain"];
-    expect(types).toHaveLength(4);
+    const keys = {
+      module_overlap: true,
+      api_contract: true,
+      file_overlap: true,
+      dependency_chain: true,
+    } as const satisfies Record<ConflictReport["type"], true>;
+    expect(Object.keys(keys)).toHaveLength(4);
   });
 });
-


### PR DESCRIPTION
## Summary

essaim's pin was `mcp-coordinator: ^0.5.0`, which under semver caret on a 0.x version means strictly the 0.5.x line — eight minor releases of upstream work (v0.6 through v0.13) were invisible to a clean install. This PR catches us up and picks up the API surface that v0.13 added specifically for essaim.

## Why now

mcp-coordinator just shipped v0.13.0 (Channels Phase 2 reply tool + chained Docker publish fix), and `startServer` now returns a `ServerHandle` with a `.stop()` method. The orchestrator was sitting on an in-place TODO asking for exactly this:

```ts
// startServer() does not expose a .close() handle; the HTTP server is
// released when the process exits. For CLI one-shot invocations this is
// fine. If long-lived embedding is needed, mcp-coordinator would need to
// expose a ServerHandle type from startServer.
```

That's now in v0.13. The coordinator's own ServerOptions JSDoc explicitly calls essaim out as the embedder that needs `registerSignalHandlers: false`, so the upstream API was designed with this use case in mind.

## Changes

- **`package.json` / `package-lock.json`**: pin bumped to `^0.13.0`, lockfile resolved.
- **`src/orchestrator/orchestrator.ts`**:
  - Capture the `ServerHandle` returned by `startServer({ port, dataDir, registerSignalHandlers: false })`.
  - Release it deterministically in the `finally` block via `await coordinatorHandle.stop()` (was: leak until process exit).
  - Pass `registerSignalHandlers: false` so the embedded coordinator doesn't fight essaim for SIGTERM/SIGINT.
  - Derived the `ServerHandle` type via `Awaited<ReturnType<typeof startServer>>` since upstream doesn't re-export the interface by name from the package root.
- **`tests/unit/types.test.ts`**: rewrote the four "exhaustive" assertions from `const xs: Union[] = [...]; expect(xs).toHaveLength(N)` (which never caught additions — a `Union[]` literal accepts a strict subset, and the length check just re-asserts what you wrote) to `as const satisfies Record<Union, true>` so a new member upstream becomes a compile error. This surfaced two cases that had silently drifted between v0.5 and v0.13:
  - `Thread["status"]` gained `"poisoned"` (work-stealing F4 poison threshold) → now 5 members
  - `CoordinatorEvent["type"]` gained 7 new event types (`impact_scored`, `introspection_requested`, `introspection_completed`, `agent_activity`, `task_claimed`, `token_usage`, `quota_update`) → now 16 members
  - `MessageType` (6) and `ConflictReport["type"]` (4) unchanged.

## Verification (Windows, Node 22)

- `npm run build` → tsc clean.
- `npm test` → 302/303 pass; the one failure is `tests/unit/orchestrator-write.test.ts > "writes hook scripts with 0o755 permissions"`, which is the pre-existing Windows chmod quirk (Windows reports `stat.mode & 0o100 === 0` regardless of `fs.chmodSync(..., 0o755)`). Same fail count as before this PR.
- Runtime smoke: `import('mcp-coordinator')` → `startServer({ port: 13100, dataDir, registerSignalHandlers: false })` → `handle.port === 13100`, `fetch('/health')` → `200 {"status":"alive","version":"0.13.0","auth_enabled":false}` → `await handle.stop()` → clean shutdown logs.

## Test plan

- [x] tsc clean
- [x] unit tests green (modulo pre-existing Windows chmod)
- [x] runtime smoke of `startServer`/`handle.stop()` end-to-end
- [ ] CI confirms the above on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)