### PR TITLE
fix(pilote): backlog #29 #31 #33 #34 — auth métriques, marqueur DONE, allowlist solo, boucle MQTT

### DIFF
--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -4,8 +4,36 @@ import { existsSync } from "fs";
 import { spawn } from "child_process";
 import { scanProject } from "../src/orchestrator/scanner.js";
 import { listTemplates } from "../src/orchestrator/template-engine.js";
-import { buildSoloPrompt } from "../src/bridge.js";
+import { buildSolo } from "../src/bridge.js";
+import { buildAllowedTools } from "../src/orchestrator/agent-launcher.js";
+import type { AgentConfig } from "../src/orchestrator/types.js";
 import { collect, parseSetParams, parseSetFileParams, buildParamTypeMap } from "./params.js";
+
+/**
+ * Build the argv for `claude -p`.
+ *
+ * Headless mode cannot answer a permission prompt: without an explicit
+ * --allowedTools allowlist the agent's Write hits a prompt nobody can approve
+ * and the artifact is silently never written (#34 — `solo gardien` produced its
+ * audit in stdout but no AUDIT.md). `run` mode always passed an allowlist; solo
+ * did not.
+ *
+ * Passing `tools` (even empty) rather than `mcpTools` is deliberate: it keeps
+ * buildAllowedTools from falling back to the full coordinator tool list for a
+ * solo agent that has no coordinator at all.
+ */
+export function buildSoloArgs(
+  prompt: string,
+  mcpTools: string[],
+  mcpConfigPath: string | null,
+): string[] {
+  const args = ["-p", prompt];
+  if (mcpConfigPath) {
+    args.push("--mcp-config", mcpConfigPath);
+  }
+  args.push("--allowedTools", buildAllowedTools({ tools: mcpTools } as AgentConfig));
+  return args;
+}
 
 export function createSoloCommand(): Command {
   return new Command("solo")
@@ -64,20 +92,21 @@ export function createSoloCommand(): Command {
         for (const [behavior, values] of Object.entries(setFileParams)) {
           setParams[behavior] = { ...setParams[behavior], ...values };
         }
-        const prompt = buildSoloPrompt(template, context, setParams, projectPath);
+        const { prompt, mcpTools } = buildSolo(template, context, setParams, projectPath);
+
+        const mcpConfigPath = resolve(projectPath, ".mcp.json");
+        const args = buildSoloArgs(
+          prompt,
+          mcpTools,
+          existsSync(mcpConfigPath) ? mcpConfigPath : null,
+        );
 
         console.log(`\nSolo mode: ${template}`);
         console.log(`  Project:  ${projectPath}`);
         console.log(`  Timeout:  ${opts.timeout} minutes`);
         console.log(`  Prompt:   ${prompt.length} chars`);
+        console.log(`  Tools:    ${args[args.indexOf("--allowedTools") + 1]}`);
         console.log(`\nLaunching Claude Code...\n`);
-
-        // Build claude args
-        const args = ["-p", prompt];
-        const mcpConfigPath = resolve(projectPath, ".mcp.json");
-        if (existsSync(mcpConfigPath)) {
-          args.push("--mcp-config", mcpConfigPath);
-        }
 
         const child = spawn("claude", args, {
           stdio: "inherit",

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -115,9 +115,36 @@ export interface AgentLoopLogger {
 }
 
 const DEFAULT_MAX_TURNS = 50;
-const DONE_MARKER = "DONE:";
 const RESPONSE_WAIT_MS = 30_000;
 const APPROVAL_WAIT_MS = 20_000;
+
+// The DONE marker is how an agent tells the loop it has finished. Detection has
+// to tolerate how an LLM actually types it, not how the prompt spells it:
+// essaim's prompts are all in French, and French typography puts a space before
+// a colon ("DONE : résumé", often a non-breaking one). Models also emphasise the
+// marker in markdown. A literal `includes("DONE:")` misses every one of those —
+// the agent has delivered, nobody hears it say so, and the loop spins to its
+// maxTurns cap before exiting non-zero (#31).
+const DONE_PATTERN = /\bDONE\b[ \t  ]*[*_`]*[ \t  ]*:/i;
+
+export function hasDoneMarker(content: string): boolean {
+  return DONE_PATTERN.test(content);
+}
+
+/**
+ * Text after the marker. The LAST marker wins: an agent routinely echoes its
+ * instruction ("je terminerai par DONE: <résumé>") before doing the work, and
+ * the first match would capture the echo instead of the real summary.
+ */
+export function extractDoneSummary(content: string, fallback: string): string {
+  const scan = new RegExp(DONE_PATTERN.source, "gi");
+  let last: RegExpExecArray | null = null;
+  for (let m = scan.exec(content); m !== null; m = scan.exec(content)) {
+    last = m;
+  }
+  if (!last) return fallback;
+  return content.slice(last.index + last[0].length).replace(/^[*_`\s]+/, "").trim() || fallback;
+}
 
 // Interrupt types that are handled silently (state update only, no LLM call)
 const SILENT_INTERRUPT_TYPES: Set<InterruptType> = new Set([
@@ -763,8 +790,8 @@ export async function runAgentLoop(
                 }
               }
 
-              if (resp.content.includes(DONE_MARKER)) {
-                summary = resp.content.split(DONE_MARKER)[1]?.trim() || "Phase complete";
+              if (hasDoneMarker(resp.content)) {
+                summary = extractDoneSummary(resp.content, "Phase complete");
               }
             } else if (phase.name === "review") {
               // Fetch existing threads for comparison
@@ -812,8 +839,8 @@ export async function runAgentLoop(
               const otherBlocked = disallowedForMode(phase.toolsMode);
               logger.info(`Phase ${phase.name}: effort=${otherProfile.level} (model=${otherProfile.model}, thinking=${otherProfile.thinking}, maxTurns=${otherProfile.maxTurns}, tools=${otherTools?.length ?? "all"}, blocked=${otherBlocked.length})`);
               const resp = await send(phase.prompt, { model: otherProfile.model, thinking: otherProfile.thinking, maxTurns: otherProfile.maxTurns, allowedTools: otherTools, disallowedTools: otherBlocked });
-              if (resp.content.includes(DONE_MARKER)) {
-                summary = resp.content.split(DONE_MARKER)[1]?.trim() || "Phase complete";
+              if (hasDoneMarker(resp.content)) {
+                summary = extractDoneSummary(resp.content, "Phase complete");
               }
             }
           } else {
@@ -948,8 +975,8 @@ export async function runAgentLoop(
                 // Re-execute the same task (it was claimed but not completed)
                 const retryResp = await send(taskPrompt, { model: execProfile.model, thinking: execProfile.thinking, maxTurns: execProfile.maxTurns, allowedTools: execTools, disallowedTools: execBlocked, freshSession: freshExec });
                 if (!retryResp.rateLimited) {
-                  if (retryResp.content.includes(DONE_MARKER)) {
-                    const taskSummary = retryResp.content.split(DONE_MARKER)[1]?.trim() || "Done";
+                  if (hasDoneMarker(retryResp.content)) {
+                    const taskSummary = extractDoneSummary(retryResp.content, "Done");
                     logger.info(`Work-stealing: completed after retry — "${taskSummary.slice(0, 80)}"`);
                     await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
                     tasksDone++;
@@ -970,8 +997,8 @@ export async function runAgentLoop(
               // "summary" and marked complete anyway — which resolved threads
               // with partial/unrelated content (e.g. "Je vais explorer..."),
               // blocking the real work from ever happening.
-              if (resp.content.includes(DONE_MARKER)) {
-                const taskSummary = resp.content.split(DONE_MARKER)[1]?.trim() || "Done";
+              if (hasDoneMarker(resp.content)) {
+                const taskSummary = extractDoneSummary(resp.content, "Done");
                 logger.info(`Work-stealing: completed — "${taskSummary.slice(0, 80)}"`);
                 await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
                 tasksDone++;
@@ -1010,8 +1037,8 @@ export async function runAgentLoop(
         // ③ WORK LOOP — send initial prompt, then iterate
         logger.info(`Phase 3: work loop (protocol.phase=${protocol.phase})`);
         const initialResp = await send(config.prompt);
-        if (initialResp.content.includes(DONE_MARKER)) {
-          summary = initialResp.content.split(DONE_MARKER)[1]?.trim() || "Complete";
+        if (hasDoneMarker(initialResp.content)) {
+          summary = extractDoneSummary(initialResp.content, "Complete");
           exitReason = "done";
         } else {
           // Iterate: drain MQTT, ask for next action
@@ -1032,8 +1059,8 @@ export async function runAgentLoop(
 
             const resp = await send("Continue. Prochaine action?");
 
-            if (resp.content.includes(DONE_MARKER)) {
-              summary = resp.content.split(DONE_MARKER)[1]?.trim() || "Complete";
+            if (hasDoneMarker(resp.content)) {
+              summary = extractDoneSummary(resp.content, "Complete");
               exitReason = "done";
               break;
             }

--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -171,11 +171,32 @@ function buildInterrupt(
   return interrupt;
 }
 
+// mqtt.js defaults to reconnectPeriod=1000 and retries FOREVER. When the WS
+// upgrade through the ingress fails, that turns into a "disconnected" log every
+// second for the whole run (#33). Push notifications are a nice-to-have — the
+// loop already degrades gracefully without them — so back off and then give up
+// rather than spin. Giving up is announced once, loudly.
+const RECONNECT_PERIOD_MS = 5_000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+
 export function createMqttListener(options: MqttListenerOptions): MqttListener {
   const { url, agentId } = options;
   let client: mqtt.MqttClient | null = null;
   let isConnected = false;
+  let reconnectAttempts = 0;
+  let gaveUp = false;
   const queue: MqttInterrupt[] = [];
+
+  /** Tear the client down for good — stops mqtt.js's endless auto-reconnect. */
+  function giveUp(reason: string): void {
+    if (gaveUp) return;
+    gaveUp = true;
+    isConnected = false;
+    log.warn(`giving up on MQTT — running without push notifications (${reason})`, { url });
+    try {
+      client?.end(true);
+    } catch { /* already gone */ }
+  }
 
   function handleMessage(topic: string, message: Buffer): void {
     let payload: Record<string, unknown>;
@@ -204,6 +225,9 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
     connect(): Promise<void> {
       return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
+          // Same teardown as on error: a client left alive here would retry
+          // forever behind a caller that has already degraded (#33).
+          giveUp("connection timeout");
           reject(new Error("MQTT connection timeout"));
         }, 5000);
 
@@ -214,7 +238,12 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         // too. The deployed coordinator's aedes authenticate hook reads the
         // JWT from the password field (username is ignored there).
         const token = coordinatorToken();
-        const mqttOpts: mqtt.IClientOptions = { clientId, clean: true };
+        const mqttOpts: mqtt.IClientOptions = {
+          clientId,
+          clean: true,
+          reconnectPeriod: RECONNECT_PERIOD_MS,
+          connectTimeout: 5000,
+        };
         if (token) {
           mqttOpts.username = "agent";
           mqttOpts.password = token;
@@ -231,6 +260,7 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         client.on("connect", () => {
           clearTimeout(timeout);
           isConnected = true;
+          reconnectAttempts = 0; // a successful connect earns a fresh budget
           client!.subscribe(TOPICS, (err) => {
             if (err) {
               reject(err);
@@ -246,16 +276,23 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         client.on("error", (err) => {
           clearTimeout(timeout);
           log.warn("connection failed", { error: (err as Error).message });
+          // Without this teardown the client keeps auto-reconnecting in the
+          // background for the entire run, even though the caller has already
+          // been told the connection failed and moved on (#33).
+          giveUp((err as Error).message);
           reject(err);
         });
 
         client.on("close", () => {
           isConnected = false;
-          log.info("disconnected");
+          log.debug("disconnected");
         });
 
         client.on("reconnect", () => {
           isConnected = false;
+          if (++reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+            giveUp(`${MAX_RECONNECT_ATTEMPTS} reconnect attempts failed`);
+          }
         });
       });
     },

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -176,12 +176,19 @@ export function listBceTemplates(projectPath?: string): { id: string; name: stri
   }));
 }
 
-export function buildSoloPrompt(
+/**
+ * Assemble a solo agent: the prompt AND the tools it is allowed to use.
+ *
+ * `claude -p` (headless) cannot answer a permission prompt, so the caller must
+ * forward `mcpTools` to an explicit --allowedTools allowlist — otherwise the
+ * agent's writes silently never land (#34).
+ */
+export function buildSolo(
   templateId: string,
   context: { language: string; test_command: string; modules: string[] },
   setParams?: Record<string, Record<string, unknown>>,
   projectPath?: string,
-): string {
+): { prompt: string; mcpTools: string[] } {
   const templates = loadTemplates(projectPath);
   const def = templates[templateId];
   if (!def) {
@@ -211,6 +218,16 @@ export function buildSoloPrompt(
     params: {} as Record<string, Record<string, unknown>>,
   };
   const result = runPipeline(agent, getCatalogRoot(), launchParams);
-  return result.output.prompt;
+  return { prompt: result.output.prompt, mcpTools: result.output.mcpTools };
+}
+
+/** @deprecated Prefer buildSolo() — this drops the tool allowlist (see #34). */
+export function buildSoloPrompt(
+  templateId: string,
+  context: { language: string; test_command: string; modules: string[] },
+  setParams?: Record<string, Record<string, unknown>>,
+  projectPath?: string,
+): string {
+  return buildSolo(templateId, context, setParams, projectPath).prompt;
 }
 

--- a/src/orchestrator/metrics.ts
+++ b/src/orchestrator/metrics.ts
@@ -1,5 +1,5 @@
-import { execSync } from "child_process";
 import type { CoordinatorMetrics } from "./types.js";
+import { authHeaders } from "../coordinator-auth.js";
 
 export interface SseEvent {
   id: number;
@@ -64,29 +64,60 @@ export function computeMetrics(events: SseEvent[]): CoordinatorMetrics {
   };
 }
 
+/**
+ * Read the run's coordination metrics off the coordinator.
+ *
+ * These calls MUST carry the bearer token. This was the lone REST caller in
+ * essaim that shelled out to a bare `curl` with no Authorization header: against
+ * a secured coordinator (the k3s deployment) every request 401'd, the SSE replay
+ * came back empty, and the report cheerfully printed "Threads ouverts: 0" for a
+ * run full of real threads (#29). Metrics that silently read as zero are worse
+ * than metrics that fail loudly.
+ */
+async function getWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: abort.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function fetchCoordinatorMetrics(coordinatorUrl: string): Promise<CoordinatorMetrics> {
   let sseRaw = "";
   try {
-    sseRaw = execSync(`curl -s --max-time 3 -H "Last-Event-ID: 1" "${coordinatorUrl}/api/events"`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-  } catch (e: unknown) {
-    // curl exits with code 28 on timeout but stdout still contains the data
-    const err = e as { stdout?: string };
-    if (err.stdout) sseRaw = err.stdout;
+    const resp = await getWithTimeout(
+      `${coordinatorUrl}/api/events`,
+      { headers: { "Last-Event-ID": "1", ...authHeaders() } },
+      3000,
+    );
+    if (resp.ok) {
+      sseRaw = await resp.text();
+    } else {
+      console.warn(`[metrics] /api/events → ${resp.status} — counters will read 0`);
+    }
+  } catch {
+    // Coordinator unreachable (or the SSE stream never closes and we abort):
+    // degrade to empty metrics rather than failing the run.
   }
 
-  const events = parseSseEvents(sseRaw);
-  const metrics = computeMetrics(events);
+  const metrics = computeMetrics(parseSseEvents(sseRaw));
 
   try {
-    const hotFilesResp = execSync(
-      `curl -s --max-time 2 -X POST "${coordinatorUrl}/api/hot-files" -H "Content-Type: application/json" -d '{}'`,
-      { encoding: "utf-8" }
+    const resp = await getWithTimeout(
+      `${coordinatorUrl}/api/hot-files`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders() },
+        body: "{}",
+      },
+      2000,
     );
-    const hotFiles = JSON.parse(hotFilesResp);
-    metrics.hot_files = hotFiles.map((f: { file_path: string }) => f.file_path);
+    if (resp.ok) {
+      const hotFiles = (await resp.json()) as { file_path: string }[];
+      metrics.hot_files = hotFiles.map((f) => f.file_path);
+    }
   } catch {}
 
   return metrics;

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -3,13 +3,46 @@ import fs from "fs";
 import path from "path";
 import type { RunResult, AgentResult, WorkspaceResult } from "./types.js";
 
+/**
+ * Changed lines (+/-) in a unified diff, ignoring headers and context.
+ *
+ * `"".split("\n")` is `[""]`, i.e. length 1 — which is why an empty diff used to
+ * report "1 line changed" for every single agent (#29).
+ */
+export function countDiffLines(diff: string): number {
+  if (!diff.trim()) return 0;
+  let changed = 0;
+  for (const line of diff.split("\n")) {
+    const added = line.startsWith("+") && !line.startsWith("+++");
+    const removed = line.startsWith("-") && !line.startsWith("---");
+    if (added || removed) changed++;
+  }
+  return changed;
+}
+
+/**
+ * Under a subscription (OAuth) the SDK reports no per-call price. Zero cost
+ * alongside real token usage means "unknown", not "free" — printing $0.0000
+ * there is a lie the report tells about itself (#29).
+ */
+export function formatCost(costUsd: number | undefined, hasTokens: boolean): string {
+  if (hasTokens && (costUsd ?? 0) === 0) return "N/A";
+  return `$${(costUsd ?? 0).toFixed(4)}`;
+}
+
 export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
   const results: AgentResult[] = [];
 
   for (const [agentId, wsPath] of workspace.paths) {
-    const diff = workspace.type === "worktree"
-      ? safeExec("git diff HEAD", wsPath)
-      : "";
+    // Agents commit their work, so `git diff HEAD` (uncommitted only) is empty by
+    // construction. Diff against the commit the worktree branched off instead —
+    // that covers committed AND uncommitted changes (#29).
+    const diffMeasured = workspace.type === "worktree";
+    const diff = !diffMeasured
+      ? ""
+      : workspace.baseSha
+        ? safeExec(`git diff ${workspace.baseSha}`, wsPath)
+        : safeExec("git diff HEAD", wsPath);
 
     const compilationOk = workspace.type !== "none"
       ? !safeExec("npx tsc --noEmit 2>&1", wsPath).includes("error")
@@ -20,6 +53,7 @@ export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
       agent_name: agentId,
       exit_code: 0,
       diff,
+      diff_measured: diffMeasured,
       compilation_ok: compilationOk,
       stdout_length: 0,
     });
@@ -67,8 +101,8 @@ export function writeReport(results: RunResult[], outputDir: string): string {
     md += `\n### Agents\n\n`;
     md += `| Agent | Exit | Compilation | Diff (lignes) |\n|-------|------|-------------|---------------|\n`;
     for (const a of r.agent_results) {
-      const diffLines = a.diff.split("\n").length;
-      md += `| ${a.agent_name} | ${a.exit_code} | ${a.compilation_ok === undefined ? "N/A" : a.compilation_ok ? "OK" : "FAIL"} | ${diffLines} |\n`;
+      const diffCell = a.diff_measured === false ? "N/A" : countDiffLines(a.diff);
+      md += `| ${a.agent_name} | ${a.exit_code} | ${a.compilation_ok === undefined ? "N/A" : a.compilation_ok ? "OK" : "FAIL"} | ${diffCell} |\n`;
     }
 
     // Token + cost breakdown (populated from agent-loop runs)
@@ -82,7 +116,7 @@ export function writeReport(results: RunResult[], outputDir: string): string {
         const t = a.tokens!;
         const totalIn = t.input + t.cacheRead + t.cacheCreation;
         const hit = totalIn > 0 ? Math.round((t.cacheRead / totalIn) * 100) : 0;
-        md += `| ${a.agent_name} | ${a.turns_count ?? "-"} | $${(a.total_cost_usd ?? 0).toFixed(4)} | ${fmtTokens(t.input)} | ${fmtTokens(t.output)} | ${fmtTokens(t.cacheRead)} | ${fmtTokens(t.cacheCreation)} | ${hit}% |\n`;
+        md += `| ${a.agent_name} | ${a.turns_count ?? "-"} | ${formatCost(a.total_cost_usd, totalIn + t.output > 0)} | ${fmtTokens(t.input)} | ${fmtTokens(t.output)} | ${fmtTokens(t.cacheRead)} | ${fmtTokens(t.cacheCreation)} | ${hit}% |\n`;
         sumCost += a.total_cost_usd ?? 0;
         sumIn += t.input;
         sumOut += t.output;
@@ -91,7 +125,12 @@ export function writeReport(results: RunResult[], outputDir: string): string {
       }
       const totalInAll = sumIn + sumCacheR + sumCacheW;
       const totalHit = totalInAll > 0 ? Math.round((sumCacheR / totalInAll) * 100) : 0;
-      md += `| **Total** | - | **$${sumCost.toFixed(4)}** | ${fmtTokens(sumIn)} | ${fmtTokens(sumOut)} | ${fmtTokens(sumCacheR)} | ${fmtTokens(sumCacheW)} | **${totalHit}%** |\n`;
+      const anyTokens = totalInAll + sumOut > 0;
+      md += `| **Total** | - | **${formatCost(sumCost, anyTokens)}** | ${fmtTokens(sumIn)} | ${fmtTokens(sumOut)} | ${fmtTokens(sumCacheR)} | ${fmtTokens(sumCacheW)} | **${totalHit}%** |\n`;
+
+      if (anyTokens && sumCost === 0) {
+        md += `\n> Coût **N/A** : sous abonnement (OAuth), l'API ne renvoie aucun prix par appel.\n> Les compteurs de tokens ci-dessus restent, eux, fiables.\n`;
+      }
 
       // Per-phase breakdown across all agents
       const phaseTotals: Record<string, number> = {};
@@ -104,7 +143,9 @@ export function writeReport(results: RunResult[], outputDir: string): string {
           modelTotals[m] = (modelTotals[m] || 0) + c;
         }
       }
-      if (Object.keys(phaseTotals).length > 0) {
+      // Skip the cost breakdowns entirely when no price is available (OAuth):
+      // a table of $0.0000 / 0.0% says nothing and reads as "these phases were free".
+      if (sumCost > 0 && Object.keys(phaseTotals).length > 0) {
         md += `\n**Coût par phase** (agents agrégés):\n\n`;
         md += `| Phase | Cost | % |\n|-------|------|---|\n`;
         const sortedPhases = Object.entries(phaseTotals).sort(([, a], [, b]) => b - a);
@@ -113,7 +154,7 @@ export function writeReport(results: RunResult[], outputDir: string): string {
           md += `| ${phase} | $${cost.toFixed(4)} | ${pct}% |\n`;
         }
       }
-      if (Object.keys(modelTotals).length > 0) {
+      if (sumCost > 0 && Object.keys(modelTotals).length > 0) {
         md += `\n**Coût par modèle** (agents agrégés):\n\n`;
         md += `| Modèle | Cost | % |\n|--------|------|---|\n`;
         const sortedModels = Object.entries(modelTotals).sort(([, a], [, b]) => b - a);

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -61,6 +61,7 @@ export interface WorkspaceResult {
   type: "worktree" | "shared" | "none";
   basePath: string;
   paths: Map<string, string>; // agent_id → workspace path
+  baseSha?: string; // commit the worktrees branch off — diff baseline (#29)
 }
 
 export interface CoordinatorMetrics {
@@ -93,6 +94,9 @@ export interface AgentResult {
   agent_name: string;
   exit_code: number;
   diff: string;
+  // False when the workspace is shared: every agent edits the same tree, so a
+  // per-agent diff is not attributable. Reported as N/A rather than a fake 0/1.
+  diff_measured?: boolean;
   compilation_ok?: boolean;
   stdout_length: number;
   // Token + cost diagnostics (populated from AgentLoopResult when available)

--- a/src/orchestrator/workspace.ts
+++ b/src/orchestrator/workspace.ts
@@ -11,6 +11,15 @@ export function createWorkspaces(
   const basePath = workspace.base || process.cwd();
   const ref = workspace.baseRef || "HEAD";
 
+  // Pin the commit the worktrees branch off. The report needs it to measure what
+  // an agent actually produced: agents are told to COMMIT their work, so a plain
+  // `git diff HEAD` in the worktree shows nothing and every agent looked like it
+  // changed nothing (#29). Diffing against this base captures commits too.
+  let baseSha: string | undefined;
+  try {
+    baseSha = execSync(`git rev-parse ${ref}`, { cwd: basePath, encoding: "utf-8" }).trim();
+  } catch { /* not a git repo — diff stats degrade to unavailable */ }
+
   if (workspace.type === "worktree") {
     // Prune stale worktree references from previous runs
     try { execSync(`git worktree prune`, { cwd: basePath, stdio: "pipe" }); } catch {}
@@ -47,7 +56,7 @@ export function createWorkspaces(
     }
   }
 
-  return { type: workspace.type, basePath, paths };
+  return { type: workspace.type, basePath, paths, baseSha };
 }
 
 export function cleanupWorkspaces(workspace: WorkspaceResult): void {

--- a/tests/unit/done-marker.test.ts
+++ b/tests/unit/done-marker.test.ts
@@ -1,0 +1,64 @@
+// tests/unit/done-marker.test.ts
+import { describe, it, expect } from 'vitest';
+import { hasDoneMarker, extractDoneSummary } from '../../src/agent-loop/agent-loop.js';
+
+// Régression #31 — un worker avait livré son commit mais sa boucle a continué
+// jusqu'au plafond de 50 tours puis est sortie en exit 1. La détection de fin
+// était un `includes("DONE:")` littéral : or TOUS les prompts d'essaim sont en
+// français, et la typographie française met une espace avant le deux-points
+// (« DONE : résumé »). Ce marqueur-là n'était jamais reconnu — l'agent avait
+// fini, personne ne l'entendait le dire.
+describe('hasDoneMarker (#31)', () => {
+  it('reconnaît la forme canonique', () => {
+    expect(hasDoneMarker('DONE: 3 items')).toBe(true);
+  });
+
+  it('reconnaît la typographie française — espace avant le deux-points', () => {
+    expect(hasDoneMarker('DONE : 3 items')).toBe(true);
+  });
+
+  it('reconnaît les espaces insécables français (U+00A0, U+202F)', () => {
+    expect(hasDoneMarker('DONE : fini')).toBe(true);
+    expect(hasDoneMarker('DONE : fini')).toBe(true);
+  });
+
+  it('reconnaît le marqueur emphasé en markdown', () => {
+    expect(hasDoneMarker('**DONE:** commit livré')).toBe(true);
+    expect(hasDoneMarker('**DONE**: commit livré')).toBe(true);
+    expect(hasDoneMarker('`DONE`: commit livré')).toBe(true);
+  });
+
+  it('est insensible à la casse', () => {
+    expect(hasDoneMarker('Done: fini')).toBe(true);
+  });
+
+  it('ne se déclenche pas sans marqueur', () => {
+    expect(hasDoneMarker('Je continue le travail.')).toBe(false);
+    expect(hasDoneMarker('Cette tâche est done, je passe à la suite.')).toBe(false);
+    expect(hasDoneMarker('ABANDONNE: rien à faire')).toBe(false);
+  });
+});
+
+describe('extractDoneSummary (#31)', () => {
+  it('extrait le résumé après le marqueur', () => {
+    expect(extractDoneSummary('DONE: 3 items (risques)', 'fallback')).toBe('3 items (risques)');
+  });
+
+  it('extrait le résumé malgré la typographie française', () => {
+    expect(extractDoneSummary('DONE : 3 items', 'fallback')).toBe('3 items');
+  });
+
+  it('nettoie le markdown résiduel', () => {
+    expect(extractDoneSummary('**DONE:** commit livré', 'fallback')).toBe('commit livré');
+  });
+
+  it('prend le DERNIER marqueur — l\'agent cite souvent sa consigne avant de finir', () => {
+    const content = 'Je terminerai par DONE: <résumé> quand j\'aurai fini.\n\nDONE: commit abc123 livré';
+    expect(extractDoneSummary(content, 'fallback')).toBe('commit abc123 livré');
+  });
+
+  it('retombe sur le fallback si le résumé est vide ou absent', () => {
+    expect(extractDoneSummary('DONE:', 'fallback')).toBe('fallback');
+    expect(extractDoneSummary('rien ici', 'fallback')).toBe('fallback');
+  });
+});

--- a/tests/unit/mqtt-backoff.test.ts
+++ b/tests/unit/mqtt-backoff.test.ts
@@ -1,0 +1,68 @@
+// tests/unit/mqtt-backoff.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Fake mqtt client — just enough surface for the listener.
+class FakeClient extends EventEmitter {
+  ended = false;
+  subscribe = vi.fn((_topics: unknown, cb: (e?: Error) => void) => cb());
+  end = vi.fn((_force?: boolean) => { this.ended = true; });
+}
+
+const connectMock = vi.fn();
+vi.mock('mqtt', () => ({
+  default: { connect: (...args: unknown[]) => connectMock(...args) },
+  connect: (...args: unknown[]) => connectMock(...args),
+  MqttClient: class {},
+}));
+
+const { createMqttListener } = await import('../../src/agent-loop/mqtt-listener.js');
+
+let fake: FakeClient;
+beforeEach(() => {
+  fake = new FakeClient();
+  connectMock.mockReset();
+  connectMock.mockImplementation(() => fake);
+});
+
+// Régression #33 — contre un coordinateur distant (wss derrière un ingress), le
+// listener logguait « disconnected » en boucle serrée pendant TOUT le run.
+// mqtt.js reconnecte par défaut toutes les 1 s, indéfiniment ; et surtout, quand
+// connect() échouait, le client n'était jamais fermé : l'appelant dégradait
+// proprement pendant que le client, lui, continuait à retenter dans son dos.
+describe('mqtt-listener — backoff et abandon (#33)', () => {
+  it('ne reconnecte pas toutes les secondes (défaut mqtt.js)', () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    listener.connect().catch(() => {});
+    const opts = connectMock.mock.calls[0][1] as { reconnectPeriod: number };
+    expect(opts.reconnectPeriod).toBeGreaterThanOrEqual(5000);
+  });
+
+  it('ferme le client quand la connexion échoue — sinon il retente dans le dos de l\'appelant', async () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    const promise = listener.connect();
+    fake.emit('error', new Error('WS upgrade refusé'));
+    await expect(promise).rejects.toThrow('WS upgrade refusé');
+    expect(fake.end).toHaveBeenCalled();
+    expect(listener.connected).toBe(false);
+  });
+
+  it('abandonne après un nombre borné de tentatives au lieu de spammer tout le run', async () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    listener.connect().catch(() => {});
+    for (let i = 0; i < 10; i++) fake.emit('reconnect');
+    expect(fake.end).toHaveBeenCalled();
+  });
+
+  it('une connexion réussie remet le budget de reconnexions à zéro', async () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    const promise = listener.connect();
+    fake.emit('connect');
+    await promise;
+    expect(listener.connected).toBe(true);
+
+    // Quelques coupures réseau passagères ne doivent pas condamner le listener.
+    for (let i = 0; i < 3; i++) fake.emit('reconnect');
+    expect(fake.end).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/report-counters.test.ts
+++ b/tests/unit/report-counters.test.ts
@@ -1,0 +1,86 @@
+// tests/unit/report-counters.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { countDiffLines, formatCost } from '../../src/orchestrator/reporter.js';
+import { fetchCoordinatorMetrics } from '../../src/orchestrator/metrics.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.COORDINATOR_TOKEN;
+});
+
+// Régression #29 — un run avec de vrais threads rapportait « Threads ouverts: 0 »,
+// « Diff (lignes): 1 » pour CHAQUE agent, et « $0.0000 ».
+
+describe('countDiffLines (#29)', () => {
+  it('un diff vide vaut 0 ligne, pas 1', () => {
+    // "".split("\n") === [""] → .length === 1 : le « 1 ligne » de tous les
+    // agents n'était pas une mesure, c'était une chaîne vide mal comptée.
+    expect(countDiffLines('')).toBe(0);
+    expect(countDiffLines('\n')).toBe(0);
+  });
+
+  it('compte les lignes ajoutées et retirées, pas les en-têtes ni le contexte', () => {
+    const diff = [
+      'diff --git a/src/a.ts b/src/a.ts',
+      'index 111..222 100644',
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -1,3 +1,4 @@',
+      ' contexte inchangé',
+      '+ligne ajoutée',
+      '+autre ligne ajoutée',
+      '-ligne retirée',
+    ].join('\n');
+    expect(countDiffLines(diff)).toBe(3);
+  });
+});
+
+describe('formatCost (#29)', () => {
+  it('affiche N/A quand des tokens ont été consommés mais que le coût est 0 (OAuth)', () => {
+    // Sous abonnement (OAuth), le SDK ne renvoie aucun prix : 0 avec de vrais
+    // tokens signifie « inconnu », pas « gratuit ».
+    expect(formatCost(0, true)).toBe('N/A');
+    expect(formatCost(undefined, true)).toBe('N/A');
+  });
+
+  it('affiche le vrai coût quand il est connu', () => {
+    expect(formatCost(1.2345, true)).toBe('$1.2345');
+  });
+
+  it('affiche $0.0000 quand il n\'y a réellement eu aucun token', () => {
+    expect(formatCost(0, false)).toBe('$0.0000');
+  });
+});
+
+describe('fetchCoordinatorMetrics — authentification (#29)', () => {
+  it('envoie le Bearer token : sans lui, le coordinateur sécurisé répond 401 et tout compteur tombe à 0', () => {
+    process.env.COORDINATOR_TOKEN = 'jeton-test';
+    const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    return fetchCoordinatorMetrics('https://coordinator.test').then(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      const headers = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer jeton-test');
+    });
+  });
+
+  it('compte les threads réellement présents dans le flux SSE', async () => {
+    const sse = [
+      'id: 1\nevent: thread_opened\ndata: {"thread_id":"t1"}',
+      'id: 2\nevent: thread_opened\ndata: {"thread_id":"t2"}',
+      'id: 3\nevent: message_posted\ndata: {"thread_id":"t1"}',
+    ].join('\n\n');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse, { status: 200 })));
+
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+    expect(metrics.threads_opened).toBe(2);
+    expect(metrics.messages_exchanged).toBe(1);
+  });
+
+  it('dégrade proprement si le coordinateur est injoignable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+    expect(metrics.threads_opened).toBe(0);
+  });
+});

--- a/tests/unit/solo.test.ts
+++ b/tests/unit/solo.test.ts
@@ -1,0 +1,64 @@
+// tests/unit/solo.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildSoloArgs } from '../../cli/solo.js';
+import { buildSolo } from '../../src/bridge.js';
+
+const CONTEXT = { language: 'typescript', test_command: 'npm test', modules: ['core'] };
+
+// Régression #34 — `essaim solo gardien` produisait son audit dans stdout mais
+// n'écrivait jamais AUDIT.md : `claude -p` était lancé SANS --allowedTools, donc
+// le Write butait sur un prompt de permission que le mode headless ne peut pas
+// approuver. Le mode `run` passait bien un allowlist ; solo, non.
+describe('solo — allowlist d\'outils en headless (#34)', () => {
+  it('passe --allowedTools à claude -p', () => {
+    const args = buildSoloArgs('prompt', [], null);
+    expect(args).toContain('--allowedTools');
+  });
+
+  it('autorise explicitement Write — sans quoi l\'artefact est perdu en headless', () => {
+    const args = buildSoloArgs('prompt', [], null);
+    const allowed = args[args.indexOf('--allowedTools') + 1];
+    for (const tool of ['Write', 'Edit', 'Read', 'Bash', 'Glob', 'Grep']) {
+      expect(allowed.split(',')).toContain(tool);
+    }
+  });
+
+  it('préfixe les outils MCP assemblés par le pipeline', () => {
+    const args = buildSoloArgs('prompt', ['list_threads'], null);
+    const allowed = args[args.indexOf('--allowedTools') + 1];
+    expect(allowed.split(',')).toContain('mcp__coordinator__list_threads');
+  });
+
+  it('sans coordinator, n\'invente pas d\'outils MCP', () => {
+    const args = buildSoloArgs('prompt', [], null);
+    const allowed = args[args.indexOf('--allowedTools') + 1];
+    expect(allowed).not.toContain('mcp__coordinator__');
+  });
+
+  it('ne passe --mcp-config que si un .mcp.json existe', () => {
+    expect(buildSoloArgs('p', [], null)).not.toContain('--mcp-config');
+    const args = buildSoloArgs('p', [], '/tmp/.mcp.json');
+    expect(args[args.indexOf('--mcp-config') + 1]).toBe('/tmp/.mcp.json');
+  });
+
+  it('garde le prompt en premier argument de -p', () => {
+    const args = buildSoloArgs('mon-prompt', [], null);
+    expect(args[0]).toBe('-p');
+    expect(args[1]).toBe('mon-prompt');
+  });
+});
+
+describe('buildSolo — expose les outils, pas seulement le prompt (#34)', () => {
+  it('retourne le prompt ET les mcpTools assemblés', () => {
+    const solo = buildSolo('gardien', CONTEXT);
+    expect(solo.prompt.length).toBeGreaterThan(0);
+    expect(Array.isArray(solo.mcpTools)).toBe(true);
+  });
+
+  it('gardien (read-only-mode + audit-output) garde Write : il DOIT écrire son AUDIT.md', () => {
+    const solo = buildSolo('gardien', CONTEXT);
+    const args = buildSoloArgs(solo.prompt, solo.mcpTools, null);
+    const allowed = args[args.indexOf('--allowedTools') + 1];
+    expect(allowed.split(',')).toContain('Write');
+  });
+});


### PR DESCRIPTION
Quatre bugs du backlog pilote. Chacun a une cause racine établie, un test de régression, et un correctif ciblé.

Closes #29. Closes #31. Closes #34.
Adresse partiellement #33 (voir plus bas — l''issue reste ouverte).

---

## #29 — compteurs de rapport (threads=0, diff=1, $0.0000)

Trois symptômes, trois causes distinctes. Aucune n''était un bug de comptage.

**`Threads ouverts: 0`** — `metrics.ts` était le **seul appelant REST d''essaim sans `authHeaders()`** : un `curl` nu, sans en-tête `Authorization`, quand `orchestrator.ts`, `work-stealing.ts` et `agent-loop.ts` en passent tous un. Contre le coordinateur sécurisé (le déploiement k3s, exactement ce contre quoi le pilote tournait), `/api/events` répondait 401 → flux SSE vide → zéro événement → `threads_opened: 0` sur un run plein de threads réels. Remplacé par `fetch` + `authHeaders()`, ce qui supprime au passage la dépendance à `curl`. Un compteur qui lit 0 en silence est pire qu''un compteur qui échoue bruyamment : on loggue maintenant le statut HTTP.

**`Diff (lignes): 1` pour chaque agent** — deux défauts qui se cumulent. `git diff HEAD` ne montre que le **non-commité**, or les agents sont explicitement instruits de **commiter** leur travail : le diff était vide par construction. Et `"".split("\n")` vaut `[""]`, donc `.length === 1` — le « 1 » n''était pas une mesure, c''était une chaîne vide mal comptée. On épingle désormais le SHA de base du worktree à sa création et on diffe contre lui (commits **et** non-commité), on compte les vraies lignes `+`/`-`, et un workspace **partagé** affiche `N/A` — un diff par agent n''y est pas attribuable — au lieu d''un chiffre inventé.

**`$0.0000`** — sous abonnement (OAuth), l''API ne renvoie aucun prix par appel. Zéro coût avec de vrais tokens consommés signifie « inconnu », pas « gratuit ». Affiché `N/A`, avec une note ; les tableaux coût-par-phase/par-modèle sont masqués quand aucun prix n''est disponible plutôt que d''afficher des colonnes de `$0.0000 / 0.0 %`.

## #31 — worker bloqué jusqu''à maxTurns

La détection de fin était un `includes("DONE:")` **littéral**. Or tous les prompts d''essaim sont en français, et la typographie française met une espace avant le deux-points : **« DONE : résumé » n''était jamais reconnu**. L''agent avait livré son commit, personne ne l''entendait le dire, et la boucle continuait jusqu''au plafond de 50 tours avant de sortir en exit 1.

Détection centralisée et tolérante (espaces insécables `U+00A0`/`U+202F`, emphase markdown, casse) appliquée aux **6 sites** qui dupliquaient l''idiome. L''extraction du résumé prend désormais le **dernier** marqueur : un agent cite régulièrement sa consigne (« je terminerai par DONE: … ») avant de faire le travail, et le premier match capturait l''écho.

⚠️ Le log du worker Delta n''était pas disponible, donc je ne peux pas **prouver** que c''est ce qui l''a tué. C''est en revanche un défaut réel et démontrable de la détection, et le plus probable. Si le log refait surface et montre autre chose, rouvrir.

## #33 — boucle de reconnexion MQTT (partiel)

`mqtt.connect()` était appelé avec les défauts de mqtt.js : `reconnectPeriod: 1000` et reconnexion **infinie**. Surtout, quand `connect()` échouait, **le client n''était jamais fermé** : l''agent-loop dégradait proprement (« running without push notifications ») pendant que le client continuait à retenter toutes les secondes dans son dos — d''où le `disconnected` en boucle serrée pendant tout le run.

Backoff à 5 s, abandon borné (5 tentatives) avec teardown explicite, annoncé une fois. Une connexion réussie remet le budget à zéro, pour qu''une coupure passagère ne condamne pas le listener.

**Ceci ne corrige pas le handshake wss à travers l''ingress** — la cause du refus (Tailscale + Envoy, upgrade WS ou credentials) n''est pas diagnosticable sans accès au cluster. Ce PR supprime le symptôme (le spam) et la fuite de client, pas la cause. **L''issue reste ouverte.**

## #34 — `solo` n''écrivait jamais son fichier

`essaim solo` lançait `claude -p` **sans `--allowedTools`**. En headless, le `Write` bute sur un prompt de permission que personne ne peut approuver : le gardien produisait son audit complet dans stdout et `AUDIT.md` n''existait jamais. Le mode `run` passait bien un allowlist via `buildAllowedTools()` ; solo, non — `buildSoloPrompt()` jetait `result.output.mcpTools`.

`buildSolo()` expose désormais le prompt **et** les outils assemblés, et `buildSoloArgs()` (pure, testée) les passe à claude. Passer `tools` plutôt que `mcpTools` est délibéré : ça évite que `buildAllowedTools` retombe sur la liste complète des outils coordinateur pour un agent solo qui n''a pas de coordinateur.

---

## Tests

27 tests ajoutés dans 4 fichiers (`report-counters`, `done-marker`, `solo`, `mqtt-backoff`), chacun écrit avant son correctif. `npm test` → **389 verts**. Le seul échec (`writes hook scripts with 0o755 permissions`) est pré-existant et propre à Windows — les bits de permission valent 0 sur cet hôte — et échoue à l''identique sur un arbre propre ; la CI Linux n''est pas concernée. `npm run build` propre.