### PR TITLE
feat(work-stealing): estampille le run_id — le pool ne voit plus les runs morts (#32)

### DIFF
--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -2,6 +2,7 @@
 
 import { createLogger } from "../logger.js";
 import { authHeaders } from "../coordinator-auth.js";
+import { currentRunId } from "../run-id.js";
 const log = createLogger("work-stealing");
 
 export interface Task {
@@ -94,6 +95,8 @@ export async function postDiscoveries(
         target_modules: [],
         target_files: task.file ? [task.file] : [],
         keep_open: true,
+        // Stamps the thread with this run so the NEXT run doesn't inherit it (#32).
+        run_id: currentRunId(),
       });
       task.id = (data.thread_id as string) || "";
       log.info(`posted thread=${task.id}: ${subject.slice(0, 80)}`);
@@ -121,7 +124,10 @@ export async function claimNextTask(
     const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
-      body: "{}",
+      // Scope the pool to this run: the threads of an aborted earlier run must
+      // not be claimable here (#32). Un-scoped threads (a human session) stay
+      // visible — the coordinator's filter keeps them on purpose.
+      body: JSON.stringify({ run_id: currentRunId() }),
     });
     if (!resp.ok) { log.warn("claimNextTask: threads-active failed", { status: resp.status }); return null; }
     const data = await resp.json();
@@ -298,7 +304,9 @@ export async function fetchExistingThreads(coordinatorUrl: string): Promise<stri
     const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
-      body: "{}",
+      // The review phase compares its findings against these threads. Feeding it
+      // a dead run's threads is how a lead ends up consulting a stale id (#32).
+      body: JSON.stringify({ run_id: currentRunId() }),
     });
     if (!resp.ok) return "(aucun thread actif)";
     const threads = (await resp.json()) as Array<Record<string, unknown>>;

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { resolve } from "path";
 import { createLogger } from "../logger.js";
 import { authHeaders, mcpAuthHeaders } from "../coordinator-auth.js";
+import { ensureRunId } from "../run-id.js";
 import { startServer } from "mcp-coordinator";
 type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 const log = createLogger("orchestrator");
