### PR TITLE
fix(coordination): gate sequential pipelines on artifacts, not thread status (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ Three rules adapt behaviors automatically based on what's assembled.
 | `sequential-then-announce` | `sequential-wait` + `announce-before-write` | Injects section 012: "wait -> announce -> code" |
 | `solo-mode-strip` | `coordinator-rules.solo_mode = true` | Strips announce / conflict-resolution entirely; agent works alone |
 
+### Gating a sequential pipeline on artifacts
+
+A resolved thread does not prove the predecessor's file is on disk: resolution and
+writing are not ordered, and the coordinator's timeout sweeper can resolve a thread
+that produced nothing at all. Gate on the artifact, not the status — give
+`sequential-wait` the files you expect and it will poll for them before treating an
+input as missing:
+
+```yaml
+params:
+  sequential-wait:
+    expect_files: ["tmp/decouverte/features.yaml", "tmp/decouverte/risques.yaml"]
+    retry_attempts: 3        # default
+    retry_delay_seconds: 10  # default
+```
+
+The producing side owes the other half of the contract: **write the artifact, read it
+back, and only then resolve** — a mission prompt that resolves before it writes will
+have its output silently dropped by the consumer.
+
 List the templates the CLI ships with via `essaim list`. To preview what a template assembles (prompt + agent plan) without burning tokens, use `essaim run <template> --dry-run`. Behaviors, presets, and composition rules live under [`behaviors/`](./behaviors/), [`presets/`](./presets/), and [`compositions/`](./compositions/) in this repo — browse them directly to author or edit.
 
 ### Read-only audits with a fixed write surface

--- a/behaviors/discovery-specialist.yaml
+++ b/behaviors/discovery-specialist.yaml
@@ -32,11 +32,19 @@ sections:
       2. Distingue l'exprimé (le client l'a dit) de l'implicite (déduit) —
          champ `origine: exprime | implicite` sur chaque item.
       3. Annonce ton scope via announce_work (subject: "Analyse découverte:
-         {{params.angle}}"), travaille, puis propose_resolution avec un résumé.
-      4. Écris ton résultat UNIQUEMENT dans `tmp/decouverte/{{params.angle}}.yaml`,
+         {{params.angle}}"), puis travaille.
+
+      Ordre de fin de mission — le synthétiseur en aval est gaté sur TON artefact,
+      et il te lira dès que ton thread sera résolu. Résoudre avant d'avoir écrit
+      fait disparaître ton angle de la synthèse. Donc, dans cet ordre STRICT :
+
+      4. ÉCRIS ton résultat UNIQUEMENT dans `tmp/decouverte/{{params.angle}}.yaml`,
          une liste d'items:
          - titre: <court>
            detail: <2-4 phrases>
            citation: "<verbatim client>"
            origine: exprime|implicite
-      5. Termine par `DONE: <n> items ({{params.angle}})`.
+      5. RELIS le fichier que tu viens d'écrire (Read) pour confirmer qu'il est
+         bien sur disque, complet et non vide.
+      6. SEULEMENT ENSUITE, propose_resolution avec un résumé.
+      7. Termine par `DONE: <n> items ({{params.angle}})`.

--- a/behaviors/sequential-wait.yaml
+++ b/behaviors/sequential-wait.yaml
@@ -14,6 +14,21 @@ params:
     type: string
     required: false
     description: "Description of who we wait for"
+  expect_files:
+    type: "string[]"
+    required: false
+    description: >
+      Artefacts que le prédécesseur doit avoir produits. Fournis-les et le gate
+      porte sur les FICHIERS, pas seulement sur le statut de thread (voir #38).
+      Vide = gate sur le statut de thread seul (comportement historique).
+  retry_attempts:
+    type: number
+    default: 3
+    description: "Nombre de vérifications des artefacts avant de les déclarer absents"
+  retry_delay_seconds:
+    type: number
+    default: 10
+    description: "Délai entre deux vérifications des artefacts"
 
 sections:
   "011-wait-predecessor":
@@ -23,5 +38,26 @@ sections:
       AVANT de commencer, vérifie avec list_threads(status: "{{params.wait_for_status}}") que l'agent précédent a terminé.
       {{#if params.predecessor_description}}Attends: {{params.predecessor_description}}.{{/if}}
       Ne commence PAS tant que l'étape précédente n'est pas résolue.
+      {{#if params.expect_files}}
+
+      ### Gate sur artefacts
+      Un thread résolu ne garantit PAS que les fichiers du prédécesseur sont sur
+      disque : la résolution et l'écriture ne sont pas ordonnées, et un thread
+      peut même être résolu par le balayage de timeout du coordinateur sans
+      qu'aucun artefact n'ait été produit. Le statut de thread est un indice, le
+      fichier est la preuve.
+
+      Une fois les threads résolus, vérifie que CHACUN de ces artefacts existe et
+      est non vide :
+      {{#each params.expect_files}}
+      - `{{this}}`
+      {{/each}}
+
+      S'il en manque un : attends `sleep {{params.retry_delay_seconds}}` puis
+      re-vérifie — jusqu'à {{params.retry_attempts}} tentatives. Un artefact
+      encore absent après la dernière tentative est réellement absent : traite-le
+      comme tel (dégradation prévue par ta mission) et dis explicitement lequel
+      manquait dans ta sortie. N'invente jamais le contenu d'un artefact absent.
+      {{/if}}
 
 mcp_tools: [list_threads]

--- a/presets/mekova-dec-synth.yaml
+++ b/presets/mekova-dec-synth.yaml
@@ -21,3 +21,8 @@ params:
       les 4 angles de découverte (features, risques, roi, questions) —
       vérifie via list_threads que leurs QUATRE sessions sont resolved
       avant de commencer ta synthèse
+    expect_files:
+      - "tmp/decouverte/features.yaml"
+      - "tmp/decouverte/risques.yaml"
+      - "tmp/decouverte/roi.yaml"
+      - "tmp/decouverte/questions.yaml"

--- a/presets/phare-synth.yaml
+++ b/presets/phare-synth.yaml
@@ -17,6 +17,11 @@ params:
   sequential-wait:
     predecessor_description: "les 4 spécialistes (inventaire, edges, deps, risques) — vérifie list_threads que leurs sessions sont terminées"
     wait_for_status: "resolved"
+    expect_files:
+      - "tmp/audit/inventaire.yaml"
+      - "tmp/audit/edges.yaml"
+      - "tmp/audit/deps.yaml"
+      - "tmp/audit/risques.yaml"
   audit-output:
     paths:
       - "MIGRATION_AUDIT.md"

--- a/tests/unit/bce-parity.test.ts
+++ b/tests/unit/bce-parity.test.ts
@@ -191,6 +191,56 @@ describe('Parity: BCE presets produce complete prompts', () => {
     });
   });
 
+  // Régression #38 — sequential-wait gatait sur le statut de thread seul, qui ne
+  // dit RIEN du système de fichiers : un thread « resolved » peut précéder le
+  // flush de l'artefact du prédécesseur (voire ne rien produire du tout, quand
+  // c'est le balayage de timeout du coordinateur qui l'a résolu). Les deux côtés
+  // du contrat sont testés : le producteur écrit avant de résoudre, le
+  // consommateur gate sur les fichiers avec retry borné.
+  describe('Artifact gate (#38)', () => {
+    // Params réellement fournis par le skill invocateur via --set (cf. SMOKE_SET_PARAMS)
+    const DEC_PARAMS = {
+      'discovery-specialist': { transcript: 'notes/rencontres/test.md' },
+      'discovery-synth': { transcript: 'notes/rencontres/test.md', projet: 'test' },
+    };
+
+    it('producer writes and verifies its artifact BEFORE proposing resolution', () => {
+      // Scopé à la section mission : d'autres behaviors mentionnent
+      // propose_resolution plus haut dans le prompt assemblé.
+      const result = buildPreset('mekova-dec-risques', DEC_PARAMS);
+      const mission = result.sectionTrace.find(
+        s => s.behaviorName === 'discovery-specialist' && s.key === '030-mission',
+      );
+      expect(mission).toBeDefined();
+      const write = mission!.prompt.indexOf('tmp/decouverte/risques.yaml');
+      const resolveIdx = mission!.prompt.indexOf('propose_resolution');
+      expect(write).toBeGreaterThan(-1);
+      expect(resolveIdx).toBeGreaterThan(-1);
+      expect(write).toBeLessThan(resolveIdx);
+    });
+
+    it('consumer gates on the expected files, not just thread status', () => {
+      const prompt = buildPreset('mekova-dec-synth', DEC_PARAMS).output.prompt;
+      for (const angle of ['features', 'risques', 'roi', 'questions']) {
+        expect(prompt).toContain(`tmp/decouverte/${angle}.yaml`);
+      }
+      expect(prompt).toContain('Séquencement');
+      expect(prompt).toContain('sleep');
+    });
+
+    it('a resolved thread is explicitly not proof the artifact exists', () => {
+      const prompt = buildPreset('mekova-dec-synth', DEC_PARAMS).output.prompt;
+      expect(prompt).toMatch(/ne (garantit|prouve) PAS/);
+    });
+
+    it('presets without expect_files render with no gate (strict-mode safe)', () => {
+      const prompt = buildPreset('relais-2').output.prompt;
+      expect(prompt).toContain('Séquencement');
+      expect(prompt).not.toContain('Gate sur artefacts');
+      expect(prompt).not.toContain('sleep');
+    });
+  });
+
   describe('Solo mode', () => {
     it('strips coordination from any preset', () => {
       const result = buildPreset('raid', { 'coordinator-rules': { solo_mode: true } });


### PR DESCRIPTION
Closes #38.

## Root cause

Two layers, both real.

**Producer (the actual trigger).** In `behaviors/discovery-specialist.yaml` the mission rules were ordered:

- rule 3 — "annonce ton scope via `announce_work`, travaille, **puis `propose_resolution`**"
- rule 4 — "**Écris ton résultat** dans `tmp/decouverte/<angle>.yaml`"

An LLM following those rules in order resolves its thread *before* writing its artifact. The prompt literally licensed resolve-then-write. Measured on the assembled mission section of `mekova-dec-risques`: the write instruction sat at offset 915, `propose_resolution` at 841.

**Consumer (why it was unrecoverable).** `sequential-wait` gated purely on `list_threads(status: "resolved")` and read the artifacts once, with no retry. Thread status is a coordination-layer event with no happens-after relationship to the filesystem — and resolution does not even prove the agent produced anything, since a thread can reach `resolved` via the coordinator's periodic timeout sweeper (hazard noted in `orchestrator.ts:256`).

Net effect in the Mekova Phase 3a pilot: the synth woke on 4 resolved threads, 2 of the 4 YAML files were not yet on disk, and those angles were permanently lost to `ANGLE NON COUVERT`.

## Fix — both sides of the contract

- **`discovery-specialist`** — strict end-of-mission order: write the artifact → read it back to confirm it is on disk and non-empty → *only then* `propose_resolution` → `DONE:`.
- **`sequential-wait`** — new optional `expect_files` param (plus `retry_attempts`, default 3, and `retry_delay_seconds`, default 10). When supplied, the gate polls for the files with a bounded retry before treating an input as missing. **Empty = historical behavior**, so the 7 existing consumers (`relais-2/3`, `chaine-review/test`, `babel-reviewer`, `phare-synth`, `mekova-dec-synth`) are unaffected. Not `required`, so Handlebars strict mode and the catalog smoke test stay green.
- **`mekova-dec-synth`, `phare-synth`** — declare their expected artifacts. `phare-synth` had the identical latent bug (4 predecessor YAMLs, thread-status-only gate).
- **README** — documents the idiom: gate on the artifact, and write-then-resolve on the producing side.

## Tests

4 new tests in `tests/unit/bce-parity.test.ts`. The producer one is a genuine regression test, scoped to the mission section via `sectionTrace` (other behaviors mention `propose_resolution` earlier in the assembled prompt, which would make a whole-prompt `indexOf` meaningless) — verified to fail on the pre-fix catalogue.

`npm test` → 358 passed. The single failure (`writes hook scripts with 0o755 permissions`) is pre-existing and Windows-only: mode bits report 0 on this host. Confirmed failing on a clean tree; CI on Linux is unaffected. `npm run build` clean.