### PR TITLE
feat(behaviors): add user-brief — free-form per-run context injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Behaviors contribute numbered sections that sort deterministically into a final 
 
 | Layer | Sections | Responsibility | Sample behaviors |
 |-------|----------|----------------|------------------|
-| Foundation | 000-009 | Who I am, which project | `project-context`, `coordinator-rules` |
+| Foundation | 000-009 | Who I am, which project | `project-context`, `user-brief`, `coordinator-rules` |
 | Patterns | 010-029 | How I coordinate | `announce-before-write`, `conflict-resolution`, `worktree-isolation`, `sequential-wait` |
 | Mission | 030-050 | What I actually do | bug-hunting, test-writing, refactoring, code-review, debate, quiz, translation, sequential pipelines — 21 in total |
 | Transversal | 050-099 | Constraints and style | `activity-tracking`, `read-only-mode` |
@@ -141,6 +141,20 @@ Three rules adapt behaviors automatically based on what's assembled.
 | `solo-mode-strip` | `coordinator-rules.solo_mode = true` | Strips announce / conflict-resolution entirely; agent works alone |
 
 List the templates the CLI ships with via `essaim list`. To preview what a template assembles (prompt + agent plan) without burning tokens, use `essaim run <template> --dry-run`. Behaviors, presets, and composition rules live under [`behaviors/`](./behaviors/), [`presets/`](./presets/), and [`compositions/`](./compositions/) in this repo — browse them directly to author or edit.
