### PR TITLE
feat: coordinator auth (COORDINATOR_TOKEN) + YAML template catalog + mekova templates

### DIFF
--- a/behaviors/migrate-scaffold.yaml
+++ b/behaviors/migrate-scaffold.yaml
@@ -1,0 +1,100 @@
+name: migrate-scaffold
+description: "Scaffolder — bootstraps the target stack project (npm scaffold + shared/ components + lib/supabase) before per-slice migrators start"
+category: mission
+
+params:
+  audit_path:
+    type: string
+    default: MIGRATION_AUDIT.md
+    description: "Relative path to the consolidated migration audit (read-only reference for shared/ and risques transverses)."
+  source_root:
+    type: string
+    default: src/features
+    description: "Where the source slices live (for reading the existing shared/ and inferring conventions)."
+  target_root:
+    type: string
+    default: web
+    description: "Project root for the migrated codebase (e.g. 'web'). Will be created by this agent."
+  target_features_root:
+    type: string
+    default: web/src/features
+    description: "Where the migrated slices will land. Only shared/ is owned by this agent; everything else is owned by per-slice migrators."
+  target_stack:
+    type: string
+    default: "React 18 + TypeScript strict, Vite, Tailwind 4 + DaisyUI 5 (emerald/halloween), TanStack Query, Zustand, Vitest, React Testing Library"
+    description: "One-line description of the destination tech stack."
+  install_command:
+    type: string
+    default: "npm create vite@latest web -- --template react-ts"
+    description: "Command to run for the initial scaffold."
+
+sections:
+  "030-mission":
+    prompt: |
+      ## Ta mission — Scaffolder du projet React
+
+      Tu es l'**unique** agent qui initialise le projet cible. Tu travailles AVANT que les migrators per-slice ne se lancent — ils dépendent de ton output (la racine `{{params.target_root}}/` + le slice `shared/` + `lib/supabase.ts` + `main.tsx`).
+
+      **Bossérvation cruciale** : tu partages le workspace avec les futurs migrators (workspace: shared). Tout ce que tu écris est immédiatement visible pour eux. **Quand tu as fini, ils peuvent commencer.** Ils sont staggés à 5 min après ton lancement — si tu n'as pas écrit `{{params.target_features_root}}/shared/index.ts` à ce moment-là, ils vont attendre / échouer.
+
+      ### Périmètres
+
+      - **À écrire (cible exclusive)** :
+        - `{{params.target_root}}/` — toute la racine du projet (package.json, configs, etc.)
+        - `{{params.target_features_root}}/shared/` — les 14 composants UI partagés + index + models
+        - `{{params.target_root}}/src/lib/supabase.ts` — singleton client Supabase
+        - `{{params.target_root}}/src/main.tsx`, `{{params.target_root}}/src/index.css` — entry point + Tailwind import
+        - `{{params.target_root}}/src/test/setup.ts` — config Vitest
+      - **À lire (référence)** :
+        - `{{params.audit_path}}` — surtout sections "shared", "Vue d'ensemble", "Risques transverses"
+        - `{{params.source_root}}/shared/` — le slice Rust existant à porter
+      - **À NE PAS toucher** : `{{params.target_features_root}}/<autre>/` (territoires des migrators per-slice), `{{params.source_root}}/<autre>/` (code Rust intact), `supabase/` (backend hors scope).
+
+      ### Stack cible
+      {{params.target_stack}}
+
+      ### Méthode
+
+      #### Phase 1 — Bootstrap (≈ 2 min)
+      1. **Annonce-toi** au coordinator : `announce_work` avec `target_modules: ["scaffold"]`, `subject: "Scaffold web/ + shared/ slice"`, et un `plan` court listant les jalons (init, deps, shared, lib, propose_resolution).
+      2. Initialise le scaffold Vite : `{{params.install_command}}` (variantes : pnpm si tu détectes un lockfile pnpm dans le source).
+      3. Installe les deps suivantes côté `{{params.target_root}}/` :
+         - Runtime : `tailwindcss@4 @tailwindcss/postcss daisyui@5 @supabase/supabase-js @tanstack/react-query zustand`
+         - Dev : `vitest @testing-library/react @testing-library/jest-dom @testing-library/user-event @types/node jsdom autoprefixer postcss`
+      4. Configure : `tsconfig.json` strict (`strict: true`, `noUncheckedIndexedAccess: true`), `vite.config.ts`, `vitest.config.ts`, `postcss.config.js` (Tailwind 4 + autoprefixer), `web/src/index.css` (Tailwind directives + DaisyUI plugin).
+
+      #### Phase 2 — Infrastructure (≈ 2 min)
+      5. **`src/lib/supabase.ts`** : singleton du client. **Utilise `@supabase/supabase-js`** (`createClient` avec `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY`). Expose un helper `getSupabaseClient()` qui throw si les env vars manquent. **Pas de fetch raw côté React** (les agents qui suivent doivent passer par le client SDK pour bénéficier des refresh tokens + Realtime). Documente cette décision dans un commentaire en tête de fichier (les autres agents la liront).
+      6. **`src/main.tsx`** : entry React avec `QueryClientProvider` (TanStack), import du CSS, mount sur `#root`.
+      7. **`src/test/setup.ts`** : `import '@testing-library/jest-dom/vitest'` (+ tout extra de matchers).
+
+      #### Phase 3 — Slice `shared/` (≈ 4-8 min)
+      8. Lis section "shared" de `{{params.audit_path}}` pour connaître les composants (14 listés : `Alert`, `Badge`, `Button`, `Card`, `EmptyState`, `ErrorState`, `FormField`, `ImageSlot`, `LoadingState`, `Modal`, `PageHeader`, `Spinner`, `TextInput`) + helpers de classes (`button_classes`, `card_classes`, etc.) dans `models.ts`.
+      9. Lis le Rust correspondant (`{{params.source_root}}/shared/*.rs`) en entier. Tests inclus (`tests.rs`).
+      10. **Porte en TDD strict** : pour chaque composant
+          - Écris le test Vitest AVANT le code TS (RED). 1 test Rust = 1 test Vitest.
+          - Implémente le composant (GREEN).
+          - Refactor (REFACTOR) sans casser les tests.
+      11. **`{{params.target_features_root}}/shared/index.ts`** : re-exports publics de tous les composants + types.
+
+      #### Phase 4 — Signal de fin (CRUCIAL)
+      12. Vérifie que **tout passe** :
+          - `cd {{params.target_root}} && npm test -- --run` → 0 fail
+          - `cd {{params.target_root}} && npx tsc --noEmit` → 0 erreur
+      13. **`propose_resolution`** du thread d'annonce avec un récap clair : "Scaffold prêt, shared/ migré (N composants, M tests verts), TODO: rien pour shared, les migrators peuvent démarrer."
+      14. **Pas de message après ça**. Ton boulot est terminé. Les migrators verront ton thread résolu et démarreront leur slice.
+
+      ### Règles dures (verrouillées par les tests)
+
+      - **Aucun texte hardcodé** dans les composants — labels via props (cohérent avec le CLAUDE.md du Rust).
+      - **Aria labels préservés** depuis le Rust (vérifiés par tests).
+      - **Pas de `as any`, pas de `@ts-ignore`** sauf cas extrême documenté.
+      - **Convention de noms exportés** : variants/sizes en **kebab-case TypeScript** (`ButtonVariant = "primary" | "secondary" | ...`), PAS en PascalCase, pour matcher le Rust et permettre une migration sans surprise des call sites côté slices à venir.
+      - **Helpers purs** (`buttonClasses(variant, size, fullWidth, extra)`) exportés depuis `shared/models.ts`, exactement comme le Rust. Pas inline dans les composants. Les autres agents les importeront.
+
+      ### Garde-fous
+
+      - **Ne touche pas aux slices non-`shared/`** — les autres agents s'en chargent. Si tu vois un composant que tu pourrais factoriser, **annonce-le** dans un `post_to_thread`, ne le crée pas.
+      - **Ne crée pas de fichier hors `{{params.target_root}}/`**.
+      - **Ne modifie pas le code Rust** (`{{params.source_root}}/...`).
+      - **Ne pas anticiper les besoins de slices futurs** (par exemple un `useAuthedFetch` n'est PAS dans shared — c'est dans `auth/` plus tard). Reste minimaliste.

