### PR TITLE
feat(behaviors): split read-only-mode + add audit-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Behaviors contribute numbered sections that sort deterministically into a final 
 | Foundation | 000-009 | Who I am, which project | `project-context`, `user-brief`, `coordinator-rules` |
 | Patterns | 010-029 | How I coordinate | `announce-before-write`, `conflict-resolution`, `worktree-isolation`, `sequential-wait` |
 | Mission | 030-050 | What I actually do | bug-hunting, test-writing, refactoring, code-review, debate, quiz, translation, sequential pipelines — 21 in total |
-| Transversal | 050-099 | Constraints and style | `activity-tracking`, `read-only-mode` |
+| Transversal | 050-099 | Constraints and style | `activity-tracking`, `read-only-mode`, `audit-output` |
 
 ### Composition rules
 
@@ -141,6 +141,17 @@ Three rules adapt behaviors automatically based on what's assembled.
 | `solo-mode-strip` | `coordinator-rules.solo_mode = true` | Strips announce / conflict-resolution entirely; agent works alone |
 
 List the templates the CLI ships with via `essaim list`. To preview what a template assembles (prompt + agent plan) without burning tokens, use `essaim run <template> --dry-run`. Behaviors, presets, and composition rules live under [`behaviors/`](./behaviors/), [`presets/`](./presets/), and [`compositions/`](./compositions/) in this repo — browse them directly to author or edit.
+
+### Read-only audits with a fixed write surface
+
+`read-only-mode` is strict: agents read, analyze, and communicate via MCP threads, but write nothing — no `Write`, no `Edit`, no created files. To carve out an exception for a specific audit report (without lifting the rest of the no-write fence), pair it with `audit-output`:
+
+```bash
+essaim solo gardien -p . \
+  --set 'audit-output.paths=["MIGRATION_AUDIT.md","docs/risks.md"]'
+```
+
+`gardien` ships with `audit-output.paths = ["AUDIT.md"]` by default; override with `--set` for any other artifact path. The pair (`read-only-mode` + `audit-output`) renders as "no writes — except these exact paths". Presets that need pure read-only communication (`debat`, `revue-reviewer`, `chaine-review`, `arene-*`) include only `read-only-mode` and write nothing at all.
 
 ### Briefing a run with free-form context
 