@@ -136,7 +137,12 @@ async function _runProjectBody(
   const runDir = path.resolve("runs", `${project.id}-${mode}-${Date.now()}`);
   fs.mkdirSync(runDir, { recursive: true });
 
-  log.info(`=== ${project.name} (${mode}, ${project.agents.length} agents) ===`);
+  // Mint the run id BEFORE any agent starts, so every thread this swarm opens
+  // carries it and the next run doesn't inherit our leftovers (#32). Published
+  // to the environment, which in-process loops and `claude -p` children share.
+  const runId = ensureRunId(project.id);
+
+  log.info(`=== ${project.name} (${mode}, ${project.agents.length} agents, run=${runId}) ===`);
 
   // 0. Pre-flight quota check — abort the raid before we commit to worktrees
   // if the Anthropic quota is already above the configured max. Fail-open if

--- a/src/run-id.ts
+++ b/src/run-id.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from "crypto";
+
+/**
+ * Identifier of the current essaim run, shared by every agent of the swarm.
+ *
+ * Threads announced with it are scoped to this run: a shared coordinator (where
+ * /api/reset is 403-forbidden by design) otherwise keeps showing the threads of
+ * an ABORTED earlier run to the next run's agents (#32).
+ *
+ * Same shape as coordinator-auth: read from the environment, absent = disabled,
+ * so a run without it degrades to exactly today's behaviour (un-scoped threads,
+ * visible to everyone).
+ */
+export function currentRunId(): string | undefined {
+  const id = process.env.ESSAIM_RUN_ID?.trim();
+  return id ? id : undefined;
+}
+
+/**
+ * Mint the run id and publish it to the environment, so in-process agent loops
+ * AND `claude -p` subprocesses (which inherit env) all stamp the same run.
+ * Idempotent: an id already set (a runner, a CI job, a parent essaim) wins.
+ */
+export function ensureRunId(templateId: string): string {
+  const existing = currentRunId();
+  if (existing) return existing;
+  const id = `${templateId}-${randomUUID().slice(0, 8)}`;
+  process.env.ESSAIM_RUN_ID = id;
+  return id;
+}

--- a/tests/unit/run-id.test.ts
+++ b/tests/unit/run-id.test.ts
@@ -1,0 +1,62 @@
+// tests/unit/run-id.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { currentRunId, ensureRunId } from '../../src/run-id.js';
+import { claimNextTask, postDiscoveries } from '../../src/agent-loop/work-stealing.js';
+
+beforeEach(() => { delete process.env.ESSAIM_RUN_ID; });
+afterEach(() => { vi.unstubAllGlobals(); delete process.env.ESSAIM_RUN_ID; });
+
+// #32 — sur un coordinateur partagé et persistant, les threads d'un run AVORTÉ
+// restaient visibles aux agents du run suivant. Chaque thread porte désormais
+// l'id de son run, et le pool est filtré dessus.
+describe('run-id', () => {
+  it('absent de l\'environnement = non scopé (comportement historique)', () => {
+    expect(currentRunId()).toBeUndefined();
+  });
+
+  it('ensureRunId frappe un id et le publie dans l\'environnement', () => {
+    const id = ensureRunId('mekova-bughunt');
+    expect(id).toMatch(/^mekova-bughunt-[0-9a-f]{8}$/);
+    expect(process.env.ESSAIM_RUN_ID).toBe(id);
+    expect(currentRunId()).toBe(id);
+  });
+
+  it('est idempotent — un runner ou une CI qui a déjà fixé le run gagne', () => {
+    process.env.ESSAIM_RUN_ID = 'run-du-runner';
+    expect(ensureRunId('mekova-bughunt')).toBe('run-du-runner');
+  });
+});
+
+describe('work-stealing — estampillage du run (#32)', () => {
+  it('postDiscoveries estampille le run_id sur l\'announce', async () => {
+    process.env.ESSAIM_RUN_ID = 'run-42';
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(JSON.stringify({ thread_id: 't1' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postDiscoveries('https://c', 'a1', [{ id: '', description: 'bug', file: 'src/a.ts' }]);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.run_id).toBe('run-42');
+  });
+
+  it('claimNextTask ne demande que le pool de SON run', async () => {
+    process.env.ESSAIM_RUN_ID = 'run-42';
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('[]', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await claimNextTask('https://c', 'a1');
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.run_id).toBe('run-42');
+  });
+
+  it('sans run_id, la requête reste valide — le coordinateur renvoie tout, comme avant', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('[]', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await claimNextTask('https://c', 'a1');
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.run_id).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #32. Pendant côté coordinator : **swoofer/mcp-coordinator#198** (à merger en premier, sinon le `run_id` envoyé est simplement ignoré — sans rien casser).

## Le problème

Sur un coordinateur partagé et persistant (où `/api/reset` est 403 par design), les threads d''un run **avorté** restaient visibles aux agents du run suivant : un lead a fini par consulter un thread éventé, et le pool de work-stealing était pollué par des tâches mortes.

## Le correctif

**`src/run-id.ts`** — `ensureRunId()` frappe l''id **avant que le moindre agent démarre** et le publie dans l''environnement, que les boucles in-process **et** les enfants `claude -p` héritent. Idempotent : un runner ou une CI qui a déjà fixé le run gagne. Même motif que `coordinator-auth.ts` — absent = désactivé, donc un run sans id se comporte **exactement** comme aujourd''hui.

Trois points de contact :
- **`postDiscoveries`** estampille le `run_id` sur l''announce.
- **`claimNextTask`** ne demande que le pool de **son** run : les tâches d''un run mort ne sont plus claimables.
- **`fetchExistingThreads`** aussi — la phase review comparait ses findings à des threads morts, ce qui est précisément la voie par laquelle un lead finissait sur un id éventé.

## L''invariant à ne pas casser

Le filtre côté coordinateur est `(run_id IS NULL OR run_id = ?)`, **pas** une égalité stricte : les threads **non scopés** — ceux d''un humain travaillant le même repo — restent visibles à l''essaim. Sans ça, les agents lui éditeraient ses fichiers sous les doigts, ce que le coordinateur existe justement pour empêcher.

**On masque les autres runs, jamais les autres sessions.**

## Tests

6 tests (`run-id.test.ts`), dont celui qui vérifie qu''un run **sans** id envoie une requête valide et récupère tout, comme avant. `npm test` → **408 verts**, build propre. Seul échec : le `0o755` pré-existant, propre à Windows.