### PR TITLE
feat(bughunt): contrat de sortie Essaim-Target — clé stable de dédup des findings

### DIFF
--- a/presets/mekova-bughunt.yaml
+++ b/presets/mekova-bughunt.yaml
@@ -32,7 +32,23 @@ params:
       Pour la cause que tu as claimée : écris un test de reproduction qui
       ÉCHOUE, dans la suite de tests du projet, avec un commentaire
       « comportement attendu vs observé ». NE CORRIGE PAS le bug — le fix est
-      planifié ailleurs (flow RCA Mekova). Commite le test sur ta branche,
-      puis poste dans ton thread un résumé de cause racine en 3-5 lignes
+      planifié ailleurs (flow RCA Mekova).
+
+
+      Commite le test sur ta branche. Le message de commit DOIT se terminer par
+      une ligne seule :
+
+
+      `Essaim-Target: <chemin du fichier SOURCE fautif>`
+
+
+      (ex. `Essaim-Target: src/report.ts` — le fichier qui CONTIENT le bug, pas
+      ton fichier de test.) C'est la seule clé stable dont dispose l'outillage
+      aval pour reconnaître un finding déjà signalé : le titre de ton commit et
+      le nom de ton test, eux, varient d'un agent à l'autre pour un même bug.
+      Sans cette ligne, ton finding sera re-signalé en doublon à chaque exécution.
+
+
+      Puis poste dans ton thread un résumé de cause racine en 3-5 lignes
       (la cause, pas le symptôme) + hypothèses écartées (1 ligne chacune).
     effort: mid

--- a/tests/unit/bce-parity.test.ts
+++ b/tests/unit/bce-parity.test.ts
@@ -241,6 +241,23 @@ describe('Parity: BCE presets produce complete prompts', () => {
     });
   });
 
+  // Le contrat de sortie appartient au PRESET, pas à l'appelant. Un consommateur
+  // aval (le runner nocturne, mais aussi n'importe quel autre) doit pouvoir
+  // reconnaître un finding déjà signalé. La clé ne peut pas être le titre du
+  // commit — le même bug est reformulé autrement d'un agent/d'une nuit à l'autre.
+  // Le seul signal stable est le FICHIER FAUTIF, d'où le trailer.
+  describe('Bughunt — contrat de sortie Essaim-Target', () => {
+    it('exige le trailer nommant le fichier source fautif', () => {
+      const prompt = buildPreset('mekova-bughunt').output.prompt;
+      expect(prompt).toContain('Essaim-Target:');
+    });
+
+    it('demande le fichier SOURCE fautif, pas le fichier de test', () => {
+      const prompt = buildPreset('mekova-bughunt').output.prompt;
+      expect(prompt).toMatch(/Essaim-Target[\s\S]{0,200}source/i);
+    });
+  });
+
   describe('Solo mode', () => {
     it('strips coordination from any preset', () => {
       const result = buildPreset('raid', { 'coordinator-rules': { solo_mode: true } });


### PR DESCRIPTION
## Le manque

`mekova-bughunt` produit des findings, mais **rien dans son contrat ne permet à un outillage aval de reconnaître un finding déjà signalé**.

Le symptôme concret, côté Mekova : un raid planifié re-clone le repo **à neuf chaque nuit**, retrouve les mêmes bugs — ils sont toujours là, personne n''a eu le temps de les corriger — et **rouvre les mêmes issues**. Indéfiniment.

## Pourquoi il faut une clé explicite

Ni le **titre du commit** ni le **nom du fichier de test** ne peuvent servir de clé : pour un même bug, deux agents (ou deux nuits) produisent deux formulations et deux noms différents.

```
Nuit 1 : "test: repro perte de receipt_date dans l'export CSV"   → test_report.spec.ts
Nuit 2 : "test(csv): reproduit l'absence de store_name à l'export" → csv_export.test.ts
```

Même bug. Rien de commun.

**Le seul signal stable, c''est le fichier fautif** — lui ne change pas de nom.

## Le contrat

`phase-execute` exige désormais, en fin de message de commit :

```
Essaim-Target: <chemin du fichier SOURCE fautif>
```

Le fichier qui **contient** le bug, pas le fichier de test. La distinction est explicite dans le prompt : c''est l''erreur naturelle que ferait un agent.

## Pourquoi dans le preset et pas chez l''appelant

L''instruction vivait jusqu''ici dans **une chaîne bash** du runner Mekova. Mauvais endroit : ce n''est pas une propriété du *job nocturne*, c''est une propriété du **contrat de `mekova-bughunt`**. Quiconque lance le preset autrement n''émettait aucune clé, et son outillage aval ne pouvait pas dédupliquer.

Le contrat voyage maintenant avec le preset.

*(Ce n''est en revanche pas la place de promptweave : le composeur de prompts ne parle jamais à GitHub, et le pattern générique « émettre une clé lisible par machine » n''a qu''un seul consommateur aujourd''hui — l''abstraire serait spéculatif.)*

## Tests

2 tests (`bce-parity`) : le trailer est bien exigé, et le prompt réclame bien le fichier **source**, pas le fichier de test. Vérifié aussi que l''instruction atterrit dans le prompt assemblé de la **phase execute** — celle où l''agent commite.

`npm test` → **410 verts**, build propre. Seul échec : le `0o755` pré-existant, propre à Windows.