+
+### Briefing a run with free-form context
+
+Every preset includes the `user-brief` behavior in slot `001-user-brief` (right after project identity, before any coordination rules). It's a free-form "system-prompt prefix" the operator can fill at launch time, no preset edit required. Both fields are optional — when neither is set, nothing renders.
+
+```bash
+essaim run raid -p . --agents 3 \
+  --set user-brief.brief='We are migrating the checkout from Stripe v3 to v4. Payment-touching code under src/payments/ must NOT be modified without a feature flag.' \
+  --set user-brief.constraints='["No breaking changes to /api/v1/*","Keep Node 18 compat","Each agent commits in its own worktree, no cross-merge"]'
+```
+
+The brief lands once per agent prompt and is visible across every phase (discover / review / execute) because `user-brief` is not phase-tagged. Confirm with `essaim run <template> --dry-run` (the assembled prompt size will jump by the brief's length).
+
+**Dispatch caveat (`maitre`, `revue`)**: in lead/worker presets, the lead's brief does NOT auto-propagate to dispatched workers — the dispatch travels through `announce_work(plan: ...)`, not through the worker's prompt. Set the brief on the worker preset too (`maitre-worker`, `revue-reviewer`) — every agent reads its own copy.
 
 ---
 

--- a/behaviors/user-brief.yaml
+++ b/behaviors/user-brief.yaml
@@ -1,0 +1,29 @@
+name: user-brief
+description: "Per-run free-form context — narrative brief and hard constraints"
+category: coordination
+
+params:
+  brief:
+    type: string
+    required: false
+    description: "Free-form context the operator wants every agent to see before doing anything (goal, background, gotchas)"
+  constraints:
+    type: "string[]"
+    required: false
+    description: "Hard rules for this run — e.g. modules not to modify, API contracts to preserve, compat requirements"
+
+sections:
+  "001-user-brief":
+    prompt: |
+      {{#if params.brief}}
+      ## Contexte de cette session
+      {{params.brief}}
+
+      {{/if}}
+      {{#if params.constraints}}
+      ### Contraintes pour ce run
+      {{#each params.constraints}}
+      - {{this}}
+      {{/each}}
+
+      {{/if}}

--- a/presets/arene-player.yaml
+++ b/presets/arene-player.yaml
@@ -3,6 +3,7 @@ description: "Joueur de trivia — répond aux questions du quizmaster"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - check-interrupt
   - activity-tracking

--- a/presets/arene-quizmaster.yaml
+++ b/presets/arene-quizmaster.yaml
@@ -3,6 +3,7 @@ description: "Quizmaster — organise un quiz sur la base de code"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/babel-reviewer.yaml
+++ b/presets/babel-reviewer.yaml
@@ -3,6 +3,7 @@ description: "Réviseur de traductions"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - check-interrupt
   - activity-tracking

--- a/presets/babel-translator.yaml
+++ b/presets/babel-translator.yaml
@@ -3,6 +3,7 @@ description: "Traducteur de documentation"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/carrefour.yaml
+++ b/presets/carrefour.yaml
@@ -3,6 +3,7 @@ description: "Test de détection de conflits — agents sur les mêmes fichiers"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/chaine-implement.yaml
+++ b/presets/chaine-implement.yaml
@@ -3,6 +3,7 @@ description: "Pipeline séquentiel — étape 1: implémentation"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/chaine-review.yaml
+++ b/presets/chaine-review.yaml
@@ -3,6 +3,7 @@ description: "Pipeline séquentiel — étape 2: review"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - check-interrupt
   - activity-tracking

--- a/presets/chaine-test.yaml
+++ b/presets/chaine-test.yaml
@@ -3,6 +3,7 @@ description: "Pipeline séquentiel — étape 3: tests"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/debat.yaml
+++ b/presets/debat.yaml
@@ -3,6 +3,7 @@ description: "Débat architectural — 3 agents débattent comment restructurer 
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/dev.yaml
+++ b/presets/dev.yaml
@@ -3,6 +3,7 @@ description: "Interactive developer session — briefing, coordinator-aware, fil
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - session-lifecycle
   - activity-tracking

--- a/presets/gardien.yaml
+++ b/presets/gardien.yaml
@@ -3,6 +3,7 @@ description: "Audit qualité du projet — analyse sans modification"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/maitre-lead.yaml
+++ b/presets/maitre-lead.yaml
@@ -3,6 +3,7 @@ description: "Tech lead — analyse et distribue les tâches aux workers"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/maitre-worker.yaml
+++ b/presets/maitre-worker.yaml
@@ -3,6 +3,7 @@ description: "Worker — exécute les tâches assignées par le lead"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/melee.yaml
+++ b/presets/melee.yaml
@@ -3,6 +3,7 @@ description: "Écriture de tests en parallèle — discovery + work-stealing"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - conflict-resolution

--- a/presets/raid.yaml
+++ b/presets/raid.yaml
@@ -3,6 +3,7 @@ description: "Bug hunting coordonné en parallèle — discovery + work-stealing
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - conflict-resolution

--- a/presets/relais-1.yaml
+++ b/presets/relais-1.yaml
@@ -3,6 +3,7 @@ description: "Course de relais — Coureur 1: nettoyage initial (départ)"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/relais-2.yaml
+++ b/presets/relais-2.yaml
@@ -3,6 +3,7 @@ description: "Course de relais — Coureur 2: amélioration architecturale (mili
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/relais-3.yaml
+++ b/presets/relais-3.yaml
@@ -3,6 +3,7 @@ description: "Course de relais — Coureur 3: finition et validation (arrivée)"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/revue-author.yaml
+++ b/presets/revue-author.yaml
@@ -3,6 +3,7 @@ description: "Auteur dans une revue croisée — améliore un module"
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - check-interrupt

--- a/presets/revue-reviewer.yaml
+++ b/presets/revue-reviewer.yaml
@@ -3,6 +3,7 @@ description: "Reviewer dans une revue croisée — review un module différent"
 profile: communicant
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - check-interrupt
   - activity-tracking

--- a/presets/swarm.yaml
+++ b/presets/swarm.yaml
@@ -3,6 +3,7 @@ description: “Refactoring en essaim — discovery + work-stealing”
 profile: codeur
 behaviors:
   - project-context
+  - user-brief
   - coordinator-rules
   - announce-before-write
   - conflict-resolution


### PR DESCRIPTION
## What

Adds a new Foundation-layer behavior \`user-brief\` that lets the operator inject narrative context and hard constraints into every agent's prompt at launch time, **without editing a preset YAML or stuffing the content into \`phase-discover.discovery_mission\`** (where it would overwrite the phase's own scope guidance and not propagate to other phases).

\`\`\`bash
essaim run raid -p . --agents 3 \
  --set user-brief.brief='Migrating checkout from Stripe v3 to v4. src/payments/ is off-limits without a feature flag.' \
  --set user-brief.constraints='[\"No breaking changes to /api/v1/*\",\"Keep Node 18 compat\"]'
\`\`\`

## Design (informed by 3 parallel codebase audits before writing a line)

| Decision | Why |
|---|---|
| Slot \`001-user-brief\` | 001 is unused in Foundation (000-009); project-context owns 000-identity. \"Who I am\" → \"What this run is about\" → \"How I coordinate\" reads in the right order. |
| No \`phase:\` field | Renders in every phase's prompt automatically (discover/review/execute). The brief follows the agent through the pipeline. |
| Both params \`required: false\` + conditional rendering | When no \`--set\` is provided, the section emits **nothing** — safe to wire into all 21 presets unconditionally. Byte-identical prompt to pre-PR when unused. |
| Wired into **all 21** presets (after \`project-context\`) | Matches the universal pattern of \`project-context\` / \`coordinator-rules\` / \`activity-tracking\` (already 21/21). Even \`debat\` is included — conditional render makes the inclusion harmless. |
| First use of \`{{#each}}\` in the catalog | Bullets for constraints are clearer than Handlebars' default array stringification (\`[\"X\",\"Y\"]\` → \`X,Y\`). promptweave's renderer supports \`{{#each}}\` out of the box (\`promptweave/dist/src/template.js\`). |

## Verification

End-to-end smoke through essaim's own \`buildProject()\` on a raid preset:

- Brief text + section header rendered in correct position (line ~6 of a ~7000-char assembled prompt, before coordination rules) ✓
- Constraints rendered as bullets, with blank lines either side so Markdown headers parse cleanly ✓
- With **no** \`--set\`, no headers leak into the prompt (byte-stable vs main) ✓
- All 21 presets accepted user-brief on load (Zod schema validation in promptweave) ✓

Also:

- \`tsc\` clean
- \`npm test\` → 302/303 (same Windows chmod skip as baseline; unrelated)

## Caveat documented in README

Lead → worker prompts (\`maitre\`, \`revue\`) do **not** auto-propagate the lead's brief — the dispatch travels through \`announce_work(plan: ...)\`, not through the worker's prompt. Each worker preset reads its own \`user-brief\`; operators can set the same brief on both, or different ones.

## Test plan

- [x] tsc + unit tests
- [x] End-to-end raid agent prompt composition with brief set
- [x] End-to-end raid agent prompt composition with brief unset (no leakage)
- [ ] Spot check via \`essaim run swarm --dry-run --set user-brief.brief='...'\` on a real project once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)