--- a/behaviors/audit-output.yaml
+++ b/behaviors/audit-output.yaml
@@ -1,0 +1,25 @@
+name: audit-output
+description: "Carve out write permission for a fixed list of audit artifact paths"
+category: safety
+
+params:
+  paths:
+    type: "string[]"
+    required: false
+    description: "Exact paths (relative to project root) the agent may write to — typically audit reports or plan documents. Anything not in this list is refused."
+
+sections:
+  "091-audit-output":
+    prompt: |
+      {{#if params.paths}}
+      ## Exception au mode lecture seule
+
+      Le mode lecture seule (section précédente) interdit toute écriture, MAIS tu as l'autorisation explicite d'écrire EXACTEMENT les fichiers listés ci-dessous — et eux seuls :
+
+      {{#each params.paths}}
+      - `{{this}}`
+      {{/each}}
+
+      Aucun autre Write ou Edit n'est autorisé. Si tu ne peux pas exprimer tes findings dans ces fichiers, signale-le et arrête. Ne tente pas de contourner (renommer, déplacer ailleurs, créer un fichier différent &laquo;&nbsp;équivalent&nbsp;&raquo;).
+
+      {{/if}}

--- a/behaviors/read-only-mode.yaml
+++ b/behaviors/read-only-mode.yaml
@@ -1,10 +1,14 @@
 name: read-only-mode
-description: "Agent cannot modify files — analysis and communication only"
+description: "Strict no-write mode — agent reads and discusses, never modifies files"
 category: safety
 
 sections:
   "090-safety-readonly":
     prompt: |
-      ## Contrainte
-      Tu es en mode lecture seule. Tu ne modifies JAMAIS de fichiers.
-      Tu analyses, communiques et rapportes. Tu ne codes pas.
+      ## Contrainte — mode lecture seule
+
+      Tu ne modifies AUCUN fichier du repo, et tu ne CRÉES aucun fichier non plus. Pas de Write, pas d'Edit, pas de NotebookEdit. Aucune exception.
+
+      Tu analyses (Read, Glob, Grep, Bash de lecture comme `wc -l` ou `find`), tu raisonnes, tu communiques tes findings dans la conversation et dans les threads MCP du coordinator (post_to_thread, propose_resolution, etc.). C'est tout.
+
+      Si un autre behavior plus tard dans ce prompt te donne une exception explicite pour un chemin précis (voir `audit-output`), seule cette exception est valide — pas d'extension par analogie.

--- a/presets/gardien.yaml
+++ b/presets/gardien.yaml
@@ -1,5 +1,5 @@
 name: gardien
-description: "Audit qualité du projet — analyse sans modification"
+description: "Audit qualité du projet — analyse sans modification, écrit un rapport unique"
 profile: communicant
 behaviors:
   - project-context
@@ -10,4 +10,9 @@ behaviors:
   - activity-tracking
   - shared-workspace
   - read-only-mode
+  - audit-output
   - quality-audit
+params:
+  audit-output:
+    paths:
+      - "AUDIT.md"


### PR DESCRIPTION
## Why

Today's monpikto migration audit surfaced a real ambiguity. The \`read-only-mode\` behavior prompt said *\"tu ne modifies JAMAIS de fichiers\"* but the \`gardien\` preset shipped an agent expected to **write** a single audit report. The agent had to figure out, from context alone, that *\"read-only\"* really meant *\"don't touch existing source files, but feel free to create the named artifact in the brief\"*.

That ambiguity bit hard on Claude Code's \`-p\` (print) mode: the Write tool calls got silently denied (no UI to approve in non-interactive mode), producing zero output even though the agent had completed its analysis.

## What

Split the concern into two composable behaviors.

| Behavior | Mode |
|---|---|
| \`read-only-mode\` (existing, tightened) | **Strict.** No Write, no Edit, no NotebookEdit, no file creation. The agent reads and communicates via MCP threads — that's it. |
| \`audit-output\` (new) | Carves out an exception for a fixed list of allowed paths (\`paths: string[]\`). Renders nothing when \`paths\` is empty/unset — the strict read-only fence stays in place. |

\`gardien\` preset declares both and defaults \`audit-output.paths\` to \`[\"AUDIT.md\"]\`:

\`\`\`bash
# Default — writes to AUDIT.md
essaim solo gardien -p .

# Override for a specific migration
essaim solo gardien -p . \
  --set 'audit-output.paths=[\"MIGRATION_AUDIT.md\",\"docs/risks.md\"]'
\`\`\`

The other 5 presets that include \`read-only-mode\` (\`debat\`, \`chaine-review\`, \`revue-reviewer\`, \`arene-quizmaster\`, \`arene-player\`) communicate purely via MCP threads and don't write files; they get the new strict behavior unchanged and gain nothing from \`audit-output\` (correctly omitted).

## Design decisions

- **Section 091** for audit-output (right after read-only at 090). Reads in order: \"no writes\" → \"except for these paths\". The narrative flows.
- **Exact paths only, no globs.** Glob patterns invite creative interpretation by the model (\`docs/audit/*.md\` → agent writes \`docs/audit/whoopsies.md\` you didn't ask for). A fixed list is auditable. If a real \"write anywhere in this dir\" need shows up later, add a separate \`audit-output-dir\` behavior — YAGNI for now.
- **\`paths\` is \`required: false\`.** Empty/unset means the section renders nothing; functionally identical to strict read-only. Lets presets opt-in to audit-output without forcing a default.
- **gardien defaults to \`[\"AUDIT.md\"]\`** to preserve out-of-the-box UX. The override pattern via \`--set\` is the canonical way to point at a different artifact.

## Verification

Smoke test through \`buildSoloPrompt(\"gardien\", ...)\` end-to-end with four cases:

| Case | Assertion | Pass |
|---|---|---|
| Default | read-only section present | ✓ |
| Default | audit-output exception section present | ✓ |
| Default | \`AUDIT.md\` listed | ✓ |
| Default | read-only renders before audit-output | ✓ |
| Override paths | new paths listed | ✓ (both \`MIGRATION_AUDIT.md\` and \`docs/risks.md\`) |
| Override paths | default \`AUDIT.md\` no longer present | ✓ |
| Empty paths | read-only still present | ✓ |
| Empty paths | no exception section rendered | ✓ |
| Strict wording | mentions Write/Edit/NotebookEdit explicitly | ✓ |
| Strict wording | forbids file creation (not just modification) | ✓ |

**11/11 passed.** \`npm run build\` clean. \`npm test\` 302/303 (same pre-existing Windows chmod skip as baseline).

## Test plan

- [x] tsc clean
- [x] Smoke test covers default, override, empty, and strict-wording cases
- [x] Unit tests baseline
- [ ] Real-world run: \`essaim solo gardien -p . --set 'audit-output.paths=[\"MIGRATION_AUDIT.md\"]'\` on a project, confirm the audit lands on the right file

🤖 Generated with [Claude Code](https://claude.com/claude-code)