### PR TITLE
fix(work-stealing): un seul agent par fichier — dédup structurelle des findings (#30)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -923,8 +923,21 @@ export async function runAgentLoop(
                 logger.debug(`Effort: ${upgraded} (model=${execProfile.model}, maxTurns=${execProfile.maxTurns})`);
               }
 
-              // Execute one task
-              const taskPrompt = phase.prompt.replace(/\{\{params\.current_task\}\}/g, task.description);
+              // Execute one task. When work already landed on this file, say so:
+              // an agent is otherwise blind to its peers, which is how three
+              // hunters each committed a near-identical repro test for one bug
+              // (#30). The file-level claim exclusion stops the concurrent case;
+              // this covers the sequential one.
+              let taskPrompt = phase.prompt.replace(/\{\{params\.current_task\}\}/g, task.description);
+              if (task.relatedDone?.length) {
+                taskPrompt += `\n\n## Déjà livré sur ce fichier (par un autre agent, ce run)\n`
+                  + task.relatedDone.map((s) => `- ${s}`).join("\n")
+                  + `\n\nAvant d'écrire quoi que ce soit : lis ce qui existe déjà.\n`
+                  + `- Même cause racine que ta tâche ? Alors c'est un DOUBLON : ne commite RIEN, `
+                  + `résous ton thread en disant « DUP de <ce qui existe> » et passe à la suite.\n`
+                  + `- Cause réellement différente ? Alors ÉTENDS le test existant plutôt que d'en `
+                  + `créer un quasi identique à côté.`;
+              }
               const execTools = toolsForMode(phase.toolsMode, config.allowedTools);
               const execBlocked = disallowedForMode(phase.toolsMode);
               const freshExec = config.freshSessionPerTask === true;

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -10,6 +10,15 @@ export interface Task {
   file?: string;
   line?: number;
   severity?: string;
+  // Summaries of work ALREADY resolved on the same file this run. The executing
+  // agent is blind to its peers otherwise — this is what lets it recognise its
+  // finding as a duplicate instead of committing a near-identical repro (#30).
+  relatedDone?: string[];
+}
+
+function threadFiles(thread: Record<string, unknown>): string[] {
+  const files = thread.target_files;
+  return Array.isArray(files) ? (files as string[]).filter((f) => typeof f === "string" && f) : [];
 }
 
 const DISCOVERY_MARKER = "DISCOVERY:";
@@ -126,10 +135,43 @@ export async function claimNextTask(
   const unclaimed = open.filter((t) => !t.claimed_by);
   log.debug(`claimNextTask: ${threads.length} active, ${open.length} open, ${unclaimed.length} unclaimed`);
 
+  // One agent per file (#30). Three hunters that each posted their own discovery
+  // for a single bug produce three threads on the same file; claiming is atomic
+  // per THREAD, so each hunter took one and all three wrote a near-identical
+  // repro test. Excluding files another agent is actively working makes the
+  // de-duplication structural instead of asking the LLM to notice — which is
+  // also, exactly, what the coordinator exists to do.
+  const busyFiles = new Set<string>();
+  for (const t of open) {
+    const owner = t.claimed_by as string | null | undefined;
+    if (owner && owner !== agentId) {
+      for (const f of threadFiles(t)) busyFiles.add(f);
+    }
+  }
+
+  // What has already LANDED on each file this run, so the executing agent can
+  // recognise a duplicate rather than re-committing it.
+  const doneByFile = new Map<string, string[]>();
+  for (const t of threads) {
+    if (t.status === "open") continue;
+    const subject = (t.subject as string) || "";
+    if (!subject) continue;
+    for (const f of threadFiles(t)) {
+      doneByFile.set(f, [...(doneByFile.get(f) ?? []), subject]);
+    }
+  }
+
   // Try to claim each open, unclaimed thread
   for (const thread of threads) {
     if (thread.status !== "open") continue;
     if (thread.claimed_by) continue;
+
+    const files = threadFiles(thread);
+    const conflict = files.find((f) => busyFiles.has(f));
+    if (conflict) {
+      log.info(`skipping thread=${thread.id} — ${conflict} is already being worked by another agent`);
+      continue;
+    }
     // Directed-dispatch: a thread with assigned_to set is only claimable by
     // that named agent. Skipping here avoids hitting claim-task just to get
     // a polite 'success: false, assigned_to: otherAgent'. For workers in a
@@ -147,11 +189,16 @@ export async function claimNextTask(
       });
       if ((result as Record<string, unknown>).success === true) {
         log.info(`claimed thread=${threadId}: ${subject.slice(0, 80)}`);
+        const relatedDone = files.flatMap((f) => doneByFile.get(f) ?? []);
+        if (relatedDone.length > 0) {
+          log.info(`thread=${threadId}: ${relatedDone.length} résolution(s) déjà livrée(s) sur ${files.join(", ")} — contexte injecté`);
+        }
         return {
           id: threadId,
           description: subject,
-          file: undefined,
+          file: files[0],
           severity: undefined,
+          relatedDone: relatedDone.length > 0 ? relatedDone : undefined,
         };
       }
       log.info(`claim race lost thread=${threadId} to ${(result as Record<string, unknown>).claimed_by as string}: ${subject.slice(0, 60)}`);

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -1,0 +1,97 @@
+// tests/unit/claim-dedup.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { claimNextTask } from '../../src/agent-loop/work-stealing.js';
+
+// Régression #30 — mekova-bughunt, 3 hunters, UN seul bug bien localisé : les
+// trois ont écrit ET commité un test de repro quasi identique. Le claim était
+// déjà atomique PAR THREAD, mais chaque hunter avait posté sa propre découverte
+// → 3 threads pour un seul bug → un thread chacun, trois tests.
+//
+// La dédup ne peut pas reposer sur le jugement du LLM (la phase review n'a rien
+// marqué DUP). Le garde-fou est structurel : deux agents ne travaillent jamais le
+// MÊME FICHIER en même temps — ce qui est la raison d'être du coordinateur.
+
+type Thread = Record<string, unknown>;
+
+function mockCoordinator(threads: Thread[], claims: Record<string, boolean> = {}) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (url.endsWith('/api/threads-active')) {
+      return new Response(JSON.stringify(threads), { status: 200 });
+    }
+    if (url.endsWith('/api/claim-task')) {
+      const body = JSON.parse((init!.body as string)) as { thread_id: string };
+      const ok = claims[body.thread_id] !== false;
+      return new Response(JSON.stringify({ success: ok, claimed_by: ok ? null : 'autre-agent' }), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  });
+}
+
+beforeEach(() => vi.restoreAllMocks());
+afterEach(() => vi.unstubAllGlobals());
+
+describe('claimNextTask — un seul agent par fichier (#30)', () => {
+  it('ne claim pas une tâche dont le fichier est déjà travaillé par un autre agent', async () => {
+    const fetchMock = mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: 'hunter-1', target_files: ['src/report.ts'] },
+      { id: 't2', status: 'open', claimed_by: null, target_files: ['src/report.ts'] },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task).toBeNull();
+    const claimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/claim-task'));
+    expect(claimed).toHaveLength(0); // on n'a même pas tenté
+  });
+
+  it('claim normalement quand le fichier est libre', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: 'hunter-1', target_files: ['src/report.ts'] },
+      { id: 't2', status: 'open', claimed_by: null, target_files: ['src/csv.ts'] },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t2');
+    expect(task?.file).toBe('src/csv.ts'); // le fichier était jeté au claim, il remonte maintenant
+  });
+
+  it('un thread sans fichier cible reste claimable (pas d\'exclusion abusive)', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: 'hunter-1', target_files: ['src/report.ts'] },
+      { id: 't2', status: 'open', claimed_by: null, target_files: [] },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+    expect(task?.id).toBe('t2');
+  });
+
+  it('mes propres claims ne me bloquent pas moi-même', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't1', status: 'resolved', claimed_by: 'hunter-2', target_files: ['src/report.ts'] },
+      { id: 't2', status: 'open', claimed_by: null, target_files: ['src/report.ts'] },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+    expect(task?.id).toBe('t2');
+  });
+
+  it('remonte le travail DÉJÀ résolu sur le même fichier — de quoi marquer DUP au lieu de recommiter', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      {
+        id: 't1',
+        status: 'resolved',
+        claimed_by: 'hunter-1',
+        target_files: ['src/report.ts'],
+        subject: 'major: CSV export perd receipt_date (src/report.ts:42)',
+      },
+      { id: 't2', status: 'open', claimed_by: null, target_files: ['src/report.ts'] },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t2');
+    expect(task?.relatedDone?.join(' ')).toContain('receipt_date');
+  });
+});


