### PR TITLE
chore(minors): mock_spec jeté, collision de rapport, shape agents, import mort

### DIFF
--- a/behaviors/proto-scaffold.yaml
+++ b/behaviors/proto-scaffold.yaml
@@ -15,9 +15,16 @@ sections:
       Tu poses la base du prototype cliquable. TU ES LE SEUL agent autorisé à
       exécuter `npm install` / créer package.json.
 
+      {{#if params.mock_spec}}
+      ### Entités à mocker (extraites de l'inventaire d'écrans)
+      {{params.mock_spec}}
+
+      Ce vocabulaire vient du client, pas d'une supposition : utilise-le tel quel.
+      {{/if}}
+
       1. `npm create vite@latest . -- --template preact-ts` (ou structure
          équivalente minimale : vite + preact + preact-iso pour le routing).
-      2. Crée `src/mock/data.ts` : les entités du brief (vocabulaire EXACT du
+      2. Crée `src/mock/data.ts` : les entités {{#if params.mock_spec}}ci-dessus{{else}}du brief{{/if}} (vocabulaire EXACT du
          client, valeurs réalistes de son métier — JAMAIS de lorem ipsum,
          minimum 3 instances cohérentes par entité).
       3. Crée `src/app.tsx` avec le routeur : une route par écran listée dans

--- a/cli/pipeline.ts
+++ b/cli/pipeline.ts
@@ -10,6 +10,7 @@ import {
   type StepOutcome,
 } from "../src/pipeline/runner.js";
 import { executeRun } from "./run-core.js";
+import { uniqueReportBase } from "../src/orchestrator/reporter.js";
 import { parseSetParams, parseSetFileParams, buildParamTypeMap } from "./params.js";
 
 export function createPipelineCommand(): Command {
@@ -115,8 +116,10 @@ function writePipelineReport(
 ): string {
   const outDir = join(pipelineDir, "reports");
   mkdirSync(outDir, { recursive: true });
-  const ts = Date.now();
-  const mdPath = join(outDir, `pipeline-${pipelineName}-${ts}.md`);
+  // Two steps finishing in the same millisecond used to overwrite each other's
+  // report — the timestamp alone is not a unique name.
+  const base = uniqueReportBase(outDir, `pipeline-${pipelineName}-${Date.now()}`, [".md"]);
+  const mdPath = join(outDir, `${base}.md`);
 
   const total = outcomes.reduce((a, o) => a + o.durationMs, 0);
   const okCount = outcomes.filter((o) => o.status === "ok").length;

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -23,7 +23,6 @@ import { fetchCoordinatorMetrics } from "./metrics.js";
 import { collectAgentResults } from "./reporter.js";
 import type { AgentConfig, MiniProject, AgentProcess, RunResult } from "./types.js";
 import { scanProject } from "./scanner.js";
-import { buildProject, listTemplates } from "./template-engine.js";
 
 import { getCatalogRoot, getScriptsDir } from "../../cli/bce-resolver.js";
 import { runPipeline } from "@swoofer/promptweave";

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -62,14 +62,29 @@ export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
   return results;
 }
 
+/**
+ * A report basename that is free for every extension it will be written under.
+ *
+ * `Date.now()` alone is not unique: two reports produced in the same millisecond
+ * (pipeline steps, notably) silently overwrote each other — the second run's
+ * report simply replaced the first, and nobody was told.
+ */
+export function uniqueReportBase(dir: string, prefix: string, extensions: string[]): string {
+  let base = prefix;
+  for (let n = 2; extensions.some((ext) => fs.existsSync(path.join(dir, base + ext))); n++) {
+    base = `${prefix}-${n}`;
+  }
+  return base;
+}
+
 export function writeReport(results: RunResult[], outputDir: string): string {
   fs.mkdirSync(outputDir, { recursive: true });
-  const ts = Date.now();
+  const base = uniqueReportBase(outputDir, `report-${Date.now()}`, [".json", ".md"]);
 
-  const jsonPath = path.join(outputDir, `report-${ts}.json`);
+  const jsonPath = path.join(outputDir, `${base}.json`);
   fs.writeFileSync(jsonPath, JSON.stringify(results, null, 2));
 
-  const mdPath = path.join(outputDir, `report-${ts}.md`);
+  const mdPath = path.join(outputDir, `${base}.md`);
   let md = `# Mini-projet Report\n\n*${new Date().toISOString()}*\n\n`;
 
   for (const r of results) {

--- a/src/template-loader.ts
+++ b/src/template-loader.ts
@@ -60,6 +60,33 @@ function loadDir(dir: string, out: Record<string, TemplateDefinition>): void {
     if (!Array.isArray(doc.agents) || doc.agents.length === 0) {
       throw new Error(`template ${f}: "agents" must be a non-empty array`);
     }
+    // Validate each agent HERE, where we still know the file and the index.
+    // Left unchecked, a template with a typo'd agent fails much later and much
+    // further away — a missing `preset` surfaces as an opaque registry lookup
+    // error, with nothing pointing back at the template that caused it.
+    doc.agents.forEach((agent: unknown, i: number) => {
+      const where = `template ${f}: agents[${i}]`;
+      if (typeof agent !== "object" || agent === null) {
+        throw new Error(`${where} must be an object`);
+      }
+      const a = agent as Record<string, unknown>;
+      for (const key of ["idPrefix", "namePrefix", "preset", "profile"]) {
+        if (typeof a[key] !== "string" || !a[key]) {
+          throw new Error(`${where}: missing or invalid "${key}" (expected a non-empty string)`);
+        }
+      }
+      if (a.profile !== "codeur" && a.profile !== "communicant") {
+        throw new Error(`${where}: "profile" must be "codeur" or "communicant", got "${String(a.profile)}"`);
+      }
+      if (
+        a.count !== undefined &&
+        typeof a.count !== "number" &&
+        a.count !== "dynamic" &&
+        a.count !== "per-module"
+      ) {
+        throw new Error(`${where}: "count" must be a number, "dynamic" or "per-module", got "${String(a.count)}"`);
+      }
+    });
     out[basename(f).replace(/\.ya?ml$/, "")] = doc as unknown as TemplateDefinition;
   }
 }

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/minors.test.ts — minors différés du pilote
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { uniqueReportBase } from '../../src/orchestrator/reporter.js';
+import { loadTemplates } from '../../src/template-loader.js';
+import { runPipeline } from '@swoofer/promptweave';
+import type { Agent } from '@swoofer/promptweave/types';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'essaim-minors-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('uniqueReportBase — collision de timestamp', () => {
+  it('rend le préfixe tel quel quand rien n\'existe', () => {
+    expect(uniqueReportBase(dir, 'report-123', ['.md'])).toBe('report-123');
+  });
+
+  it('ne réutilise pas un nom déjà pris — deux rapports dans la même milliseconde s\'écrasaient', () => {
+    writeFileSync(join(dir, 'report-123.md'), 'premier');
+    expect(uniqueReportBase(dir, 'report-123', ['.md'])).toBe('report-123-2');
+  });
+
+  it('exige que TOUTES les extensions soient libres (le rapport écrit .json ET .md)', () => {
+    writeFileSync(join(dir, 'report-123.json'), '{}');
+    // .md est libre, mais .json est pris : le couple doit basculer ensemble,
+    // sinon le .md d'un run cohabite avec le .json d'un autre.
+    expect(uniqueReportBase(dir, 'report-123', ['.json', '.md'])).toBe('report-123-2');
+  });
+});
+
+describe('template-loader — validation de la shape des agents', () => {
+  function writeTemplate(body: string): string {
+    const tdir = join(dir, '.essaim', 'templates');
+    mkdirSync(tdir, { recursive: true });
+    writeFileSync(join(tdir, 'bancal.yaml'), body);
+    return dir;
+  }
+
+  const HEADER = `name: Bancal
+description: template de test
+phase: 1
+workspace: shared
+stagger: { mode: fixed, delay: [0, 0] }
+timeout_minutes: 5
+metrics: []
+compare_mode: false
+agents:
+`;
+
+  it('accepte un agent bien formé', () => {
+    const p = writeTemplate(HEADER + `  - idPrefix: a
+    namePrefix: A
+    preset: raid
+    profile: codeur
+`);
+    expect(loadTemplates(p).bancal).toBeDefined();
+  });
+
+  it('rejette un agent sans preset, en nommant le template et l\'index', () => {
+    const p = writeTemplate(HEADER + `  - idPrefix: a
+    namePrefix: A
+    profile: codeur
+`);
+    expect(() => loadTemplates(p)).toThrow(/bancal\.yaml: agents\[0\].*preset/s);
+  });
+
+  it('rejette un profile hors des deux valeurs admises', () => {
+    const p = writeTemplate(HEADER + `  - idPrefix: a
+    namePrefix: A
+    preset: raid
+    profile: architecte
+`);
+    expect(() => loadTemplates(p)).toThrow(/profile.*codeur.*communicant/s);
+  });
+
+  it('rejette un count invalide', () => {
+    const p = writeTemplate(HEADER + `  - idPrefix: a
+    namePrefix: A
+    preset: raid
+    profile: codeur
+    count: beaucoup
+`);
+    expect(() => loadTemplates(p)).toThrow(/count/);
+  });
+});
+
+describe('proto-scaffold — mock_spec est réellement transmis à l\'agent', () => {
+  const BCE_DIR = resolve(import.meta.dirname, '../..');
+
+  it('le mock_spec extrait par le skill atterrit dans le prompt (il était déclaré puis jeté)', () => {
+    const agent: Agent = { name: 'test', preset: 'mekova-proto-scaffold', add: [], remove: [], params: {} };
+    const result = runPipeline(agent, BCE_DIR, {
+      'proto-scaffold': { mock_spec: 'Commande: id, client, pains[], heure_retrait' },
+    });
+    expect(result.output.prompt).toContain('heure_retrait');
+  });
+});


### PR DESCRIPTION
Les minors différés du pilote. Deux d''entre eux se sont révélés **plus que cosmétiques** en les regardant de près.

## `mock_spec` était silencieusement jeté (perte de données)

`behaviors/proto-scaffold.yaml` **déclarait** le param `mock_spec`… et ne le rendait **jamais** dans son prompt. Or `/post-rencontre` (Phase 3) extrait délibérément ce mock-spec de `ecrans.md` — entités, champs, vocabulaire client — et le passe via `--set`. Tout ça partait à la poubelle, et l''agent scaffolder retombait sur ce que disait le brief.

Ce n''était donc pas un « param déclaré non référencé » à nettoyer : c''était une donnée que le pipeline prenait la peine d''extraire et qui n''arrivait jamais à destination. Rendue conditionnellement (le bloc n''apparaît que si le param est fourni, donc rien ne change pour les runs sans mock-spec).

## Collision de nom de rapport (écrasement silencieux)

`Date.now()` n''est pas un nom unique. Deux rapports produits dans la même milliseconde — ce qui arrive entre étapes de pipeline — **s''écrasaient l''un l''autre**, et personne n''était prévenu. `uniqueReportBase()` est désormais partagé par le reporter et le pipeline. Le couple `.json`/`.md` bascule **ensemble** : sinon on se retrouve avec le `.md` d''un run à côté du `.json` d''un autre.

## Validation de la shape des agents (message d''erreur utilisable)

Le loader vérifiait les champs de haut niveau et que `agents` était un tableau non vide, mais pas la forme de chaque agent. Un `preset` manquant ou un `profile` mal orthographié partait sans bruit et ressortait bien plus loin, bien plus tard, en erreur opaque de registry — sans rien qui pointe vers le template fautif. La validation se fait maintenant à la lecture, là où on connaît encore **le fichier et l''index** : `template bancal.yaml: agents[0]: missing or invalid "preset"`.

## Import mort

`orchestrator.ts` importait `buildProject` et `listTemplates` — aucun des deux n''était utilisé.

## Non fait

Le **test de caractérisation d''`executeRun`** (le dernier minor de la liste) n''est pas dans ce lot : `executeRun` orchestre un run complet, et le caractériser correctement mérite son propre travail plutôt qu''un test bâclé glissé dans un lot de nettoyage.

## Tests

8 tests (`minors.test.ts`). `npm test` → **402 verts**, build propre. Seul échec : le `0o755` pré-existant, propre à Windows.