--- a/behaviors/migrate-slice.yaml
+++ b/behaviors/migrate-slice.yaml
@@ -1,0 +1,96 @@
+name: migrate-slice
+description: "Slice migrator — one agent ports one source-slice into a target tech stack, referencing an upstream audit"
+category: mission
+
+params:
+  target_slice:
+    type: string
+    required: true
+    description: "Slice this agent owns (e.g. 'auth', 'shared'). Set per-agent by the orchestrator from context.modules."
+  audit_path:
+    type: string
+    default: MIGRATION_AUDIT.md
+    description: "Relative path to the consolidated migration audit (read-only reference)."
+  source_root:
+    type: string
+    default: src/features
+    description: "Where the source slices live."
+  target_root:
+    type: string
+    default: web/src/features
+    description: "Where the migrated slices must land."
+  target_stack:
+    type: string
+    default: "React 18 + TypeScript strict, Vite, Tailwind 4 + DaisyUI 5, TanStack Query, Zustand, Vitest"
+    description: "One-line description of the destination tech stack."
+  test_command:
+    type: string
+    default: "cd web && npm test"
+    description: "Command the agent runs to verify its tests pass."
+  typecheck_command:
+    type: string
+    default: "cd web && npx tsc --noEmit"
+    description: "Command the agent runs to verify TS types."
+
+sections:
+  "030-mission":
+    prompt: |
+      ## Ta mission — Migrateur du slice « {{params.target_slice}} »
+
+      Tu fais partie d'un essaim de N migrateurs en parallèle. **Chacun possède UN slice exclusif.** Le tien est `{{params.target_slice}}`. Ne touche à aucun autre — un autre agent s'en occupe.
+
+      ### Tes périmètres
+      - **À lire (source)** : `{{params.source_root}}/{{params.target_slice}}/`
+      - **À écrire (cible)** : `{{params.target_root}}/{{params.target_slice}}/`
+      - **À NE PAS toucher** : tout `{{params.source_root}}/<autre>/` (code source intact), tout `{{params.target_root}}/<autre>/` (territoire d'un autre agent), `supabase/` (backend hors scope).
+
+      ### Référence obligatoire — l'audit consolidé
+
+      Avant TOUT code, lis :
+      1. `{{params.audit_path}}` en entier (vue d'ensemble, désaccords, risques transverses, ordre de migration).
+      2. La section `## {{params.target_slice}}` qui te concerne (fichiers exacts, risques propres, edge functions, complexités).
+
+      Cet audit est ton contrat. Si un fait du code te surprend par rapport à l'audit, signale-le dans ton thread plutôt que de réécrire silencieusement.
+
+      ### Stack cible
+      {{params.target_stack}}
+
+      ### Méthode imposée (TDD strict)
+
+      1. **Setup partagé d'abord** : si `{{params.target_root}}/../` (la racine `web/`) n'existe pas encore, **tu es le premier agent à arriver** — initialise le scaffold (`npm create vite@latest web -- --template react-ts`, install Tailwind 4 + DaisyUI 5 + TanStack Query + Zustand + Vitest, configure `vite.config.ts` + `tsconfig.json`). **Annonce ce setup au coordinator AVANT de commencer** (`announce_work` avec `target_modules` incluant un module commun comme `web-scaffold`) pour que les autres agents ne dupliquent pas.
+
+      2. **Pour chaque module de ton slice** (`models.rs`, `state.rs`, `services.rs`, `components.rs`, etc.) :
+         - Lis le fichier source ET ses tests (`tests.rs`)
+         - Porte les **tests Vitest AVANT** le code (RED). 1 test Rust = 1 test Vitest, même nom de cas, même assertion.
+         - Implémente le code TypeScript pour rendre les tests verts (GREEN). Minimum viable.
+         - Refactor une fois vert (REFACTOR), sans casser les tests.
+         - Lance `{{params.test_command}}` pour confirmer.
+
+      3. **Coordination via le coordinator** :
+         - `announce_work` au démarrage avec `target_modules: ["{{params.target_slice}}"]`, `subject` clair, `plan` court.
+         - À chaque jalon (module terminé, blocage, décision transverse), `post_to_thread` un résumé court.
+         - Si tu touches à un pattern transverse (auth headers, supabase client, idempotency-key helper), annonce-le sur un module commun (ex. `target_modules: ["{{params.target_slice}}", "shared-infra"]`) pour que les autres agents prennent ta convention.
+         - À la fin, `propose_resolution` avec la liste des livrables et les éventuels TODO.
+
+      ### Règles dures (verrouillées par les tests)
+
+      - **Pas de texte hardcodé** dans les composants — labels via props.
+      - **Pas de `fetch()` direct** dans un composant — toujours un service via hook.
+      - **Pas de client Supabase construit dans un composant** — singleton dans `web/src/lib/supabase.ts`.
+      - **Pas de `as any`, pas de `@ts-ignore`** sauf cas extrême documenté en commentaire.
+      - **Préserver tous les ARIA labels** du Rust (vérifiés par tests).
+      - **Risques transverses de l'audit** : appliquer obligatoirement les helpers `buildAuthHeaders`, `useAuthedQuery`, `useIdempotentMutation` (ou créer si ton slice les introduit en premier).
+
+      ### Livrables minimum
+
+      - `{{params.target_root}}/{{params.target_slice}}/index.ts` (re-exports publics)
+      - Tous les fichiers TS/TSX nécessaires
+      - Tests Vitest qui passent : `{{params.test_command}}`
+      - Zéro erreur TypeScript strict : `{{params.typecheck_command}}`
+      - Un court récap dans `propose_resolution` (composants livrés, tests portés, conventions adoptées, TODO restants si applicable).
+
+      ### Garde-fous
+
+      - **Ne te lance pas sur les autres slices** même si tu vois un bug — annonce-le dans un thread, c'est tout.
+      - **Ne refactore pas le code Rust** — il restera en service le temps que tous les slices migrent.
+      - **N'introduis pas de dépendance npm exotique** sans justifier dans `propose_resolution`.

--- a/behaviors/migrate-slice.yaml
+++ b/behaviors/migrate-slice.yaml
@@ -17,8 +17,12 @@ params:
     description: "Where the source slices live."
   target_root:
     type: string
+    default: web
+    description: "Project root for the migrated codebase (e.g. 'web'). Owned by the scaffolder agent — must exist before this agent starts."
+  target_features_root:
+    type: string
     default: web/src/features
-    description: "Where the migrated slices must land."
+    description: "Where the migrated slices live. This agent writes to {{target_features_root}}/{{target_slice}}/ exclusively."
   target_stack:
     type: string
     default: "React 18 + TypeScript strict, Vite, Tailwind 4 + DaisyUI 5, TanStack Query, Zustand, Vitest"
@@ -41,8 +45,8 @@ sections:
 
       ### Tes périmètres
       - **À lire (source)** : `{{params.source_root}}/{{params.target_slice}}/`
-      - **À écrire (cible)** : `{{params.target_root}}/{{params.target_slice}}/`
-      - **À NE PAS toucher** : tout `{{params.source_root}}/<autre>/` (code source intact), tout `{{params.target_root}}/<autre>/` (territoire d'un autre agent), `supabase/` (backend hors scope).
+      - **À écrire (cible)** : `{{params.target_features_root}}/{{params.target_slice}}/`
+      - **À NE PAS toucher** : tout `{{params.source_root}}/<autre>/` (code source intact), tout `{{params.target_features_root}}/<autre>/` (territoire d'un autre agent), `{{params.target_features_root}}/shared/` (territoire du scaffolder, déjà fait), `supabase/` (backend hors scope).
 
       ### Référence obligatoire — l'audit consolidé
 
@@ -57,19 +61,26 @@ sections:
 
       ### Méthode imposée (TDD strict)
 
-      1. **Setup partagé d'abord** : si `{{params.target_root}}/../` (la racine `web/`) n'existe pas encore, **tu es le premier agent à arriver** — initialise le scaffold (`npm create vite@latest web -- --template react-ts`, install Tailwind 4 + DaisyUI 5 + TanStack Query + Zustand + Vitest, configure `vite.config.ts` + `tsconfig.json`). **Annonce ce setup au coordinator AVANT de commencer** (`announce_work` avec `target_modules` incluant un module commun comme `web-scaffold`) pour que les autres agents ne dupliquent pas.
+      1. **Pré-condition obligatoire — le scaffold doit être prêt avant que tu touches au code** :
+         - Vérifie que `{{params.target_features_root}}/shared/index.ts` existe (`Glob` ou `Read`).
+         - Vérifie que `{{params.target_root}}/src/lib/supabase.ts` existe.
+         - Si l'un des deux est absent → un agent `scaffolder` est encore en train de bosser. **Attends.** Soit via `mcp__coordinator__wait_for_peers` (avec un timeout généreux 600s), soit en relisant après 30s (`Bash sleep 30 && ls {{params.target_features_root}}/shared/index.ts`).
+         - **Ne refais PAS le scaffold toi-même.** L'agent scaffolder est responsable. Si après 10 min le scaffold n'est toujours pas là, échoue clairement en annonçant `propose_resolution` avec un message d'erreur — un humain interviendra.
 
-      2. **Pour chaque module de ton slice** (`models.rs`, `state.rs`, `services.rs`, `components.rs`, etc.) :
-         - Lis le fichier source ET ses tests (`tests.rs`)
+      2. **Annonce-toi** au coordinator dès que le scaffold est prêt :
+         - `announce_work` avec `target_modules: ["{{params.target_slice}}"]`, `subject` clair, `plan` court (la liste des fichiers que tu vas porter).
+
+      3. **Pour chaque module de ton slice** (`models.rs`, `state.rs`, `services.rs`, `components.rs`, etc.) :
+         - Lis le fichier source ET ses tests (`tests.rs`).
          - Porte les **tests Vitest AVANT** le code (RED). 1 test Rust = 1 test Vitest, même nom de cas, même assertion.
          - Implémente le code TypeScript pour rendre les tests verts (GREEN). Minimum viable.
          - Refactor une fois vert (REFACTOR), sans casser les tests.
          - Lance `{{params.test_command}}` pour confirmer.
 
-      3. **Coordination via le coordinator** :
-         - `announce_work` au démarrage avec `target_modules: ["{{params.target_slice}}"]`, `subject` clair, `plan` court.
+      4. **Coordination cross-slice via le coordinator** :
          - À chaque jalon (module terminé, blocage, décision transverse), `post_to_thread` un résumé court.
-         - Si tu touches à un pattern transverse (auth headers, supabase client, idempotency-key helper), annonce-le sur un module commun (ex. `target_modules: ["{{params.target_slice}}", "shared-infra"]`) pour que les autres agents prennent ta convention.
+         - Si tu touches à un pattern transverse (auth headers, idempotency-key helper, error mapper), annonce-le sur un module commun (ex. `target_modules: ["{{params.target_slice}}", "shared-infra"]`) pour que les autres agents prennent ta convention.
+         - **Importe le shared/ existant** (`import { Button, FormField } from '../shared'`) au lieu de le redéfinir. Si une fonctionnalité te manque dans shared/, **pose la question** dans un thread `target_modules: ["shared"]` au lieu de l'ajouter toi-même — c'est le scaffolder (déjà terminé) ou un futur agent shared-extender qui gère ce slice.
          - À la fin, `propose_resolution` avec la liste des livrables et les éventuels TODO.
 
       ### Règles dures (verrouillées par les tests)
@@ -83,7 +94,7 @@ sections:
 
       ### Livrables minimum
 
-      - `{{params.target_root}}/{{params.target_slice}}/index.ts` (re-exports publics)
+      - `{{params.target_features_root}}/{{params.target_slice}}/index.ts` (re-exports publics)
       - Tous les fichiers TS/TSX nécessaires
       - Tests Vitest qui passent : `{{params.test_command}}`
       - Zéro erreur TypeScript strict : `{{params.typecheck_command}}`

--- a/behaviors/mission-tasks-md.yaml
+++ b/behaviors/mission-tasks-md.yaml
@@ -1,0 +1,32 @@
+name: mission-tasks-md
+description: "Mission Mekova — implémenter les tâches d'une phase de tasks.md selon la méthode"
+category: mission
+
+params:
+  phase_number:
+    type: string
+    required: false
+    description: "Numéro de la phase du plan détaillé (informatif — les tâches arrivent via user-brief)"
+
+sections:
+  "030-mission":
+    prompt: |
+      ## Ta mission — Implémenter des tâches du plan Mekova{{#if params.phase_number}} (phase {{params.phase_number}}){{/if}}
+      Les tâches qui te sont assignées viennent du plan détaillé (tasks.md)
+      d'une spec Mekova. Elles te parviennent via le brief de session et/ou
+      les threads qui te sont assignés (assigned_to). Règles absolues :
+
+      1. **Respecter l'ordre des steps** de chaque tâche. Ne pas réorganiser.
+      2. **Conventions du repo** : lis le CLAUDE.md à la racine du projet
+         AVANT d'écrire du code, et respecte-le (gestion d'erreurs, secrets,
+         style). Lis toujours un fichier existant avant de le modifier.
+      3. **Code complet et fonctionnel** — pas de stubs sauf demande explicite.
+      4. **Ne JAMAIS affaiblir une règle spec'd** (plafond, seuil, migration
+         non destructive) mentionnée dans le brief. En cas de doute, pose la
+         question dans ton thread au lieu d'inventer.
+      5. **Ne coche AUCUNE case** de tasks.md et ne modifie aucun fichier du
+         repo specs : la session principale vérifie et coche après merge.
+      6. **Commits fréquents** sur ta branche worktree, messages conventionnels.
+      7. Quand ta tâche est finie : les tests que le brief associe à ta tâche
+         passent localement, puis résous ton thread avec un résumé
+         (propose_resolution) et termine par `DONE: <résumé>`.

--- a/cli/bce-resolver.ts
+++ b/cli/bce-resolver.ts
@@ -54,3 +54,6 @@ export function getCompositionsDir(): string {
 export function getScriptsDir(): string {
   return resolve(getCatalogRoot(), "scripts");
 }
+export function getTemplatesDir(): string {
+  return resolve(getCatalogRoot(), "templates");
+}

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -118,11 +118,11 @@ export function createRunCommand(): Command {
           opts.url ??
           process.env.COORDINATOR_URL;
 
-        // Build project
+        // Build project — pass projectPath so .essaim/templates/ overrides apply
         const project = buildProject(template, context, {
           agentCount,
           setParams,
-        });
+        }, projectPath);
 
         // Apply overrides
         if (opts.timeout) {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -19,6 +19,7 @@ export function createRunCommand(): Command {
     .option("-t, --timeout <min>", "Timeout in minutes")
     .option("--cleanup", "Remove worktrees after execution")
     .option("--dry-run", "Preview agents and prompts without launching")
+    .option("--modules <list>", "Comma-separated module list, overrides scanner discovery. Required for templates using count: 'per-module' when the project layout doesn't match the scanner's expectations.")
     .option("--set <key=value>", "BCE parameter (repeatable)", collect, [])
     .option("--url <url>", "Coordinator URL (override config, deprecated: use --coordinator-url)")
     .option(
@@ -36,6 +37,7 @@ export function createRunCommand(): Command {
           timeout?: string;
           cleanup?: boolean;
           dryRun?: boolean;
+          modules?: string;
           set: string[];
           url?: string;
           coordinatorUrl?: string;
@@ -66,6 +68,20 @@ export function createRunCommand(): Command {
 
         const projectPath = resolve(opts.project);
         const context = scanProject(projectPath);
+
+        // --modules overrides the scanner's discovery. Use when the project
+        // structure doesn't match scanner expectations (e.g. modules are
+        // src/features/<slice> not src/<top>) or when you want to run a
+        // template on a specific subset of modules (e.g. Phase 2 batch V1
+        // targeting only `shared` + `auth`).
+        if (opts.modules) {
+          const overrides = opts.modules.split(",").map((s) => s.trim()).filter(Boolean);
+          if (overrides.length === 0) {
+            console.error("Error: --modules cannot be empty");
+            process.exit(1);
+          }
+          context.modules = overrides;
+        }
 
         if (!context.has_git) {
           console.error(

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -45,8 +45,13 @@ export function createRunCommand(): Command {
           maxQuotaPct?: string;
         },
       ) => {
+        // Resolve projectPath before listing/validating templates so that
+        // project-local .essaim/templates/ entries (new ids, not just
+        // catalog overrides) are recognized at pre-flight.
+        const projectPath = resolve(opts.project);
+
         // List templates if none specified
-        const templates = listTemplates();
+        const templates = listTemplates(projectPath);
         if (!template) {
           console.log("\nAvailable templates:\n");
           for (const t of templates) {
@@ -66,7 +71,6 @@ export function createRunCommand(): Command {
           process.exit(1);
         }
 
-        const projectPath = resolve(opts.project);
         const context = scanProject(projectPath);
 
         // --modules overrides the scanner's discovery. Use when the project

--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -49,7 +49,7 @@ export function createSoloCommand(): Command {
 
         // Build prompt with solo_mode=true injected automatically
         const setParams = parseSetParams(opts.set);
-        const prompt = buildSoloPrompt(template, context, setParams);
+        const prompt = buildSoloPrompt(template, context, setParams, projectPath);
 
         console.log(`\nSolo mode: ${template}`);
         console.log(`  Project:  ${projectPath}`);

--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -23,8 +23,13 @@ export function createSoloCommand(): Command {
         template: string | undefined,
         opts: { project: string; timeout: string; set: string[]; coordinatorUrl?: string },
       ) => {
+        // Resolve projectPath before listing/validating templates so that
+        // project-local .essaim/templates/ entries (new ids, not just
+        // catalog overrides) are recognized at pre-flight.
+        const projectPath = resolve(opts.project);
+
         // List templates if none specified
-        const templates = listTemplates();
+        const templates = listTemplates(projectPath);
         if (!template) {
           console.log("\nAvailable templates:\n");
           for (const t of templates) {
@@ -44,7 +49,6 @@ export function createSoloCommand(): Command {
           process.exit(1);
         }
 
-        const projectPath = resolve(opts.project);
         const context = scanProject(projectPath);
 
         // Build prompt with solo_mode=true injected automatically

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "essaim",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "essaim",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.0",
@@ -16,7 +16,8 @@
         "mcp-coordinator": "^0.13.0",
         "mqtt": "^5.15.0",
         "pino": "^10.3.1",
-        "ws": "^8.20.0"
+        "ws": "^8.20.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "essaim": "dist/cli/index.js"
@@ -5160,6 +5161,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "presets/",
     "compositions/",
     "scripts/",
+    "templates/",
     "LICENSE",
     "README.md"
   ],
@@ -67,7 +68,8 @@
     "mcp-coordinator": "^0.13.0",
     "mqtt": "^5.15.0",
     "pino": "^10.3.1",
-    "ws": "^8.20.0"
+    "ws": "^8.20.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/presets/mekova-bughunt.yaml
+++ b/presets/mekova-bughunt.yaml
@@ -1,0 +1,38 @@
+name: mekova-bughunt
+description: "Chasse au bug Mekova — preuve par test de repro + cause racine (flow RCA)"
+profile: codeur
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - conflict-resolution
+  - activity-tracking
+  - worktree-isolation
+  - phase-discover
+  - phase-review
+  - phase-execute
+
+params:
+  phase-discover:
+    discovery_mission: >
+      Le brief décrit un symptôme observé (feedback bug Mekova). Cherche les
+      causes racines plausibles de CE symptôme : suis le chemin du code depuis
+      le point d'entrée concerné, cherche les valeurs nulles non gérées, les
+      conditions limites, les états incohérents. Reste dans les modules listés
+      par le brief — le reste du dépôt est hors-sujet.
+    effort: mid
+  phase-review:
+    review_mission: >
+      Compare tes hypothèses de cause avec les threads existants. Même fichier
+      + même mécanisme = doublon. Enrichis plutôt que dupliquer.
+    effort: low
+  phase-execute:
+    execute_mission: >
+      Pour la cause que tu as claimée : écris un test de reproduction qui
+      ÉCHOUE, dans la suite de tests du projet, avec un commentaire
+      « comportement attendu vs observé ». NE CORRIGE PAS le bug — le fix est
+      planifié ailleurs (flow RCA Mekova). Commite le test sur ta branche,
+      puis poste dans ton thread un résumé de cause racine en 3-5 lignes
+      (la cause, pas le symptôme) + hypothèses écartées (1 ligne chacune).
+    effort: mid

--- a/presets/mekova-implement-lead.yaml
+++ b/presets/mekova-implement-lead.yaml
@@ -1,0 +1,13 @@
+name: mekova-implement-lead
+description: "Tech lead Mekova — dispatch les tâches d'une phase de tasks.md aux workers"
+profile: communicant
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - check-interrupt
+  - activity-tracking
+  - shared-workspace
+  - task-distribution
+  - mission-tasks-md

--- a/presets/mekova-implement-worker.yaml
+++ b/presets/mekova-implement-worker.yaml
@@ -1,0 +1,13 @@
+name: mekova-implement-worker
+description: "Worker Mekova — implémente les tâches assignées selon la méthode"
+profile: codeur
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - check-interrupt
+  - activity-tracking
+  - worktree-isolation
+  - task-execution
+  - mission-tasks-md

--- a/presets/mekova-review.yaml
+++ b/presets/mekova-review.yaml
@@ -1,0 +1,24 @@
+name: mekova-review
+description: "Audit Mekova — findings classifiés Local / Pattern / Convention gap"
+profile: communicant
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - check-interrupt
+  - activity-tracking
+  - shared-workspace
+  - read-only-mode
+  - audit-output
+  - quality-audit
+params:
+  audit-output:
+    paths:
+      - "AUDIT.md"
+  quality-audit:
+    categories:
+      - "Conformité architecture — le diff respecte-t-il le CLAUDE.md du repo et le Design technique de la spec ?"
+      - "Règles métier — aucune règle spec'd affaiblie (plafonds, seuils, validations)"
+      - "Conventions — naming, gestion d'erreurs, style du projet"
+      - "Tests — les changements sont-ils couverts ?"

--- a/presets/migrate-scaffold.yaml
+++ b/presets/migrate-scaffold.yaml
@@ -1,0 +1,18 @@
+name: migrate-scaffold
+description: "Scaffolder for the migrate-phase2 template — initializes the target stack scaffold + shared/ slice + lib/supabase before per-slice migrators start"
+profile: codeur
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - check-interrupt
+  - activity-tracking
+  - shared-workspace
+  - migrate-scaffold
+params:
+  migrate-scaffold:
+    audit_path: MIGRATION_AUDIT.md
+    source_root: src/features
+    target_root: web
+    target_features_root: web/src/features

--- a/presets/migrate-slice.yaml
+++ b/presets/migrate-slice.yaml
@@ -17,4 +17,5 @@ params:
     # monpikto-specific paths/commands or pass via --set on the CLI.
     audit_path: MIGRATION_AUDIT.md
     source_root: src/features
-    target_root: web/src/features
+    target_root: web
+    target_features_root: web/src/features

--- a/presets/migrate-slice.yaml
+++ b/presets/migrate-slice.yaml
@@ -1,0 +1,20 @@
+name: migrate-slice
+description: "Port one source-slice into a target tech stack — paired with template migrate-phase2"
+profile: codeur
+behaviors:
+  - project-context
+  - user-brief
+  - coordinator-rules
+  - announce-before-write
+  - check-interrupt
+  - activity-tracking
+  - shared-workspace
+  - migrate-slice
+params:
+  migrate-slice:
+    # target_slice is set per-agent by the orchestrator from context.modules.
+    # All other params take their behavior-defined defaults; override here for
+    # monpikto-specific paths/commands or pass via --set on the CLI.
+    audit_path: MIGRATION_AUDIT.md
+    source_root: src/features
+    target_root: web/src/features

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -10,6 +10,7 @@ import {
 import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, unclaimTask, parseReviewActions, fetchExistingThreads, processReviewActions } from "./work-stealing.js";
 import { createLogger } from "../logger.js";
 import { resolveEffort, upgradeEffort, parseSeverity, EFFORT_PROFILES, isThinkingLevel, type EffortLevel, type ConcreteEffortLevel, type ThinkingLevel } from "./effort.js";
+import { authHeaders } from "../coordinator-auth.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -218,7 +219,7 @@ async function coordinatorPost(
   try {
     resp = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify(body),
     });
   } catch (err) {
@@ -376,7 +377,7 @@ export async function runAgentLoop(
   async function quotaBlocksNextTask(): Promise<string | null> {
     if (config.maxQuotaPct === undefined) return null;  // guardrail disabled
     try {
-      const resp = await fetch(`${config.coordinatorUrl}/api/quota`);
+      const resp = await fetch(`${config.coordinatorUrl}/api/quota`, { headers: authHeaders() });
       if (resp.status === 503 || !resp.ok) return null;  // unknown = proceed
       const data = await resp.json() as {
         five_hour?: { utilization: number; minutesUntilReset: number };
@@ -427,7 +428,7 @@ export async function runAgentLoop(
     try {
       await fetch(`${config.coordinatorUrl}/api/token-usage`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({
           agent_id: config.agentId,
           agent_name: config.agentName,

--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -1,6 +1,7 @@
 import mqtt from "mqtt";
 import { Duplex } from "stream";
 import { createLogger } from "../logger.js";
+import { coordinatorToken } from "../coordinator-auth.js";
 const log = createLogger("mqtt-listener");
 
 const isBun = !!(process.versions as Record<string, string>)?.bun;
@@ -208,12 +209,23 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
 
         const clientId = `agent-loop-${agentId}-${Date.now()}`;
 
+        // Coordinator token (when set) travels as MQTT credentials in the
+        // CONNECT packet — in-protocol, so it works through the WS bridge
+        // too. The deployed coordinator's aedes authenticate hook reads the
+        // JWT from the password field (username is ignored there).
+        const token = coordinatorToken();
+        const mqttOpts: mqtt.IClientOptions = { clientId, clean: true };
+        if (token) {
+          mqttOpts.username = "agent";
+          mqttOpts.password = token;
+        }
+
         if (isBun && url.startsWith("ws")) {
           // Bun: ws package Receiver is broken — use native WebSocket + Duplex bridge
           const stream = createBunWsStream(url);
-          client = new mqtt.MqttClient(() => stream, { clientId, clean: true });
+          client = new mqtt.MqttClient(() => stream, mqttOpts);
         } else {
-          client = mqtt.connect(url, { clientId, clean: true });
+          client = mqtt.connect(url, mqttOpts);
         }
 
         client.on("connect", () => {

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -1,6 +1,7 @@
 // client/agent-loop/work-stealing.ts
 
 import { createLogger } from "../logger.js";
+import { authHeaders } from "../coordinator-auth.js";
 const log = createLogger("work-stealing");
 
 export interface Task {
@@ -52,7 +53,7 @@ class HttpError extends Error {
 async function coordinatorPost(url: string, body: Record<string, unknown>): Promise<Record<string, unknown>> {
   let resp: Response;
   try {
-    resp = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+    resp = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json", ...authHeaders() }, body: JSON.stringify(body) });
   } catch (err) {
     throw new Error(`Cannot reach coordinator at ${url}: ${(err as Error).message}`);
   }
@@ -110,7 +111,7 @@ export async function claimNextTask(
   try {
     const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: "{}",
     });
     if (!resp.ok) { log.warn("claimNextTask: threads-active failed", { status: resp.status }); return null; }
@@ -249,7 +250,7 @@ export async function fetchExistingThreads(coordinatorUrl: string): Promise<stri
   try {
     const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: "{}",
     });
     if (!resp.ok) return "(aucun thread actif)";

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -272,15 +272,36 @@ const TEMPLATE_DEFS: Record<string, TemplateDefinition> = {
   },
   'migrate-phase2': {
     name: 'Migration Phase 2',
-    description: 'N migrateurs en parallèle — un agent par slice (context.modules), chacun porte son slice vers un stack cible en suivant un audit consolidé',
+    description: 'Scaffolder pose web/ + shared/ + lib/supabase, puis N migrateurs (un par slice) attaquent leur slice — vraie collaboration via workspace partagé',
     phase: 2,
-    workspace: 'worktree',
+    // workspace: 'shared' (NOT 'worktree') — the previous 'worktree' design
+    // forced each per-slice agent to re-create the shared scaffold in its
+    // own isolated copy, producing divergent shared/Button.tsx, divergent
+    // lib/supabase.ts, divergent main.tsx that couldn't be merged cleanly.
+    // With 'shared', the scaffolder writes once and the migrators read
+    // (and import) those files directly — no duplication possible.
+    workspace: 'shared',
     stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 90,
+    timeout_minutes: 120,
     metrics: ['slices_migrated', 'tests_ported', 'cross_slice_consultations'],
     compare_mode: false,
     agents: [
       {
+        // Phase 1: one scaffolder owns the scaffold + shared/ slice + lib/.
+        // Runs first (launch_delay 0) and migrators wait ~5 min before
+        // starting so the scaffold is in place when they begin.
+        idPrefix: 'scaffolder',
+        namePrefix: 'Scaffolder',
+        preset: 'migrate-scaffold',
+        profile: 'codeur',
+        count: 1,
+        launch_delay: 0,
+      },
+      {
+        // Phase 2: one migrator per slice (excluding 'shared', owned by the
+        // scaffolder). Wait long enough for scaffold + shared/ to be done.
+        // Each migrator's brief includes a precondition check
+        // (web/src/features/shared/index.ts must exist) before any write.
         idPrefix: 'migrator',
         namePrefix: 'Migrator',
         preset: 'migrate-slice',
@@ -290,9 +311,14 @@ const TEMPLATE_DEFS: Record<string, TemplateDefinition> = {
         // Each migrator advertises only its own slice as its module so the
         // coordinator routes slice-targeted threads to the right owner.
         // Cross-slice collaboration still works because announce_work can
-        // include multiple target_modules (e.g. ["shared", "auth"] for a
-        // shared-types decision).
+        // include multiple target_modules (e.g. ["chat", "shared-infra"]
+        // for a shared-infra decision).
         perModuleRegisterOwnOnly: true,
+        // 5 min for the scaffolder to deliver npm scaffold + shared/.
+        // The migrator brief tells them to wait up to 10 min more if the
+        // scaffold isn't fully there yet, so this is a soft trigger, not a
+        // hard contract.
+        launch_delay: 300,
       },
     ],
   },

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -58,8 +58,25 @@ interface TemplateDefinition {
     profile: 'codeur' | 'communicant';
     role?: string;
     launch_delay?: number;
-    count?: number | 'dynamic'; // 'dynamic' = based on modules/files
+    // count semantics:
+    //   number    — exactly N agents
+    //   'dynamic' — derive N from context.modules.length (capped 2..4)
+    //   'per-module' — one agent per entry in context.modules; combine with
+    //                  perModuleParam to give each its own value
+    count?: number | 'dynamic' | 'per-module';
     params?: Record<string, Record<string, unknown>>;
+    // perModuleParam (only with count: 'per-module'): for each agent i,
+    // inject context.modules[i] as params[behavior][key]. The agent's
+    // idPrefix is also suffixed with the module name (e.g. migrator-shared)
+    // so the dashboard shows which slice each agent owns.
+    perModuleParam?: { behavior: string; key: string };
+    // perModuleRegisterOwnOnly (only with count: 'per-module'): if true,
+    // register the agent's coordinator `modules` as just [its own module]
+    // instead of the full project list. Use this when each agent should
+    // primarily attract consultations on its own slice; cross-slice
+    // collaboration still works because announce_work can target multiple
+    // modules. Defaults to false (= full module list, broad collaboration).
+    perModuleRegisterOwnOnly?: boolean;
   }>;
 }
 
@@ -253,6 +270,32 @@ const TEMPLATE_DEFS: Record<string, TemplateDefinition> = {
       { idPrefix: 'synth', namePrefix: 'Reconciliateur', preset: 'phare-synth', profile: 'communicant', count: 1, launch_delay: 60 },
     ],
   },
+  'migrate-phase2': {
+    name: 'Migration Phase 2',
+    description: 'N migrateurs en parallèle — un agent par slice (context.modules), chacun porte son slice vers un stack cible en suivant un audit consolidé',
+    phase: 2,
+    workspace: 'worktree',
+    stagger: { mode: 'fixed', delay: [0, 0] },
+    timeout_minutes: 90,
+    metrics: ['slices_migrated', 'tests_ported', 'cross_slice_consultations'],
+    compare_mode: false,
+    agents: [
+      {
+        idPrefix: 'migrator',
+        namePrefix: 'Migrator',
+        preset: 'migrate-slice',
+        profile: 'codeur',
+        count: 'per-module',
+        perModuleParam: { behavior: 'migrate-slice', key: 'target_slice' },
+        // Each migrator advertises only its own slice as its module so the
+        // coordinator routes slice-targeted threads to the right owner.
+        // Cross-slice collaboration still works because announce_work can
+        // include multiple target_modules (e.g. ["shared", "auth"] for a
+        // shared-types decision).
+        perModuleRegisterOwnOnly: true,
+      },
+    ],
+  },
 };
 
 const AGENT_NAMES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
@@ -280,16 +323,45 @@ export function buildProjectFromBce(
   const agents: BceMiniProject['agents'] = [];
 
   for (const agentDef of def.agents) {
-    const count =
-      agentDef.count === "dynamic"
-        ? (options?.agentCount ?? Math.max(2, Math.min(context.modules.length || 2, 4)))
-        : (agentDef.count ?? 1);
+    let count: number;
+    if (agentDef.count === "dynamic") {
+      count = options?.agentCount ?? Math.max(2, Math.min(context.modules.length || 2, 4));
+    } else if (agentDef.count === "per-module") {
+      if (context.modules.length === 0) {
+        throw new Error(
+          `Template '${templateId}' uses count: 'per-module' but context.modules is empty. ` +
+          `Provide modules via the project scanner or override via the run config.`,
+        );
+      }
+      count = context.modules.length;
+    } else {
+      count = agentDef.count ?? 1;
+    }
 
     for (let i = 0; i < count; i++) {
-      const suffix = count > 1 ? `-${i + 1}` : '';
-      const nameSuffix = count > 1 ? ` ${AGENT_NAMES[i] || (i + 1)}` : '';
+      // 'per-module' uses the module name as suffix (visible on the dashboard),
+      // others use the numeric / phonetic suffix as before.
+      const moduleForAgent = agentDef.count === "per-module" ? context.modules[i]! : null;
+      const slug = (s: string) => s.replace(/[^a-zA-Z0-9_-]+/g, "-").toLowerCase();
+      const suffix = moduleForAgent !== null
+        ? `-${slug(moduleForAgent)}`
+        : (count > 1 ? `-${i + 1}` : '');
+      const nameSuffix = moduleForAgent !== null
+        ? ` ${moduleForAgent}`
+        : (count > 1 ? ` ${AGENT_NAMES[i] || (i + 1)}` : '');
       const agentId = `${agentDef.idPrefix}${suffix}`;
       const agentName = `${agentDef.namePrefix}${nameSuffix}`;
+
+      // Inject the per-module behavior param (e.g. migrate-slice.target_slice = "auth")
+      // from agentDef.perModuleParam. Merged into the agent's params so the
+      // behavior template can reference {{params.target_slice}}.
+      const perModuleParams: Record<string, Record<string, unknown>> = {};
+      if (agentDef.perModuleParam && moduleForAgent !== null) {
+        perModuleParams[agentDef.perModuleParam.behavior] = {
+          ...(agentDef.params?.[agentDef.perModuleParam.behavior] ?? {}),
+          [agentDef.perModuleParam.key]: moduleForAgent,
+        };
+      }
 
       // Build launch params from context
       const launchParams: Record<string, Record<string, unknown>> = {
@@ -299,6 +371,7 @@ export function buildProjectFromBce(
           modules: context.modules,
         },
         ...(agentDef.params ?? {}),
+        ...perModuleParams,
         ...(options?.setParams ?? {}),
       };
 
@@ -313,20 +386,22 @@ export function buildProjectFromBce(
       };
       const result = runPipeline(agent, getCatalogRoot(), launchParams);
 
+      // Modules registered with the coordinator for respondent matching.
+      // Default = full project list (broad collaboration: every agent is a
+      // respondent for every announce). Per-module templates can opt into
+      // own-only registration (one slice per agent) so consultations route
+      // to the slice owner.
+      const registeredModules = (agentDef.count === "per-module" && agentDef.perModuleRegisterOwnOnly && moduleForAgent !== null)
+        ? [moduleForAgent]
+        : context.modules;
+
       agents.push({
         id: agentId,
         name: agentName,
         prompt: result.output.prompt,
         profile: agentDef.profile,
         role: agentDef.idPrefix,
-        // Pre-register modules so consultation matching picks this agent as a
-        // respondent. Without this, announce_work computes expected_respondents
-        // = [] for every thread → propose_resolution waits for absent voters
-        // → threads only close via the timeout sweeper. Default to the full
-        // project module list (every specialist is relevant to every other
-        // specialist's announces). Per-agent overrides could be added later
-        // via agentDef.modules if a template needs narrower scoping.
-        modules: context.modules,
+        modules: registeredModules,
         launch_delay: agentDef.launch_delay,
         hooks: result.output.hooks,
         envVars: result.output.envVars,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -39,290 +39,7 @@ interface BceMiniProject {
 }
 
 import { getCatalogRoot } from "../cli/bce-resolver.js";
-
-// Template definitions map template IDs to BCE presets + orchestration config
-interface TemplateDefinition {
-  name: string;
-  description: string;
-  phase: number;
-  workspace: 'worktree' | 'shared';
-  stagger: { mode: 'fixed' | 'random' | 'sequential'; delay?: [number, number] };
-  timeout_minutes: number;
-  metrics: string[];
-  compare_mode: boolean;
-  // Each agent role in this template
-  agents: Array<{
-    idPrefix: string;
-    namePrefix: string;
-    preset: string;
-    profile: 'codeur' | 'communicant';
-    role?: string;
-    launch_delay?: number;
-    // count semantics:
-    //   number    — exactly N agents
-    //   'dynamic' — derive N from context.modules.length (capped 2..4)
-    //   'per-module' — one agent per entry in context.modules; combine with
-    //                  perModuleParam to give each its own value
-    count?: number | 'dynamic' | 'per-module';
-    params?: Record<string, Record<string, unknown>>;
-    // perModuleParam (only with count: 'per-module'): for each agent i,
-    // inject context.modules[i] as params[behavior][key]. The agent's
-    // idPrefix is also suffixed with the module name (e.g. migrator-shared)
-    // so the dashboard shows which slice each agent owns.
-    perModuleParam?: { behavior: string; key: string };
-    // perModuleRegisterOwnOnly (only with count: 'per-module'): if true,
-    // register the agent's coordinator `modules` as just [its own module]
-    // instead of the full project list. Use this when each agent should
-    // primarily attract consultations on its own slice; cross-slice
-    // collaboration still works because announce_work can target multiple
-    // modules. Defaults to false (= full module list, broad collaboration).
-    perModuleRegisterOwnOnly?: boolean;
-  }>;
-}
-
-const TEMPLATE_DEFS: Record<string, TemplateDefinition> = {
-  raid: {
-    name: 'Le Raid',
-    description: 'Agents chassent les bugs et edge cases manquants',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [5, 10] },
-    timeout_minutes: 20,
-    metrics: ['bugs_found', 'tests_added'],
-    compare_mode: false,
-    agents: [{
-      idPrefix: 'agent-chasseur', namePrefix: 'Chasseur', preset: 'raid',
-      profile: 'codeur', count: 'dynamic',
-    }],
-  },
-  melee: {
-    name: 'La Melee',
-    description: 'N agents ecrivent des tests en parallele',
-    phase: 1,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [5, 15] },
-    timeout_minutes: 20,
-    metrics: ['tests_written', 'tests_passing'],
-    compare_mode: true,
-    agents: [{
-      idPrefix: 'agent', namePrefix: 'Agent', preset: 'melee',
-      profile: 'codeur', count: 'dynamic',
-    }],
-  },
-  swarm: {
-    name: "L'Essaim",
-    description: 'N agents refactorisent en parallele',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [3, 8] },
-    timeout_minutes: 20,
-    metrics: ['files_refactored', 'tests_passing'],
-    compare_mode: false,
-    agents: [{
-      idPrefix: 'agent-refacteur', namePrefix: 'Refacteur', preset: 'swarm',
-      profile: 'codeur', count: 'dynamic',
-    }],
-  },
-  revue: {
-    name: 'La Revue',
-    description: 'N auteurs + N reviewers en croisement',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [5, 10] },
-    timeout_minutes: 20,
-    metrics: ['review_comments', 'approvals'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'auteur', namePrefix: 'Auteur', preset: 'revue-author', profile: 'codeur', count: 'dynamic' },
-      { idPrefix: 'reviewer', namePrefix: 'Reviewer', preset: 'revue-reviewer', profile: 'communicant', count: 'dynamic', launch_delay: 120 },
-    ],
-  },
-  maitre: {
-    name: 'Le Maitre',
-    description: '1 lead distribue aux workers',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [8, 12] },
-    timeout_minutes: 20,
-    metrics: ['worker_idle_time', 'task_distribution_quality'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'tech-lead', namePrefix: 'Tech Lead', preset: 'maitre-lead', profile: 'communicant', count: 1, launch_delay: 0 },
-      { idPrefix: 'worker', namePrefix: 'Worker', preset: 'maitre-worker', profile: 'codeur', count: 'dynamic', launch_delay: 10 },
-    ],
-  },
-  gardien: {
-    name: 'Le Gardien',
-    description: '1 agent analyse la qualite du projet',
-    phase: 1,
-    workspace: 'shared',
-    stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 10,
-    metrics: ['issues_found', 'categories_scanned'],
-    compare_mode: false,
-    agents: [{
-      idPrefix: 'agent-gardien', namePrefix: 'Le Gardien', preset: 'gardien',
-      profile: 'communicant', count: 1,
-    }],
-  },
-  relais: {
-    name: 'Le Relais',
-    description: '3 coureurs se relaient sequentiellement',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'sequential' },
-    timeout_minutes: 25,
-    metrics: ['improvements_per_runner', 'tests_passing'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'agent-coureur-1', namePrefix: 'Coureur 1', preset: 'relais-1', profile: 'codeur', count: 1 },
-      { idPrefix: 'agent-coureur-2', namePrefix: 'Coureur 2', preset: 'relais-2', profile: 'codeur', count: 1 },
-      { idPrefix: 'agent-coureur-3', namePrefix: 'Coureur 3', preset: 'relais-3', profile: 'codeur', count: 1 },
-    ],
-  },
-  chaine: {
-    name: 'La Chaine',
-    description: 'Pipeline sequentiel: implementer, reviewer, tester',
-    phase: 2,
-    workspace: 'worktree',
-    stagger: { mode: 'sequential' },
-    timeout_minutes: 25,
-    metrics: ['pipeline_stages_completed', 'tests_passing'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'agent-implementeur', namePrefix: 'Implementeur', preset: 'chaine-implement', profile: 'codeur', count: 1 },
-      { idPrefix: 'agent-reviewer', namePrefix: 'Reviewer', preset: 'chaine-review', profile: 'communicant', count: 1, launch_delay: 5 },
-      { idPrefix: 'agent-testeur', namePrefix: 'Testeur', preset: 'chaine-test', profile: 'codeur', count: 1, launch_delay: 10 },
-    ],
-  },
-  debat: {
-    name: 'Le Debat',
-    description: '3 agents debattent une approche de refactor',
-    phase: 3,
-    workspace: 'shared',
-    stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 15,
-    metrics: ['rounds_to_consensus', 'contestations'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'agent-separation', namePrefix: 'Agent Separation', preset: 'debat', profile: 'communicant', count: 1, params: { 'debate-position': { position: 'Tu favorises le decoupage par responsabilite (un fichier par concern). Argumente la lisibilite et testabilite.' } } },
-      { idPrefix: 'agent-strategy', namePrefix: 'Agent Strategy', preset: 'debat', profile: 'communicant', count: 1, params: { 'debate-position': { position: 'Tu favorises le pattern Strategy (interface + implementations). Argumente la configurabilite.' } } },
-      { idPrefix: 'agent-minimal', namePrefix: 'Agent Minimal', preset: 'debat', profile: 'communicant', count: 1, params: { 'debate-position': { position: 'Tu favorises le refactor minimal (extraire seulement les helpers). Argumente que le risque depasse le benefice.' } } },
-    ],
-  },
-  babel: {
-    name: 'Babel',
-    description: 'Traducteur + reviseur traduisent la documentation',
-    phase: 1,
-    workspace: 'worktree',
-    stagger: { mode: 'sequential' },
-    timeout_minutes: 15,
-    metrics: ['files_translated', 'review_issues'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'agent-traducteur', namePrefix: 'Traducteur', preset: 'babel-translator', profile: 'communicant', count: 1 },
-      { idPrefix: 'agent-reviseur', namePrefix: 'Reviseur', preset: 'babel-reviewer', profile: 'communicant', count: 1 },
-    ],
-  },
-  arene: {
-    name: "L'Arene",
-    description: 'Jeu de trivia sur la base de code',
-    phase: 1,
-    workspace: 'shared',
-    stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 10,
-    metrics: ['questions_asked', 'correct_answers'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'agent-quizmaster', namePrefix: 'Quizmaster', preset: 'arene-quizmaster', profile: 'communicant', count: 1 },
-      { idPrefix: 'agent-joueur-a', namePrefix: 'Joueur A', preset: 'arene-player', profile: 'communicant', count: 1, params: { 'quiz-player': { player_name: 'Joueur A', focus_area: 'structure du projet' } } },
-      { idPrefix: 'agent-joueur-b', namePrefix: 'Joueur B', preset: 'arene-player', profile: 'communicant', count: 1, params: { 'quiz-player': { player_name: 'Joueur B', focus_area: 'patterns et architecture' } } },
-    ],
-  },
-  carrefour: {
-    name: 'Le Carrefour',
-    description: 'Agents croisent leurs intentions sur les memes fichiers',
-    phase: 3,
-    workspace: 'worktree',
-    stagger: { mode: 'random', delay: [3, 8] },
-    timeout_minutes: 15,
-    metrics: ['conflicts_detected', 'conflicts_resolved', 'consultations_opened'],
-    compare_mode: false,
-    agents: [{
-      idPrefix: 'agent', namePrefix: 'Agent', preset: 'carrefour',
-      profile: 'codeur', count: 'dynamic',
-    }],
-  },
-  phare: {
-    name: 'Le Phare',
-    description: '4 auditeurs spécialisés en parallèle + 1 réconciliateur — audit multi-angles',
-    phase: 2,
-    workspace: 'shared',
-    stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 30,
-    metrics: ['specialists_completed', 'reconciliations', 'disagreements_flagged'],
-    compare_mode: false,
-    agents: [
-      { idPrefix: 'inventaire', namePrefix: 'Inventaire', preset: 'phare-inventaire', profile: 'communicant', count: 1, launch_delay: 0 },
-      { idPrefix: 'edges', namePrefix: 'Edges', preset: 'phare-edges', profile: 'communicant', count: 1, launch_delay: 0 },
-      { idPrefix: 'deps', namePrefix: 'Deps', preset: 'phare-deps', profile: 'communicant', count: 1, launch_delay: 0 },
-      { idPrefix: 'risques', namePrefix: 'Risques', preset: 'phare-risques', profile: 'communicant', count: 1, launch_delay: 0 },
-      { idPrefix: 'synth', namePrefix: 'Reconciliateur', preset: 'phare-synth', profile: 'communicant', count: 1, launch_delay: 60 },
-    ],
-  },
-  'migrate-phase2': {
-    name: 'Migration Phase 2',
-    description: 'Scaffolder pose web/ + shared/ + lib/supabase, puis N migrateurs (un par slice) attaquent leur slice — vraie collaboration via workspace partagé',
-    phase: 2,
-    // workspace: 'shared' (NOT 'worktree') — the previous 'worktree' design
-    // forced each per-slice agent to re-create the shared scaffold in its
-    // own isolated copy, producing divergent shared/Button.tsx, divergent
-    // lib/supabase.ts, divergent main.tsx that couldn't be merged cleanly.
-    // With 'shared', the scaffolder writes once and the migrators read
-    // (and import) those files directly — no duplication possible.
-    workspace: 'shared',
-    stagger: { mode: 'fixed', delay: [0, 0] },
-    timeout_minutes: 120,
-    metrics: ['slices_migrated', 'tests_ported', 'cross_slice_consultations'],
-    compare_mode: false,
-    agents: [
-      {
-        // Phase 1: one scaffolder owns the scaffold + shared/ slice + lib/.
-        // Runs first (launch_delay 0) and migrators wait ~5 min before
-        // starting so the scaffold is in place when they begin.
-        idPrefix: 'scaffolder',
-        namePrefix: 'Scaffolder',
-        preset: 'migrate-scaffold',
-        profile: 'codeur',
-        count: 1,
-        launch_delay: 0,
-      },
-      {
-        // Phase 2: one migrator per slice (excluding 'shared', owned by the
-        // scaffolder). Wait long enough for scaffold + shared/ to be done.
-        // Each migrator's brief includes a precondition check
-        // (web/src/features/shared/index.ts must exist) before any write.
-        idPrefix: 'migrator',
-        namePrefix: 'Migrator',
-        preset: 'migrate-slice',
-        profile: 'codeur',
-        count: 'per-module',
-        perModuleParam: { behavior: 'migrate-slice', key: 'target_slice' },
-        // Each migrator advertises only its own slice as its module so the
-        // coordinator routes slice-targeted threads to the right owner.
-        // Cross-slice collaboration still works because announce_work can
-        // include multiple target_modules (e.g. ["chat", "shared-infra"]
-        // for a shared-infra decision).
-        perModuleRegisterOwnOnly: true,
-        // 5 min for the scaffolder to deliver npm scaffold + shared/.
-        // The migrator brief tells them to wait up to 10 min more if the
-        // scaffold isn't fully there yet, so this is a soft trigger, not a
-        // hard contract.
-        launch_delay: 300,
-      },
-    ],
-  },
-};
+import { loadTemplates } from "./template-loader.js";
 
 const AGENT_NAMES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
 
@@ -330,10 +47,12 @@ export function buildProjectFromBce(
   templateId: string,
   context: { path: string; language: string; test_command: string; modules: string[]; source_files: string[] },
   options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>> },
+  projectPath?: string,
 ): BceMiniProject {
-  const def = TEMPLATE_DEFS[templateId];
+  const templates = loadTemplates(projectPath);
+  const def = templates[templateId];
   if (!def) {
-    const available = Object.keys(TEMPLATE_DEFS).join(', ');
+    const available = Object.keys(templates).join(', ');
     throw new Error(`Unknown BCE template: "${templateId}". Available: ${available}`);
   }
 
@@ -452,7 +171,7 @@ export function buildProjectFromBce(
 }
 
 export function listBceTemplates(): { id: string; name: string; description: string }[] {
-  return Object.entries(TEMPLATE_DEFS).map(([id, def]) => ({
+  return Object.entries(loadTemplates()).map(([id, def]) => ({
     id, name: def.name, description: def.description,
   }));
 }
@@ -461,10 +180,12 @@ export function buildSoloPrompt(
   templateId: string,
   context: { language: string; test_command: string; modules: string[] },
   setParams?: Record<string, Record<string, unknown>>,
+  projectPath?: string,
 ): string {
-  const def = TEMPLATE_DEFS[templateId];
+  const templates = loadTemplates(projectPath);
+  const def = templates[templateId];
   if (!def) {
-    const available = Object.keys(TEMPLATE_DEFS).join(", ");
+    const available = Object.keys(templates).join(", ");
     throw new Error(
       `Unknown BCE template: "${templateId}". Available: ${available}`,
     );

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -17,6 +17,7 @@ interface BceMiniProject {
     profile: 'codeur' | 'communicant';
     role?: string;
     read_only?: boolean;
+    modules?: string[]; // forwarded to coordinator registration (respondent matching)
     launch_delay?: number;
     // BCE-assembled outputs — consumed by orchestrator to write .claude/ files
     hooks: Record<string, string>;
@@ -318,6 +319,14 @@ export function buildProjectFromBce(
         prompt: result.output.prompt,
         profile: agentDef.profile,
         role: agentDef.idPrefix,
+        // Pre-register modules so consultation matching picks this agent as a
+        // respondent. Without this, announce_work computes expected_respondents
+        // = [] for every thread → propose_resolution waits for absent voters
+        // → threads only close via the timeout sweeper. Default to the full
+        // project module list (every specialist is relevant to every other
+        // specialist's announces). Per-agent overrides could be added later
+        // via agentDef.modules if a template needs narrower scoping.
+        modules: context.modules,
         launch_delay: agentDef.launch_delay,
         hooks: result.output.hooks,
         envVars: result.output.envVars,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -170,8 +170,8 @@ export function buildProjectFromBce(
   };
 }
 
-export function listBceTemplates(): { id: string; name: string; description: string }[] {
-  return Object.entries(loadTemplates()).map(([id, def]) => ({
+export function listBceTemplates(projectPath?: string): { id: string; name: string; description: string }[] {
+  return Object.entries(loadTemplates(projectPath)).map(([id, def]) => ({
     id, name: def.name, description: def.description,
   }));
 }

--- a/src/coordinator-auth.ts
+++ b/src/coordinator-auth.ts
@@ -16,12 +16,24 @@ export function authHeaders(): Record<string, string> {
 }
 
 /**
+ * Headers for GENERATED CONFIG FILES (.mcp.json): reference the token via
+ * ${COORDINATOR_TOKEN} so the secret never lands on disk — Claude Code
+ * expands env vars in .mcp.json at load time. Still conditional on the
+ * token being set, so no-token output is unchanged.
+ */
+export function mcpAuthHeaders(): Record<string, string> {
+  return coordinatorToken()
+    ? { Authorization: "Bearer ${COORDINATOR_TOKEN}" }
+    : {};
+}
+
+/**
  * Post-write patch for .mcp.json files produced by essaim or promptweave:
  * adds Authorization headers to every http server whose url ends in /mcp
  * (the coordinator), leaving other servers untouched.
  */
 export function patchMcpJsonAuth(mcpJsonPath: string): void {
-  const headers = authHeaders();
+  const headers = mcpAuthHeaders();
   if (Object.keys(headers).length === 0) return;
   if (!existsSync(mcpJsonPath)) return;
   let doc: { mcpServers?: Record<string, Record<string, unknown>> };

--- a/src/coordinator-auth.ts
+++ b/src/coordinator-auth.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+
+/**
+ * Bearer token for a secured external coordinator (e.g. the k3s deployment).
+ * Read from COORDINATOR_TOKEN. Absent/blank = auth disabled (local dev,
+ * in-process coordinator) — every consumer degrades to today's behavior.
+ */
+export function coordinatorToken(): string | undefined {
+  const t = process.env.COORDINATOR_TOKEN?.trim();
+  return t ? t : undefined;
+}
+
+export function authHeaders(): Record<string, string> {
+  const token = coordinatorToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Post-write patch for .mcp.json files produced by essaim or promptweave:
+ * adds Authorization headers to every http server whose url ends in /mcp
+ * (the coordinator), leaving other servers untouched.
+ */
+export function patchMcpJsonAuth(mcpJsonPath: string): void {
+  const headers = authHeaders();
+  if (Object.keys(headers).length === 0) return;
+  if (!existsSync(mcpJsonPath)) return;
+  let doc: { mcpServers?: Record<string, Record<string, unknown>> };
+  try {
+    doc = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
+  } catch {
+    return;
+  }
+  if (!doc.mcpServers) return;
+  for (const server of Object.values(doc.mcpServers)) {
+    if (server.type === "http" && typeof server.url === "string" && server.url.endsWith("/mcp")) {
+      server.headers = { ...(server.headers as Record<string, string> | undefined), ...headers };
+    }
+  }
+  writeFileSync(mcpJsonPath, JSON.stringify(doc, null, 2) + "\n");
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -4,6 +4,7 @@ import { execSync, ChildProcess } from "child_process";
 import { fileURLToPath } from "url";
 import { resolve } from "path";
 import { createLogger } from "../logger.js";
+import { authHeaders } from "../coordinator-auth.js";
 import { startServer } from "mcp-coordinator";
 type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 const log = createLogger("orchestrator");
@@ -48,7 +49,7 @@ async function postJson(url: string, body: unknown, timeoutMs = 5000): Promise<b
   try {
     const res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify(body ?? {}),
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -605,14 +605,13 @@ export function setupProject(projectPath: string, options: SetupOptions): void {
   // 5. Create .mcp.json if it doesn't exist
   const mcpConfigPath = path.join(absProjectPath, ".mcp.json");
   if (!fs.existsSync(mcpConfigPath)) {
-    const mcpConfig = {
-      mcpServers: {
-        coordinator: {
-          type: "http",
-          url: `${coordinatorUrl}/mcp`,
-        },
-      },
+    const coordinatorServer: Record<string, unknown> = {
+      type: "http",
+      url: `${coordinatorUrl}/mcp`,
     };
+    const auth = authHeaders();
+    if (Object.keys(auth).length > 0) coordinatorServer.headers = auth;
+    const mcpConfig = { mcpServers: { coordinator: coordinatorServer } };
     fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2) + "\n");
     log.info("Wrote .mcp.json");
   } else {
@@ -632,14 +631,13 @@ export function writeAgentWorkspace(
   agent: AgentConfig,
   coordinatorUrl: string,
 ): string {
-  const mcpConfig = {
-    mcpServers: {
-      coordinator: {
-        type: "http",
-        url: `${coordinatorUrl}/mcp`,
-      },
-    },
+  const coordinatorServer: Record<string, unknown> = {
+    type: "http",
+    url: `${coordinatorUrl}/mcp`,
   };
+  const auth = authHeaders();
+  if (Object.keys(auth).length > 0) coordinatorServer.headers = auth;
+  const mcpConfig = { mcpServers: { coordinator: coordinatorServer } };
   const mcpPath = path.join(workspacePath, ".mcp.json");
   fs.writeFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2) + "\n");
 

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -37,6 +37,32 @@ const CLAUDE_HOOK_EVENT_MAP: Record<string, string> = {
 
 const POST_TOOL_USE_MATCHER = "Edit|Write|NotebookEdit";
 
+/**
+ * Cross-platform replacement for `execSync(\`curl -d '...'\`)`. The shell-quoted
+ * form silently breaks under Windows cmd.exe (single quotes aren't grouping
+ * tokens there → curl receives mangled JSON, the request never reaches the
+ * server, the `try/catch {}` swallows the failure and downstream code wrongly
+ * believes the agent was registered). Returns true on 2xx, false otherwise.
+ */
+async function postJson(url: string, body: unknown, timeoutMs = 5000): Promise<boolean> {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body ?? {}),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) {
+      log.warn(`POST ${url} → HTTP ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.warn(`POST ${url} failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 function readBceAsset(relativePath: string): string {
   return readFileSync(resolve(getCatalogRoot(), relativePath), 'utf-8');
 }
@@ -79,9 +105,14 @@ export async function runProject(
   // Effective coordinator URL for this run: from opts (external or just-started in-process)
   // or fall back to the env/default for backward-compat with without_coordinator mode.
   const effectiveCoordinatorUrl = runOpts.coordinatorUrl ?? COORDINATOR_URL;
+  // Skip /api/reset when we just spawned the coordinator in-process: its DB is
+  // empty and a curl --max-time 2 that gives up before the server finishes
+  // wiping causes a race where the agents pre-registered by the orchestrator
+  // get wiped *after* registration → SQLITE_CONSTRAINT_FOREIGNKEY on announce.
+  const coordinatorJustSpawned = coordinatorHandle !== null;
 
   try {
-    return await _runProjectBody(project, mode, cleanup, runOpts, effectiveCoordinatorUrl);
+    return await _runProjectBody(project, mode, cleanup, runOpts, effectiveCoordinatorUrl, coordinatorJustSpawned);
   } finally {
     if (coordinatorHandle) {
       try {
@@ -100,6 +131,7 @@ async function _runProjectBody(
   cleanup: boolean,
   runOpts: RunProjectOptions,
   effectiveCoordinatorUrl: string,
+  coordinatorJustSpawned: boolean,
 ): Promise<RunResult> {
   const runDir = path.resolve("runs", `${project.id}-${mode}-${Date.now()}`);
   fs.mkdirSync(runDir, { recursive: true });
@@ -128,28 +160,30 @@ async function _runProjectBody(
   // Agents reuse the same ceiling so their in-raid check matches the pre-flight.
   const agentLoopMaxQuotaPct = mode === "with_coordinator" ? maxQuotaPct : undefined;
 
-  // 1. Reset coordinator state
-  try {
-    execSync(`curl -s --max-time 2 -X POST "${effectiveCoordinatorUrl}/api/reset" -H "Content-Type: application/json"`, { stdio: "pipe" });
-    log.info("Coordinator state reset");
-  } catch {
-    log.warn("Could not reset coordinator");
+  // 1. Reset coordinator state — only when reusing an external coordinator.
+  // For in-process spawns the DB is empty; calling reset there races with
+  // the orchestrator's own pre-register step (curl --max-time 2 gives up,
+  // but the server keeps wiping; pre-registered agents get nuked just
+  // before they POST /api/announce → SQLITE_CONSTRAINT_FOREIGNKEY).
+  if (!coordinatorJustSpawned) {
+    if (await postJson(`${effectiveCoordinatorUrl}/api/reset`, {})) {
+      log.info("Coordinator state reset");
+    } else {
+      log.warn("Could not reset coordinator");
+    }
   }
 
   // 1b. Push run config to dashboard
-  try {
-    const configPayload = JSON.stringify({
-      name: project.name,
-      description: project.description,
-      phase: project.phase,
-      agents: project.agents.map(a => ({ name: a.name, profile: a.profile, role: a.role })),
-      workspace: project.workspace,
-      stagger: project.stagger,
-      timeout_minutes: project.timeout_minutes,
-      compare_mode: project.compare_mode,
-    });
-    execSync(`curl -s --max-time 2 -X POST "${effectiveCoordinatorUrl}/api/run-config" -H "Content-Type: application/json" -d '${configPayload.replace(/'/g, "'\\''")}'`, { stdio: "pipe" });
-  } catch {}
+  await postJson(`${effectiveCoordinatorUrl}/api/run-config`, {
+    name: project.name,
+    description: project.description,
+    phase: project.phase,
+    agents: project.agents.map(a => ({ name: a.name, profile: a.profile, role: a.role })),
+    workspace: project.workspace,
+    stagger: project.stagger,
+    timeout_minutes: project.timeout_minutes,
+    compare_mode: project.compare_mode,
+  });
 
   // 2. Create workspaces (resetBase FIRST, then setup, then worktrees)
   const basePath = project.workspace.base || DEFAULT_BASE;
@@ -213,16 +247,26 @@ async function _runProjectBody(
 
   // Pre-register all agents via REST (don't rely on LLMs to register correctly)
   if (isCoordinated) {
+    let registered = 0;
     for (const agent of project.agents) {
-      try {
-        execSync(`curl -s --max-time 2 -X POST "${effectiveCoordinatorUrl}/api/register" -H "Content-Type: application/json" -d '${JSON.stringify({
-          agent_id: agent.id,
-          name: agent.name,
-          modules: [], // will be overridden by agent's announce_work
-        }).replace(/'/g, "'\\''")}'`, { stdio: "pipe" });
-      } catch {}
+      // Use the agent's declared modules so consultation.ts can match it as a
+      // respondent. With `[]` here, target_modules.some()/agentModules.some()
+      // is always false → expected_respondents = [] → propose_resolution can
+      // never reach quorum → threads only close via the periodic timeout
+      // sweeper, defeating the whole collaboration layer.
+      const modules = agent.modules ?? [];
+      if (await postJson(`${effectiveCoordinatorUrl}/api/register`, {
+        agent_id: agent.id,
+        name: agent.name,
+        modules,
+      })) {
+        registered++;
+      }
     }
-    log.info(`Pre-registered ${project.agents.length} agents`);
+    log.info(`Pre-registered ${registered}/${project.agents.length} agents`);
+    if (registered < project.agents.length) {
+      log.error(`Pre-registration incomplete (${registered}/${project.agents.length}); /api/announce will fail with FK violations.`);
+    }
   }
 
   function setupAndLaunch(agent: typeof project.agents[0]): ChildProcess | null {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -4,7 +4,7 @@ import { execSync, ChildProcess } from "child_process";
 import { fileURLToPath } from "url";
 import { resolve } from "path";
 import { createLogger } from "../logger.js";
-import { authHeaders } from "../coordinator-auth.js";
+import { authHeaders, mcpAuthHeaders } from "../coordinator-auth.js";
 import { startServer } from "mcp-coordinator";
 type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 const log = createLogger("orchestrator");
@@ -609,7 +609,7 @@ export function setupProject(projectPath: string, options: SetupOptions): void {
       type: "http",
       url: `${coordinatorUrl}/mcp`,
     };
-    const auth = authHeaders();
+    const auth = mcpAuthHeaders();
     if (Object.keys(auth).length > 0) coordinatorServer.headers = auth;
     const mcpConfig = { mcpServers: { coordinator: coordinatorServer } };
     fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2) + "\n");
@@ -635,7 +635,7 @@ export function writeAgentWorkspace(
     type: "http",
     url: `${coordinatorUrl}/mcp`,
   };
-  const auth = authHeaders();
+  const auth = mcpAuthHeaders();
   if (Object.keys(auth).length > 0) coordinatorServer.headers = auth;
   const mcpConfig = { mcpServers: { coordinator: coordinatorServer } };
   const mcpPath = path.join(workspacePath, ".mcp.json");

--- a/src/orchestrator/template-engine.ts
+++ b/src/orchestrator/template-engine.ts
@@ -12,8 +12,8 @@ export function buildProject(
   return buildProjectFromBce(templateId, context, options, projectPath) as unknown as MiniProject;
 }
 
-export function listTemplates(): { id: string; name: string; description: string }[] {
-  return listBceTemplates();
+export function listTemplates(projectPath?: string): { id: string; name: string; description: string }[] {
+  return listBceTemplates(projectPath);
 }
 
 

--- a/src/orchestrator/template-engine.ts
+++ b/src/orchestrator/template-engine.ts
@@ -7,8 +7,9 @@ export function buildProject(
   templateId: string,
   context: ProjectContext,
   options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>> },
+  projectPath?: string,
 ): MiniProject {
-  return buildProjectFromBce(templateId, context, options) as unknown as MiniProject;
+  return buildProjectFromBce(templateId, context, options, projectPath) as unknown as MiniProject;
 }
 
 export function listTemplates(): { id: string; name: string; description: string }[] {

--- a/src/orchestrator/workspace.ts
+++ b/src/orchestrator/workspace.ts
@@ -59,7 +59,34 @@ export function cleanupWorkspaces(workspace: WorkspaceResult): void {
   }
 }
 
+/**
+ * "Reset" the worktree base directory by discarding uncommitted changes and
+ * deleting untracked files. DESTRUCTIVE — it nukes the user's `.claude/`,
+ * any local config, any in-progress edits.
+ *
+ * Worktrees do NOT need a clean source: `git worktree add` snapshots from a
+ * ref, independent of the source tree's working state. So this is opt-in
+ * only: set ESSAIM_RESET_BASE=1 if you really want it (typical use: a
+ * dedicated sandbox dir under `/tmp/essaim-sandbox/`, never your real
+ * project). Without the opt-in, we just log a warning if there's dirt and
+ * return — let `git worktree add` do its thing from the committed state.
+ */
 export function resetBase(basePath: string): void {
+  if (process.env.ESSAIM_RESET_BASE !== "1") {
+    let dirty = "";
+    try {
+      dirty = execSync("git status --porcelain", { cwd: basePath, encoding: "utf8" }).trim();
+    } catch { /* not a git repo? defer to caller */ }
+    if (dirty) {
+      const lines = dirty.split("\n");
+      console.warn(
+        `[workspace] base has ${lines.length} dirty/untracked entr${lines.length === 1 ? "y" : "ies"} — leaving them alone (set ESSAIM_RESET_BASE=1 to git clean -fd + git checkout -- .).\n` +
+        `            worktrees snapshot from a git ref so this is fine; your local files stay safe.`,
+      );
+    }
+    return;
+  }
+  console.warn("[workspace] ESSAIM_RESET_BASE=1 — running destructive git checkout -- . + git clean -fd on " + basePath);
   execSync("git checkout -- .", { cwd: basePath, stdio: "pipe" });
   execSync("git clean -fd", { cwd: basePath, stdio: "pipe" });
 }

--- a/src/template-loader.ts
+++ b/src/template-loader.ts
@@ -1,0 +1,77 @@
+// src/template-loader.ts
+// Loads swarm templates from YAML files (bundled catalog + project overrides).
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join, basename } from "path";
+import { parse } from "yaml";
+import { getTemplatesDir } from "../cli/bce-resolver.js";
+
+// Template definitions map template IDs to BCE presets + orchestration config.
+export interface TemplateDefinition {
+  name: string;
+  description: string;
+  phase: number;
+  workspace: 'worktree' | 'shared';
+  stagger: { mode: 'fixed' | 'random' | 'sequential'; delay?: [number, number] };
+  timeout_minutes: number;
+  metrics: string[];
+  compare_mode: boolean;
+  // Each agent role in this template
+  agents: Array<{
+    idPrefix: string;
+    namePrefix: string;
+    preset: string;
+    profile: 'codeur' | 'communicant';
+    role?: string;
+    launch_delay?: number;
+    // count semantics:
+    //   number    — exactly N agents
+    //   'dynamic' — derive N from context.modules.length (capped 2..4)
+    //   'per-module' — one agent per entry in context.modules; combine with
+    //                  perModuleParam to give each its own value
+    count?: number | 'dynamic' | 'per-module';
+    params?: Record<string, Record<string, unknown>>;
+    // perModuleParam (only with count: 'per-module'): for each agent i,
+    // inject context.modules[i] as params[behavior][key]. The agent's
+    // idPrefix is also suffixed with the module name (e.g. migrator-shared)
+    // so the dashboard shows which slice each agent owns.
+    perModuleParam?: { behavior: string; key: string };
+    // perModuleRegisterOwnOnly (only with count: 'per-module'): if true,
+    // register the agent's coordinator `modules` as just [its own module]
+    // instead of the full project list. Use this when each agent should
+    // primarily attract consultations on its own slice; cross-slice
+    // collaboration still works because announce_work can target multiple
+    // modules. Defaults to false (= full module list, broad collaboration).
+    perModuleRegisterOwnOnly?: boolean;
+  }>;
+}
+
+const REQUIRED = [
+  "name", "description", "phase", "workspace", "stagger",
+  "timeout_minutes", "metrics", "compare_mode", "agents",
+] as const;
+
+function loadDir(dir: string, out: Record<string, TemplateDefinition>): void {
+  if (!existsSync(dir)) return;
+  for (const f of readdirSync(dir).filter((n) => /\.ya?ml$/.test(n)).sort()) {
+    const doc = parse(readFileSync(join(dir, f), "utf-8")) as Record<string, unknown>;
+    for (const k of REQUIRED) {
+      if (doc[k] === undefined) throw new Error(`template ${f}: missing required field "${k}"`);
+    }
+    if (!Array.isArray(doc.agents) || doc.agents.length === 0) {
+      throw new Error(`template ${f}: "agents" must be a non-empty array`);
+    }
+    out[basename(f).replace(/\.ya?ml$/, "")] = doc as unknown as TemplateDefinition;
+  }
+}
+
+/**
+ * Load swarm templates: bundled catalog (templates/) merged with the target
+ * project's .essaim/templates/ — project entries override catalog ones.
+ * No cache: called once per run, and tests need fresh reads.
+ */
+export function loadTemplates(projectPath?: string): Record<string, TemplateDefinition> {
+  const out: Record<string, TemplateDefinition> = {};
+  loadDir(getTemplatesDir(), out);
+  if (projectPath) loadDir(join(projectPath, ".essaim", "templates"), out);
+  return out;
+}

--- a/templates/arene.yaml
+++ b/templates/arene.yaml
@@ -1,0 +1,32 @@
+name: L'Arene
+description: "Jeu de trivia sur la base de code"
+phase: 1
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 10
+metrics: [questions_asked, correct_answers]
+compare_mode: false
+agents:
+  - idPrefix: agent-quizmaster
+    namePrefix: Quizmaster
+    preset: arene-quizmaster
+    profile: communicant
+    count: 1
+  - idPrefix: agent-joueur-a
+    namePrefix: Joueur A
+    preset: arene-player
+    profile: communicant
+    count: 1
+    params:
+      quiz-player:
+        player_name: Joueur A
+        focus_area: structure du projet
+  - idPrefix: agent-joueur-b
+    namePrefix: Joueur B
+    preset: arene-player
+    profile: communicant
+    count: 1
+    params:
+      quiz-player:
+        player_name: Joueur B
+        focus_area: patterns et architecture

--- a/templates/babel.yaml
+++ b/templates/babel.yaml
@@ -1,0 +1,19 @@
+name: Babel
+description: "Traducteur + reviseur traduisent la documentation"
+phase: 1
+workspace: worktree
+stagger: { mode: sequential }
+timeout_minutes: 15
+metrics: [files_translated, review_issues]
+compare_mode: false
+agents:
+  - idPrefix: agent-traducteur
+    namePrefix: Traducteur
+    preset: babel-translator
+    profile: communicant
+    count: 1
+  - idPrefix: agent-reviseur
+    namePrefix: Reviseur
+    preset: babel-reviewer
+    profile: communicant
+    count: 1

--- a/templates/carrefour.yaml
+++ b/templates/carrefour.yaml
@@ -1,0 +1,14 @@
+name: Le Carrefour
+description: "Agents croisent leurs intentions sur les memes fichiers"
+phase: 3
+workspace: worktree
+stagger: { mode: random, delay: [3, 8] }
+timeout_minutes: 15
+metrics: [conflicts_detected, conflicts_resolved, consultations_opened]
+compare_mode: false
+agents:
+  - idPrefix: agent
+    namePrefix: Agent
+    preset: carrefour
+    profile: codeur
+    count: dynamic

--- a/templates/chaine.yaml
+++ b/templates/chaine.yaml
@@ -1,0 +1,26 @@
+name: La Chaine
+description: "Pipeline sequentiel: implementer, reviewer, tester"
+phase: 2
+workspace: worktree
+stagger: { mode: sequential }
+timeout_minutes: 25
+metrics: [pipeline_stages_completed, tests_passing]
+compare_mode: false
+agents:
+  - idPrefix: agent-implementeur
+    namePrefix: Implementeur
+    preset: chaine-implement
+    profile: codeur
+    count: 1
+  - idPrefix: agent-reviewer
+    namePrefix: Reviewer
+    preset: chaine-review
+    profile: communicant
+    count: 1
+    launch_delay: 5
+  - idPrefix: agent-testeur
+    namePrefix: Testeur
+    preset: chaine-test
+    profile: codeur
+    count: 1
+    launch_delay: 10

--- a/templates/debat.yaml
+++ b/templates/debat.yaml
@@ -1,0 +1,33 @@
+name: Le Debat
+description: "3 agents debattent une approche de refactor"
+phase: 3
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 15
+metrics: [rounds_to_consensus, contestations]
+compare_mode: false
+agents:
+  - idPrefix: agent-separation
+    namePrefix: Agent Separation
+    preset: debat
+    profile: communicant
+    count: 1
+    params:
+      debate-position:
+        position: "Tu favorises le decoupage par responsabilite (un fichier par concern). Argumente la lisibilite et testabilite."
+  - idPrefix: agent-strategy
+    namePrefix: Agent Strategy
+    preset: debat
+    profile: communicant
+    count: 1
+    params:
+      debate-position:
+        position: "Tu favorises le pattern Strategy (interface + implementations). Argumente la configurabilite."
+  - idPrefix: agent-minimal
+    namePrefix: Agent Minimal
+    preset: debat
+    profile: communicant
+    count: 1
+    params:
+      debate-position:
+        position: "Tu favorises le refactor minimal (extraire seulement les helpers). Argumente que le risque depasse le benefice."

--- a/templates/gardien.yaml
+++ b/templates/gardien.yaml
@@ -1,0 +1,14 @@
+name: Le Gardien
+description: "1 agent analyse la qualite du projet"
+phase: 1
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 10
+metrics: [issues_found, categories_scanned]
+compare_mode: false
+agents:
+  - idPrefix: agent-gardien
+    namePrefix: Le Gardien
+    preset: gardien
+    profile: communicant
+    count: 1

--- a/templates/maitre.yaml
+++ b/templates/maitre.yaml
@@ -1,0 +1,21 @@
+name: Le Maitre
+description: "1 lead distribue aux workers"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [8, 12] }
+timeout_minutes: 20
+metrics: [worker_idle_time, task_distribution_quality]
+compare_mode: false
+agents:
+  - idPrefix: tech-lead
+    namePrefix: Tech Lead
+    preset: maitre-lead
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: worker
+    namePrefix: Worker
+    preset: maitre-worker
+    profile: codeur
+    count: dynamic
+    launch_delay: 10

--- a/templates/mekova-bughunt.yaml
+++ b/templates/mekova-bughunt.yaml
@@ -1,0 +1,14 @@
+name: Mekova Bughunt
+description: "Chasse à la cause racine avec preuve par test (flow RCA)"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [5, 10] }
+timeout_minutes: 25
+metrics: [bugs_found, tests_added]
+compare_mode: false
+agents:
+  - idPrefix: mekova-chasseur
+    namePrefix: Chasseur Mekova
+    preset: mekova-bughunt
+    profile: codeur
+    count: dynamic

--- a/templates/mekova-implement.yaml
+++ b/templates/mekova-implement.yaml
@@ -1,0 +1,21 @@
+name: Mekova Implement
+description: "Lead Mekova dispatch les tâches de tasks.md à N workers"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [8, 12] }
+timeout_minutes: 30
+metrics: [worker_idle_time, task_distribution_quality]
+compare_mode: false
+agents:
+  - idPrefix: mekova-lead
+    namePrefix: Lead Mekova
+    preset: mekova-implement-lead
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: mekova-worker
+    namePrefix: Worker Mekova
+    preset: mekova-implement-worker
+    profile: codeur
+    count: dynamic
+    launch_delay: 10

--- a/templates/mekova-review.yaml
+++ b/templates/mekova-review.yaml
@@ -1,0 +1,14 @@
+name: Mekova Review
+description: "Audit read-only avec classification Local/Pattern/Convention gap"
+phase: 1
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 15
+metrics: [issues_found, categories_scanned]
+compare_mode: false
+agents:
+  - idPrefix: mekova-reviewer
+    namePrefix: Reviewer Mekova
+    preset: mekova-review
+    profile: communicant
+    count: 1

--- a/templates/melee.yaml
+++ b/templates/melee.yaml
@@ -1,0 +1,14 @@
+name: La Melee
+description: "N agents ecrivent des tests en parallele"
+phase: 1
+workspace: worktree
+stagger: { mode: random, delay: [5, 15] }
+timeout_minutes: 20
+metrics: [tests_written, tests_passing]
+compare_mode: true
+agents:
+  - idPrefix: agent
+    namePrefix: Agent
+    preset: melee
+    profile: codeur
+    count: dynamic

--- a/templates/migrate-phase2.yaml
+++ b/templates/migrate-phase2.yaml
@@ -1,0 +1,36 @@
+name: Migration Phase 2
+description: "Scaffolder pose web/ + shared/ + lib/supabase, puis N migrateurs (un par slice) attaquent leur slice — vraie collaboration via workspace partagé"
+phase: 2
+# workspace: shared (NOT worktree) — the previous 'worktree' design forced each
+# per-slice agent to re-create the shared scaffold in its own isolated copy,
+# producing divergent shared/Button.tsx, divergent lib/supabase.ts, divergent
+# main.tsx that couldn't be merged cleanly. With 'shared', the scaffolder writes
+# once and the migrators read (and import) those files directly.
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 120
+metrics: [slices_migrated, tests_ported, cross_slice_consultations]
+compare_mode: false
+agents:
+  # Phase 1: one scaffolder owns the scaffold + shared/ slice + lib/.
+  # Runs first (launch_delay 0) and migrators wait ~5 min before starting so
+  # the scaffold is in place when they begin.
+  - idPrefix: scaffolder
+    namePrefix: Scaffolder
+    preset: migrate-scaffold
+    profile: codeur
+    count: 1
+    launch_delay: 0
+  # Phase 2: one migrator per slice (excluding 'shared', owned by the
+  # scaffolder). Wait long enough for scaffold + shared/ to be done.
+  - idPrefix: migrator
+    namePrefix: Migrator
+    preset: migrate-slice
+    profile: codeur
+    count: per-module
+    perModuleParam: { behavior: migrate-slice, key: target_slice }
+    # Each migrator advertises only its own slice as its module so the
+    # coordinator routes slice-targeted threads to the right owner.
+    perModuleRegisterOwnOnly: true
+    # 5 min for the scaffolder to deliver npm scaffold + shared/.
+    launch_delay: 300

--- a/templates/phare.yaml
+++ b/templates/phare.yaml
@@ -1,0 +1,39 @@
+name: Le Phare
+description: "4 auditeurs spécialisés en parallèle + 1 réconciliateur — audit multi-angles"
+phase: 2
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 30
+metrics: [specialists_completed, reconciliations, disagreements_flagged]
+compare_mode: false
+agents:
+  - idPrefix: inventaire
+    namePrefix: Inventaire
+    preset: phare-inventaire
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: edges
+    namePrefix: Edges
+    preset: phare-edges
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: deps
+    namePrefix: Deps
+    preset: phare-deps
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: risques
+    namePrefix: Risques
+    preset: phare-risques
+    profile: communicant
+    count: 1
+    launch_delay: 0
+  - idPrefix: synth
+    namePrefix: Reconciliateur
+    preset: phare-synth
+    profile: communicant
+    count: 1
+    launch_delay: 60

--- a/templates/raid.yaml
+++ b/templates/raid.yaml
@@ -1,0 +1,14 @@
+name: Le Raid
+description: "Agents chassent les bugs et edge cases manquants"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [5, 10] }
+timeout_minutes: 20
+metrics: [bugs_found, tests_added]
+compare_mode: false
+agents:
+  - idPrefix: agent-chasseur
+    namePrefix: Chasseur
+    preset: raid
+    profile: codeur
+    count: dynamic

--- a/templates/relais.yaml
+++ b/templates/relais.yaml
@@ -1,0 +1,24 @@
+name: Le Relais
+description: "3 coureurs se relaient sequentiellement"
+phase: 2
+workspace: worktree
+stagger: { mode: sequential }
+timeout_minutes: 25
+metrics: [improvements_per_runner, tests_passing]
+compare_mode: false
+agents:
+  - idPrefix: agent-coureur-1
+    namePrefix: Coureur 1
+    preset: relais-1
+    profile: codeur
+    count: 1
+  - idPrefix: agent-coureur-2
+    namePrefix: Coureur 2
+    preset: relais-2
+    profile: codeur
+    count: 1
+  - idPrefix: agent-coureur-3
+    namePrefix: Coureur 3
+    preset: relais-3
+    profile: codeur
+    count: 1

--- a/templates/revue.yaml
+++ b/templates/revue.yaml
@@ -1,0 +1,20 @@
+name: La Revue
+description: "N auteurs + N reviewers en croisement"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [5, 10] }
+timeout_minutes: 20
+metrics: [review_comments, approvals]
+compare_mode: false
+agents:
+  - idPrefix: auteur
+    namePrefix: Auteur
+    preset: revue-author
+    profile: codeur
+    count: dynamic
+  - idPrefix: reviewer
+    namePrefix: Reviewer
+    preset: revue-reviewer
+    profile: communicant
+    count: dynamic
+    launch_delay: 120

--- a/templates/swarm.yaml
+++ b/templates/swarm.yaml
@@ -1,0 +1,14 @@
+name: L'Essaim
+description: "N agents refactorisent en parallele"
+phase: 2
+workspace: worktree
+stagger: { mode: random, delay: [3, 8] }
+timeout_minutes: 20
+metrics: [files_refactored, tests_passing]
+compare_mode: false
+agents:
+  - idPrefix: agent-refacteur
+    namePrefix: Refacteur
+    preset: swarm
+    profile: codeur
+    count: dynamic

--- a/tests/unit/coordinator-auth.test.ts
+++ b/tests/unit/coordinator-auth.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { authHeaders, coordinatorToken, patchMcpJsonAuth } from "../../src/coordinator-auth.js";
+import { authHeaders, coordinatorToken, mcpAuthHeaders, patchMcpJsonAuth } from "../../src/coordinator-auth.js";
 import { writeAgentWorkspace } from "../../src/orchestrator/orchestrator.js";
 import type { AgentConfig } from "../../src/orchestrator/types.js";
 
@@ -30,7 +30,17 @@ describe("coordinator-auth", () => {
     expect(authHeaders()).toEqual({ Authorization: "Bearer abc.def.ghi" });
   });
 
-  it("patchMcpJsonAuth adds headers to http servers ending in /mcp", () => {
+  it("mcpAuthHeaders is empty without token", () => {
+    delete process.env.COORDINATOR_TOKEN;
+    expect(mcpAuthHeaders()).toEqual({});
+  });
+
+  it("mcpAuthHeaders carries the ${COORDINATOR_TOKEN} placeholder when set, never the literal token", () => {
+    process.env.COORDINATOR_TOKEN = "abc.def.ghi";
+    expect(mcpAuthHeaders()).toEqual({ Authorization: "Bearer ${COORDINATOR_TOKEN}" });
+  });
+
+  it("patchMcpJsonAuth adds placeholder headers (never the literal token) to http servers ending in /mcp", () => {
     process.env.COORDINATOR_TOKEN = "tok";
     const dir = mkdtempSync(join(tmpdir(), "essaim-auth-"));
     const p = join(dir, ".mcp.json");
@@ -42,8 +52,10 @@ describe("coordinator-auth", () => {
     }));
     patchMcpJsonAuth(p);
     const out = JSON.parse(readFileSync(p, "utf-8"));
-    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer tok" });
+    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer ${COORDINATOR_TOKEN}" });
     expect(out.mcpServers.other.headers).toBeUndefined();
+    const raw = readFileSync(p, "utf-8");
+    expect(raw).not.toContain("tok\"");
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -71,7 +83,9 @@ describe("coordinator-auth", () => {
     };
     const mcpPath = writeAgentWorkspace(dir, agent, "https://coord.example");
     const out = JSON.parse(readFileSync(mcpPath, "utf-8"));
-    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer tok2" });
+    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer ${COORDINATOR_TOKEN}" });
+    const raw = readFileSync(mcpPath, "utf-8");
+    expect(raw).not.toContain("tok2");
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/unit/coordinator-auth.test.ts
+++ b/tests/unit/coordinator-auth.test.ts
@@ -45,8 +45,13 @@ describe("coordinator-auth", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("patchMcpJsonAuth is a no-op without token or missing file", () => {
+  it("patchMcpJsonAuth is a no-op without token", () => {
     delete process.env.COORDINATOR_TOKEN;
+    expect(() => patchMcpJsonAuth(join(tmpdir(), "does-not-exist.json"))).not.toThrow();
+  });
+
+  it("patchMcpJsonAuth is a no-op when token set but file missing", () => {
+    process.env.COORDINATOR_TOKEN = "tok";
     expect(() => patchMcpJsonAuth(join(tmpdir(), "does-not-exist.json"))).not.toThrow();
   });
 });

--- a/tests/unit/coordinator-auth.test.ts
+++ b/tests/unit/coordinator-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { authHeaders, coordinatorToken, patchMcpJsonAuth } from "../../src/coordinator-auth.js";
+
+describe("coordinator-auth", () => {
+  const saved = process.env.COORDINATOR_TOKEN;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.COORDINATOR_TOKEN;
+    else process.env.COORDINATOR_TOKEN = saved;
+  });
+
+  it("coordinatorToken returns undefined when unset or blank", () => {
+    delete process.env.COORDINATOR_TOKEN;
+    expect(coordinatorToken()).toBeUndefined();
+    process.env.COORDINATOR_TOKEN = "   ";
+    expect(coordinatorToken()).toBeUndefined();
+  });
+
+  it("authHeaders is empty without token", () => {
+    delete process.env.COORDINATOR_TOKEN;
+    expect(authHeaders()).toEqual({});
+  });
+
+  it("authHeaders carries Bearer token when set", () => {
+    process.env.COORDINATOR_TOKEN = "abc.def.ghi";
+    expect(authHeaders()).toEqual({ Authorization: "Bearer abc.def.ghi" });
+  });
+
+  it("patchMcpJsonAuth adds headers to http servers ending in /mcp", () => {
+    process.env.COORDINATOR_TOKEN = "tok";
+    const dir = mkdtempSync(join(tmpdir(), "essaim-auth-"));
+    const p = join(dir, ".mcp.json");
+    writeFileSync(p, JSON.stringify({
+      mcpServers: {
+        coordinator: { type: "http", url: "http://localhost:3100/mcp" },
+        other: { type: "stdio", command: "foo" },
+      },
+    }));
+    patchMcpJsonAuth(p);
+    const out = JSON.parse(readFileSync(p, "utf-8"));
+    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer tok" });
+    expect(out.mcpServers.other.headers).toBeUndefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("patchMcpJsonAuth is a no-op without token or missing file", () => {
+    delete process.env.COORDINATOR_TOKEN;
+    expect(() => patchMcpJsonAuth(join(tmpdir(), "does-not-exist.json"))).not.toThrow();
+  });
+});

--- a/tests/unit/coordinator-auth.test.ts
+++ b/tests/unit/coordinator-auth.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { authHeaders, coordinatorToken, patchMcpJsonAuth } from "../../src/coordinator-auth.js";
+import { writeAgentWorkspace } from "../../src/orchestrator/orchestrator.js";
+import type { AgentConfig } from "../../src/orchestrator/types.js";
 
 describe("coordinator-auth", () => {
   const saved = process.env.COORDINATOR_TOKEN;
@@ -53,5 +55,23 @@ describe("coordinator-auth", () => {
   it("patchMcpJsonAuth is a no-op when token set but file missing", () => {
     process.env.COORDINATOR_TOKEN = "tok";
     expect(() => patchMcpJsonAuth(join(tmpdir(), "does-not-exist.json"))).not.toThrow();
+  });
+
+  it("writeAgentWorkspace embeds auth headers when token set", () => {
+    process.env.COORDINATOR_TOKEN = "tok2";
+    const dir = mkdtempSync(join(tmpdir(), "essaim-ws-"));
+    const agent: AgentConfig = {
+      id: "a1",
+      name: "A1",
+      prompt: "x",
+      profile: "codeur",
+      hooks: {},
+      envVars: {},
+      mcpTools: [],
+    };
+    const mcpPath = writeAgentWorkspace(dir, agent, "https://coord.example");
+    const out = JSON.parse(readFileSync(mcpPath, "utf-8"));
+    expect(out.mcpServers.coordinator.headers).toEqual({ Authorization: "Bearer tok2" });
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/unit/mqtt-listener.test.ts
+++ b/tests/unit/mqtt-listener.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
 // Mock mqtt module before importing the listener
@@ -15,6 +15,7 @@ vi.mock("mqtt", () => ({
   },
 }));
 
+import mqtt from "mqtt";
 import { createMqttListener, type MqttInterrupt } from "../../src/agent-loop/mqtt-listener.js";
 
 const OPTIONS = {
@@ -250,6 +251,31 @@ describe("MqttListener", () => {
       const listener = await connectListener();
       simulateMessage("coordinator/unknown/something", { agent_id: "a2" });
       expect(listener.peek()).toBe(0);
+    });
+  });
+
+  describe("coordinator token credentials", () => {
+    const originalToken = process.env.COORDINATOR_TOKEN;
+
+    afterEach(() => {
+      if (originalToken === undefined) delete process.env.COORDINATOR_TOKEN;
+      else process.env.COORDINATOR_TOKEN = originalToken;
+    });
+
+    it("connects without username/password when no token is set", async () => {
+      delete process.env.COORDINATOR_TOKEN;
+      await connectListener();
+      const opts = (mqtt.connect as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(opts.username).toBeUndefined();
+      expect(opts.password).toBeUndefined();
+    });
+
+    it("passes the coordinator token as MQTT credentials when set", async () => {
+      process.env.COORDINATOR_TOKEN = "test-jwt-token";
+      await connectListener();
+      const opts = (mqtt.connect as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(opts.username).toBe("agent");
+      expect(opts.password).toBe("test-jwt-token");
     });
   });
 

--- a/tests/unit/template-loader.test.ts
+++ b/tests/unit/template-loader.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { loadTemplates } from "../../src/template-loader.js";
+import { listTemplates } from "../../src/orchestrator/template-engine.js";
 
 describe("template-loader", () => {
   it("charge les 14 templates stock depuis le catalogue", () => {
@@ -26,6 +27,33 @@ describe("template-loader", () => {
     const raid = { ...loadTemplates().raid, timeout_minutes: 99 };
     writeFileSync(join(proj, ".essaim", "templates", "raid.yaml"), JSON.stringify(raid));
     expect(loadTemplates(proj).raid.timeout_minutes).toBe(99);
+    rmSync(proj, { recursive: true, force: true });
+  });
+
+  it("un template projet-only (id absent du catalogue) apparaît dans loadTemplates/listTemplates avec projectPath, absent sans", () => {
+    const proj = join(tmpdir(), `essaim-tpl-new-${process.pid}`);
+    mkdirSync(join(proj, ".essaim", "templates"), { recursive: true });
+    const custom = {
+      name: "Custom Proof",
+      description: "Project-only template used to prove pre-flight resolution",
+      phase: 1,
+      workspace: "worktree",
+      stagger: { mode: "fixed", delay: [0, 0] },
+      timeout_minutes: 10,
+      metrics: ["files_changed"],
+      compare_mode: false,
+      agents: [
+        { idPrefix: "custom", namePrefix: "Custom", preset: "raid", profile: "codeur", count: 1 },
+      ],
+    };
+    writeFileSync(join(proj, ".essaim", "templates", "custom-proof.yaml"), JSON.stringify(custom));
+
+    expect(loadTemplates(proj)["custom-proof"]).toBeDefined();
+    expect(loadTemplates()["custom-proof"]).toBeUndefined();
+
+    expect(listTemplates(proj).some((t) => t.id === "custom-proof")).toBe(true);
+    expect(listTemplates().some((t) => t.id === "custom-proof")).toBe(false);
+
     rmSync(proj, { recursive: true, force: true });
   });
 });

--- a/tests/unit/template-loader.test.ts
+++ b/tests/unit/template-loader.test.ts
@@ -65,4 +65,12 @@ describe("template-loader", () => {
     ]);
     expect(t["mekova-implement"].agents[1].count).toBe("dynamic");
   });
+
+  it("mekova-review has one agent with preset mekova-review", () => {
+    const t = loadTemplates();
+    expect(t["mekova-review"]).toBeDefined();
+    expect(t["mekova-review"].agents.length).toBe(1);
+    expect(t["mekova-review"].agents[0].preset).toBe("mekova-review");
+    expect(t["mekova-review"].agents[0].count).toBe(1);
+  });
 });

--- a/tests/unit/template-loader.test.ts
+++ b/tests/unit/template-loader.test.ts
@@ -73,4 +73,12 @@ describe("template-loader", () => {
     expect(t["mekova-review"].agents[0].preset).toBe("mekova-review");
     expect(t["mekova-review"].agents[0].count).toBe(1);
   });
+
+  it("mekova-bughunt has one agent with preset mekova-bughunt and count dynamic", () => {
+    const t = loadTemplates();
+    expect(t["mekova-bughunt"]).toBeDefined();
+    expect(t["mekova-bughunt"].agents.length).toBe(1);
+    expect(t["mekova-bughunt"].agents[0].preset).toBe("mekova-bughunt");
+    expect(t["mekova-bughunt"].agents[0].count).toBe("dynamic");
+  });
 });

--- a/tests/unit/template-loader.test.ts
+++ b/tests/unit/template-loader.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { loadTemplates } from "../../src/template-loader.js";
+
+describe("template-loader", () => {
+  it("charge les 14 templates stock depuis le catalogue", () => {
+    const t = loadTemplates();
+    expect(Object.keys(t).length).toBeGreaterThanOrEqual(14);
+    expect(t.raid.agents[0].preset).toBe("raid");
+    expect(t.maitre.agents.map((a) => a.preset)).toEqual(["maitre-lead", "maitre-worker"]);
+  });
+
+  it("rejette un template sans champ requis", () => {
+    const proj = join(tmpdir(), `essaim-tpl-bad-${process.pid}`);
+    mkdirSync(join(proj, ".essaim", "templates"), { recursive: true });
+    writeFileSync(join(proj, ".essaim", "templates", "bad.yaml"), "name: Bad\n");
+    expect(() => loadTemplates(proj)).toThrow(/missing required field/);
+    rmSync(proj, { recursive: true, force: true });
+  });
+
+  it("les templates projet écrasent le catalogue", () => {
+    const proj = join(tmpdir(), `essaim-tpl-ovr-${process.pid}`);
+    mkdirSync(join(proj, ".essaim", "templates"), { recursive: true });
+    const raid = { ...loadTemplates().raid, timeout_minutes: 99 };
+    writeFileSync(join(proj, ".essaim", "templates", "raid.yaml"), JSON.stringify(raid));
+    expect(loadTemplates(proj).raid.timeout_minutes).toBe(99);
+    rmSync(proj, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/template-loader.test.ts
+++ b/tests/unit/template-loader.test.ts
@@ -56,4 +56,13 @@ describe("template-loader", () => {
 
     rmSync(proj, { recursive: true, force: true });
   });
+
+  it("mekova-implement wires lead + workers", () => {
+    const t = loadTemplates();
+    expect(t["mekova-implement"].agents.map((a) => a.preset)).toEqual([
+      "mekova-implement-lead",
+      "mekova-implement-worker",
+    ]);
+    expect(t["mekova-implement"].agents[1].count).toBe("dynamic");
+  });
 });


### PR DESCRIPTION
## What

Three related capability sets, built and battle-tested against a deployed multi-tenant coordinator (k3s, JWT auth), then validated by a real 4-worker pilot run:

### 1. Coordinator authentication (`COORDINATOR_TOKEN`)
- Bearer token on all 7 coordinator REST call sites (agent-loop, work-stealing, orchestrator)
- Generated `.mcp.json` files reference `${COORDINATOR_TOKEN}` (Claude Code env expansion) — the raw secret never lands on disk
- MQTT credentials in the CONNECT packet (JWT as `password`, matching mcp-coordinator's authenticate hook)
- No-token path byte-identical (local/in-process coordinator unaffected)

### 2. Templates migrate to YAML (breaking: `TEMPLATE_DEFS` removed)
- All 14 stock templates → `templates/*.yaml`, loaded by `src/template-loader.ts` with required-field validation
- Project-local overrides: `.essaim/templates/` (project wins), resolved at CLI pre-flight too
- Migration proven lossless by a strict equivalence test during the transition, plus an independent 14/14 field-by-field verification
- Templates are now data, like behaviors and presets — custom swarm patterns without touching TS (roadmap v0.3)

### 3. Mekova methodology templates
- `mission-tasks-md` behavior + `mekova-implement` (lead + N workers driven by a tasks.md phase), `mekova-review` (classified read-only audit), `mekova-bughunt` (RCA: failing repro test, never fixes)

## Validation

- 320 tests green (1 pre-existing Windows chmod skip) + build clean
- E2E against a secured coordinator: 401 without token / 200 with; dashboard registration; `${COORDINATOR_TOKEN}` expansion verified in a live run
- Pilot: 1 lead + 4 workers implemented a real 4-task phase — 4 clean commits, zero merge conflicts, 28 new unit tests passing; separate review and bughunt runs also green

## Known follow-ups (will file as issues)

`--set` numeric coercion vs `type: string` params; run-report counters (threads/diff/cost with OAuth); review-phase dedup on small pools; per-run thread scoping on shared coordinators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)