### PR DESCRIPTION
Closes #30.

## Cause racine

Trois hunters, **un seul** bug bien localisé, et trois tests de repro quasi identiques commités.

Le claim était pourtant déjà **atomique par thread**. Le problème est en amont : chaque hunter poste ses **propres** découvertes via `/api/announce`, donc un seul bug trouvé par trois agents devient **trois threads**. Chacun en claim un — légitimement, de son point de vue — et écrit son test. La phase review devait déduplicquer, mais elle repose sur le jugement du LLM et n''a rien marqué `DUP` (elle ne pouvait pas : quand les trois agents postent en parallèle, aucun ne voit encore les threads des autres).

Autrement dit, la dédup était **sémantique** là où elle devait être **structurelle**.

## Le correctif

**Cas concurrent — un seul agent par fichier.** `claimNextTask` exclut désormais tout thread dont un fichier cible est déjà travaillé par un *autre* agent. Deux agents ne touchent plus jamais le même fichier en même temps — ce qui est, très exactement, ce que le coordinateur existe pour garantir. Aucun jugement demandé au modèle.

**Cas séquentiel — l''agent n''est plus aveugle à ses pairs.** Les threads déjà **résolus** sur le même fichier sont injectés dans le prompt d''exécution. L''agent lit ce qui a atterri avant lui, puis : même cause racine → il marque `DUP` et ne commite rien ; cause réellement différente → il **étend** le test existant au lieu d''en créer un jumeau à côté.

Au passage : le `file` du thread était **jeté** au moment du claim (`file: undefined`) — il remonte maintenant dans la `Task`, ce dont dépend toute l''exclusion.

## Ce que ça ne casse pas

- Un thread **sans fichier cible** reste claimable — pas d''exclusion abusive.
- Mes **propres** threads résolus ne me bloquent pas moi-même.
- La convergence de plusieurs hunters sur un même bug reste un **signal** (elle est visible dans les threads) ; on ne paie simplement plus trois commits pour l''obtenir.

Effet de bord assumé : deux bugs **réellement différents** dans un même fichier sont désormais traités l''un après l''autre plutôt qu''en parallèle. C''est le prix de l''exclusion — et c''est aussi ce qui évite deux agents en conflit d''édition sur le même fichier.

## Tests

5 tests (`claim-dedup.test.ts`) sur un coordinateur simulé. `npm test` → **394 verts**, build propre. Le seul échec (`0o755`) est pré-existant et propre à Windows.