### PR TITLE
feat(catalog): catalogues externes — --catalog, ESSAIM_CATALOG, .essaim/ projet

### DIFF
--- a/cli/bce-resolver.ts
+++ b/cli/bce-resolver.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from "path";
+import { dirname, resolve, delimiter } from "path";
 import { existsSync } from "fs";
 import { fileURLToPath } from "url";
 
@@ -12,10 +12,14 @@ try {
   SCRIPT_DIR = process.cwd();
 }
 
-let _root: string | null = null;
+// Cached: the BUNDLED root only. Never the resolved list — an agent-loop, a
+// pipeline step or the next test would otherwise inherit the catalogs of the
+// previous call and assemble prompts from a catalog nobody chose.
+let _bundledRoot: string | null = null;
 
-export function getCatalogRoot(): string {
-  if (_root !== null) return _root;
+/** The catalog shipped with essaim itself. */
+export function getBundledRoot(): string {
+  if (_bundledRoot !== null) return _bundledRoot;
   // Walk up looking for a directory that contains all 3 catalog dirs.
   // tsx dev:        starts at cli/        → walks up 1 level → repo root
   // node from dist: starts at dist/cli/   → walks up 2 levels → repo root
@@ -30,8 +34,8 @@ export function getCatalogRoot(): string {
         existsSync(resolve(dir, "presets")) &&
         existsSync(resolve(dir, "compositions"))
       ) {
-        _root = dir;
-        return _root;
+        _bundledRoot = dir;
+        return _bundledRoot;
       }
       dir = dirname(dir);
     }
@@ -42,18 +46,82 @@ export function getCatalogRoot(): string {
   );
 }
 
+/** @deprecated Prefer getCatalogRoots() — this only ever sees the bundled catalog. */
+export function getCatalogRoot(): string {
+  return getBundledRoot();
+}
+
+export interface CatalogOptions {
+  /** Explicit catalogs (`--catalog`, repeatable). */
+  catalogs?: string[];
+  /** Project whose `.essaim/` catalog should be layered on top, if it has one. */
+  projectPath?: string;
+}
+
+function requireCatalog(path: string): string {
+  const abs = resolve(path);
+  if (!existsSync(abs)) {
+    // A catalog the user NAMED must never degrade into a silent no-op: the
+    // typo would simply be ignored, and the failure would resurface two screens
+    // later as an opaque "Unknown template".
+    throw new Error(`essaim: catalogue introuvable — ${abs}`);
+  }
+  return abs;
+}
+
+/**
+ * Catalog roots, in precedence order — **the last one wins**.
+ *
+ *   bundled  <  ESSAIM_CATALOG  <  --catalog  <  <project>/.essaim
+ *
+ * From the most general to the most local. The explicit flag beats the ambient
+ * environment (an env var set months ago must not quietly outrank what the user
+ * just typed), and a project's own `.essaim/` beats everything.
+ */
+export function getCatalogRoots(opts: CatalogOptions = {}): string[] {
+  const roots = [getBundledRoot()];
+
+  // path.delimiter, never a hardcoded ':' — that would cut "C:\..." in half on
+  // Windows, where this is developed.
+  const fromEnv = (process.env.ESSAIM_CATALOG ?? "")
+    .split(delimiter)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  for (const c of [...fromEnv, ...(opts.catalogs ?? [])]) {
+    roots.push(requireCatalog(c));
+  }
+
+  if (opts.projectPath) {
+    const local = resolve(opts.projectPath, ".essaim");
+    if (existsSync(local)) roots.push(local);
+  }
+
+  return roots;
+}
+
+const subdir = (name: string) => (opts: CatalogOptions = {}): string[] =>
+  getCatalogRoots(opts).map((r) => resolve(r, name)).filter(existsSync);
+
+/** Every existing `behaviors/` dir across the catalogs, in precedence order. */
+export const getBehaviorsDirs = subdir("behaviors");
+/** Every existing `templates/` dir across the catalogs, in precedence order. */
+export const getTemplatesDirs = subdir("templates");
+/** Every existing `scripts/` dir across the catalogs, in precedence order. */
+export const getScriptsDirs = subdir("scripts");
+
 export function getBehaviorsDir(): string {
-  return resolve(getCatalogRoot(), "behaviors");
+  return resolve(getBundledRoot(), "behaviors");
 }
 export function getPresetsDir(): string {
-  return resolve(getCatalogRoot(), "presets");
+  return resolve(getBundledRoot(), "presets");
 }
 export function getCompositionsDir(): string {
-  return resolve(getCatalogRoot(), "compositions");
+  return resolve(getBundledRoot(), "compositions");
 }
 export function getScriptsDir(): string {
-  return resolve(getCatalogRoot(), "scripts");
+  return resolve(getBundledRoot(), "scripts");
 }
 export function getTemplatesDir(): string {
-  return resolve(getCatalogRoot(), "templates");
+  return resolve(getBundledRoot(), "templates");
 }

--- a/cli/list.ts
+++ b/cli/list.ts
@@ -1,11 +1,21 @@
 import { Command } from "commander";
+import { resolve } from "path";
 import { listTemplates } from "../src/orchestrator/template-engine.js";
+import { collect } from "./params.js";
 
 export function createListCommand(): Command {
   return new Command("list")
     .description("List available templates")
-    .action(() => {
-      const templates = listTemplates();
+    // Sans ces deux options, `list` n'affiche que les templates bundlés — il dirait
+    // donc ne pas savoir faire ce que `run` sait faire. Une divergence entre ce que
+    // l'outil annonce et ce qu'il exécute est un piège en soi.
+    .option("-p, --project <path>", "Project path (pour voir les templates de son .essaim/)")
+    .option("--catalog <path>", "Catalogue externe — répétable, le dernier gagne", collect, [])
+    .action((opts: { project?: string; catalog: string[] }) => {
+      const templates = listTemplates(
+        opts.project ? resolve(opts.project) : undefined,
+        { catalogs: opts.catalog },
+      );
       console.log("\nTemplates disponibles:\n");
       for (const t of templates) {
         console.log(`  ${t.id.padEnd(14)} ${t.name}`);
@@ -13,4 +23,3 @@ export function createListCommand(): Command {
       }
     });
 }
-

--- a/cli/params.ts
+++ b/cli/params.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { parse } from "yaml";
-import { getBehaviorsDir } from "./bce-resolver.js";
+import { getBehaviorsDirs, type CatalogOptions } from "./bce-resolver.js";
 
 export function collect(val: string, prev: string[]): string[] {
   return prev.concat([val]);
@@ -10,17 +10,21 @@ export function collect(val: string, prev: string[]): string[] {
 export type ParamType = "string" | "number" | "boolean" | "string[]" | "unknown";
 
 /** Types déclarés du catalogue : clé "<behavior>.<param>" → type. */
-export function buildParamTypeMap(): Record<string, ParamType> {
+export function buildParamTypeMap(opts: CatalogOptions = {}): Record<string, ParamType> {
   const map: Record<string, ParamType> = {};
-  const dir = getBehaviorsDir();
-  for (const f of readdirSync(dir).filter((n) => /\.ya?ml$/.test(n))) {
-    const doc = parse(readFileSync(join(dir, f), "utf-8")) as {
-      name?: string;
-      params?: Record<string, { type?: string }>;
-    };
-    if (!doc?.name || !doc.params) continue;
-    for (const [p, def] of Object.entries(doc.params)) {
-      map[`${doc.name}.${p}`] = (def?.type as ParamType) ?? "unknown";
+  // Toutes les racines, pas seulement la bundlée : sinon le type déclaré d'un param
+  // d'un behavior EXTERNE est perdu, et `--set mon-behavior.projet=2026` passerait
+  // par JSON.parse — le slug "2026" deviendrait le NOMBRE 2026, sans un mot.
+  for (const dir of getBehaviorsDirs(opts)) {
+    for (const f of readdirSync(dir).filter((n) => /\.ya?ml$/.test(n))) {
+      const doc = parse(readFileSync(join(dir, f), "utf-8")) as {
+        name?: string;
+        params?: Record<string, { type?: string }>;
+      };
+      if (!doc?.name || !doc.params) continue;
+      for (const [p, def] of Object.entries(doc.params)) {
+        map[`${doc.name}.${p}`] = (def?.type as ParamType) ?? "unknown";
+      }
     }
   }
   return map;

--- a/cli/pipeline.ts
+++ b/cli/pipeline.ts
@@ -85,6 +85,7 @@ export function createPipelineCommand(): Command {
               coordinatorUrl: sh.coordinatorUrl,
               maxQuotaPct: sh.maxQuotaPct,
               dryRun: sh.dryRun,
+              catalogs: def.catalog,
             });
           },
           execHook: (cmd, cwd) => {

--- a/cli/run-core.ts
+++ b/cli/run-core.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path";
 import { scanProject } from "../src/orchestrator/scanner.js";
 import { buildProject, listTemplates } from "../src/orchestrator/template-engine.js";
+import { getCatalogRoots } from "./bce-resolver.js";
 import { runProject } from "../src/orchestrator/orchestrator.js";
 import { writeReport } from "../src/orchestrator/reporter.js";
 import { loadConfig } from "./config.js";
@@ -25,6 +26,8 @@ export interface ExecuteRunOptions {
   coordinatorUrl?: string;
   baseRef?: string;
   maxQuotaPct?: number;
+  /** Catalogues externes (--catalog, répétable). */
+  catalogs?: string[];
 }
 
 /**
@@ -40,10 +43,18 @@ export async function executeRun(opts: ExecuteRunOptions): Promise<RunResult | u
   // overrides) are recognized at pre-flight.
   const projectPath = resolve(opts.project);
 
-  const templates = listTemplates(projectPath);
+  const catalogs = opts.catalogs;
+  const templates = listTemplates(projectPath, { catalogs });
   if (!templates.find((t) => t.id === opts.template)) {
     const available = templates.map((t) => t.id).join(", ");
-    throw new Error(`Unknown template '${opts.template}'. Available: ${available}`);
+    // Lister les catalogues consultés : sans ça, un catalogue oublié (ou mal
+    // orthographié dans ESSAIM_CATALOG) ressort en « Unknown template » et on
+    // cherche le bug dans le template, jamais dans la résolution.
+    const roots = getCatalogRoots({ catalogs, projectPath }).join(", ");
+    throw new Error(
+      `Unknown template '${opts.template}'. Available: ${available}
+Catalogues consultés : ${roots}`,
+    );
   }
 
   const context = scanProject(projectPath);
@@ -81,7 +92,7 @@ export async function executeRun(opts: ExecuteRunOptions): Promise<RunResult | u
   const project = buildProject(
     opts.template,
     context,
-    { agentCount, setParams },
+    { agentCount, setParams, catalogs },
     projectPath,
   );
 

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -14,6 +14,7 @@ export function createRunCommand(): Command {
     .option("--cleanup", "Remove worktrees after execution")
     .option("--dry-run", "Preview agents and prompts without launching")
     .option("--modules <list>", "Comma-separated module list, overrides scanner discovery. Required for templates using count: 'per-module' when the project layout doesn't match the scanner's expectations.")
+        .option("--catalog <path>", "Catalogue externe (behaviors/presets/compositions/templates) — répétable, le dernier gagne", collect, [])
     .option("--set <key=value>", "BCE parameter (repeatable)", collect, [])
     .option("--set-file <behavior.param>=<path>", "BCE parameter, value read verbatim from a file (repeatable, wins over --set on conflict)", collect, [])
     .option("--url <url>", "Coordinator URL (override config, deprecated: use --coordinator-url)")
@@ -39,13 +40,14 @@ export function createRunCommand(): Command {
           coordinatorUrl?: string;
           baseRef?: string;
           maxQuotaPct?: string;
+          catalog: string[];
         },
       ) => {
         // List templates if none specified. Resolve projectPath first so that
         // project-local .essaim/templates/ entries are recognized at pre-flight.
         if (!template) {
           const projectPath = resolve(opts.project);
-          const templates = listTemplates(projectPath);
+          const templates = listTemplates(projectPath, { catalogs: opts.catalog });
           console.log("\nAvailable templates:\n");
           for (const t of templates) {
             console.log(`  ${t.id.padEnd(14)} ${t.name}`);
@@ -56,7 +58,7 @@ export function createRunCommand(): Command {
         }
 
         // Merge --set + --set-file (set-file wins on conflict).
-        const setParams = parseSetParams(opts.set, buildParamTypeMap());
+        const setParams = parseSetParams(opts.set, buildParamTypeMap({ catalogs: opts.catalog, projectPath: resolve(opts.project) }));
         const setFileParams = parseSetFileParams(opts.setFile);
         for (const [behavior, values] of Object.entries(setFileParams)) {
           setParams[behavior] = { ...setParams[behavior], ...values };
@@ -83,6 +85,7 @@ export function createRunCommand(): Command {
             coordinatorUrl: opts.coordinatorUrl ?? opts.url,
             baseRef: opts.baseRef,
             maxQuotaPct: opts.maxQuotaPct ? Number(opts.maxQuotaPct) : undefined,
+            catalogs: opts.catalog,
           });
         } catch (e) {
           console.error(e instanceof Error ? e.message : String(e));

--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -41,6 +41,7 @@ export function createSoloCommand(): Command {
     .argument("[template]", "Template to use (raid, melee, swarm, ...)")
     .option("-p, --project <path>", "Target project path", ".")
     .option("-t, --timeout <min>", "Timeout in minutes", "15")
+        .option("--catalog <path>", "Catalogue externe (behaviors/presets/compositions/templates) — répétable, le dernier gagne", collect, [])
     .option("--set <key=value>", "BCE parameter (repeatable)", collect, [])
     .option("--set-file <behavior.param>=<path>", "BCE parameter, value read verbatim from a file (repeatable, wins over --set on conflict)", collect, [])
     .option(
@@ -56,6 +57,7 @@ export function createSoloCommand(): Command {
           set: string[];
           setFile: string[];
           coordinatorUrl?: string;
+          catalog: string[];
         },
       ) => {
         // Resolve projectPath before listing/validating templates so that
@@ -64,7 +66,7 @@ export function createSoloCommand(): Command {
         const projectPath = resolve(opts.project);
 
         // List templates if none specified
-        const templates = listTemplates(projectPath);
+        const templates = listTemplates(projectPath, { catalogs: opts.catalog });
         if (!template) {
           console.log("\nAvailable templates:\n");
           for (const t of templates) {
@@ -87,12 +89,12 @@ export function createSoloCommand(): Command {
         const context = scanProject(projectPath);
 
         // Build prompt with solo_mode=true injected automatically
-        const setParams = parseSetParams(opts.set, buildParamTypeMap());
+        const setParams = parseSetParams(opts.set, buildParamTypeMap({ catalogs: opts.catalog, projectPath }));
         const setFileParams = parseSetFileParams(opts.setFile);
         for (const [behavior, values] of Object.entries(setFileParams)) {
           setParams[behavior] = { ...setParams[behavior], ...values };
         }
-        const { prompt, mcpTools } = buildSolo(template, context, setParams, projectPath);
+        const { prompt, mcpTools } = buildSolo(template, context, setParams, projectPath, opts.catalog);
 
         const mcpConfigPath = resolve(projectPath, ".mcp.json");
         const args = buildSoloArgs(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.0",
-        "@swoofer/promptweave": "^0.1.0",
+        "@swoofer/promptweave": "^0.3.0",
         "commander": "^14.0.3",
         "handlebars": "^4.7.0",
         "mcp-coordinator": "^0.13.0",
@@ -937,9 +937,9 @@
       "license": "MIT"
     },
     "node_modules/@swoofer/promptweave": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@swoofer/promptweave/-/promptweave-0.1.0.tgz",
-      "integrity": "sha512-mXUtHrleKe1x52tBFk9E0C5yaUFUqhwY/GYIaEj2YsgKTZMagDhGjkYJvrzezn72/WmoJVv0xzOUGwxtrKpjHw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@swoofer/promptweave/-/promptweave-0.3.0.tgz",
+      "integrity": "sha512-dViqf6Qw3yssegnKCRyfvIS9TsyKH9x3XITZNGB9UfRB7z3SxBEDTJXqM6SKmfTiUI4qJGrry4DGvV6IaXyXYg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",
-    "@swoofer/promptweave": "^0.1.0",
+    "@swoofer/promptweave": "^0.3.0",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
     "mcp-coordinator": "^0.13.0",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -38,7 +38,7 @@ interface BceMiniProject {
   compare_mode: boolean;
 }
 
-import { getCatalogRoot } from "../cli/bce-resolver.js";
+import { getCatalogRoots, type CatalogOptions } from "../cli/bce-resolver.js";
 import { loadTemplates } from "./template-loader.js";
 
 const AGENT_NAMES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
@@ -46,10 +46,11 @@ const AGENT_NAMES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
 export function buildProjectFromBce(
   templateId: string,
   context: { path: string; language: string; test_command: string; modules: string[]; source_files: string[] },
-  options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>> },
+  options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>>; catalogs?: string[] },
   projectPath?: string,
 ): BceMiniProject {
-  const templates = loadTemplates(projectPath);
+  const catalogOpts: CatalogOptions = { catalogs: options?.catalogs, projectPath };
+  const templates = loadTemplates(projectPath, catalogOpts);
   const def = templates[templateId];
   if (!def) {
     const available = Object.keys(templates).join(', ');
@@ -129,7 +130,7 @@ export function buildProjectFromBce(
         remove: [],
         params: {},
       };
-      const result = runPipeline(agent, getCatalogRoot(), launchParams);
+      const result = runPipeline(agent, getCatalogRoots(catalogOpts), launchParams);
 
       // Modules registered with the coordinator for respondent matching.
       // Default = full project list (broad collaboration: every agent is a
@@ -170,8 +171,8 @@ export function buildProjectFromBce(
   };
 }
 
-export function listBceTemplates(projectPath?: string): { id: string; name: string; description: string }[] {
-  return Object.entries(loadTemplates(projectPath)).map(([id, def]) => ({
+export function listBceTemplates(projectPath?: string, opts?: CatalogOptions): { id: string; name: string; description: string }[] {
+  return Object.entries(loadTemplates(projectPath, { ...opts, projectPath })).map(([id, def]) => ({
     id, name: def.name, description: def.description,
   }));
 }
@@ -188,8 +189,11 @@ export function buildSolo(
   context: { language: string; test_command: string; modules: string[] },
   setParams?: Record<string, Record<string, unknown>>,
   projectPath?: string,
+  catalogs?: string[],
 ): { prompt: string; mcpTools: string[] } {
-  const templates = loadTemplates(projectPath);
+  // catalogs en DERNIER argument, jamais réordonné : c'est de la surface publique.
+  const catalogOpts: CatalogOptions = { catalogs, projectPath };
+  const templates = loadTemplates(projectPath, catalogOpts);
   const def = templates[templateId];
   if (!def) {
     const available = Object.keys(templates).join(", ");
@@ -217,7 +221,7 @@ export function buildSolo(
     remove: [] as string[],
     params: {} as Record<string, Record<string, unknown>>,
   };
-  const result = runPipeline(agent, getCatalogRoot(), launchParams);
+  const result = runPipeline(agent, getCatalogRoots(catalogOpts), launchParams);
   return { prompt: result.output.prompt, mcpTools: result.output.mcpTools };
 }
 
@@ -227,7 +231,8 @@ export function buildSoloPrompt(
   context: { language: string; test_command: string; modules: string[] },
   setParams?: Record<string, Record<string, unknown>>,
   projectPath?: string,
+  catalogs?: string[],
 ): string {
-  return buildSolo(templateId, context, setParams, projectPath).prompt;
+  return buildSolo(templateId, context, setParams, projectPath, catalogs).prompt;
 }
 

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -25,7 +25,7 @@ import { collectAgentResults } from "./reporter.js";
 import type { AgentConfig, MiniProject, AgentProcess, RunResult } from "./types.js";
 import { scanProject } from "./scanner.js";
 
-import { getCatalogRoot, getScriptsDir } from "../../cli/bce-resolver.js";
+import { getCatalogRoots, getScriptsDirs } from "../../cli/bce-resolver.js";
 import { runPipeline } from "@swoofer/promptweave";
 import { preflightQuotaCheck, resolveMaxUtilizationPct } from "./preflight.js";
 
@@ -62,10 +62,6 @@ async function postJson(url: string, body: unknown, timeoutMs = 5000): Promise<b
     log.warn(`POST ${url} failed: ${err instanceof Error ? err.message : String(err)}`);
     return false;
   }
-}
-
-function readBceAsset(relativePath: string): string {
-  return readFileSync(resolve(getCatalogRoot(), relativePath), 'utf-8');
 }
 
 const COORDINATOR_URL = process.env.COORDINATOR_URL || "http://localhost:3100";
@@ -507,7 +503,17 @@ export function writeClaudeHooksDir(params: {
   const writtenFiles: string[] = [];
   const writtenHookFiles: Record<string, string> = {};
   for (const [lifecycle, script] of Object.entries(hooks)) {
-    const resolvedScript = script.replace(/\$BCE_SCRIPTS_DIR/g, getScriptsDir());
+    // Un behavior d'un catalogue EXTERNE peut déclarer un hook `$BCE_SCRIPTS_DIR/x.sh`.
+    // Résoudre systématiquement vers le scripts/ bundlé pointerait sur un fichier
+    // absent — et Claude Code n'échoue PAS fort sur un hook manquant. On prend donc
+    // le premier dossier scripts/ qui contient réellement le script, en partant de
+    // la racine la plus locale.
+    const scriptDirs = getScriptsDirs();
+    const scriptsDir = [...scriptDirs].reverse().find((d) => {
+      const m = script.match(/\$BCE_SCRIPTS_DIR\/([\w.-]+)/);
+      return m ? fs.existsSync(path.join(d, m[1])) : false;
+    }) ?? scriptDirs[0] ?? "";
+    const resolvedScript = script.replace(/\$BCE_SCRIPTS_DIR/g, scriptsDir);
     const filename = `${lifecycle}.sh`;
     const hookPath = path.join(hooksDir, filename);
     fs.writeFileSync(hookPath, resolvedScript, { mode: 0o755 });
@@ -580,7 +586,7 @@ export function setupProject(projectPath: string, options: SetupOptions): void {
     remove: [] as string[],
     params: {} as Record<string, Record<string, unknown>>,
   };
-  const result = runPipeline(bceAgent, getCatalogRoot(), launchParams);
+  const result = runPipeline(bceAgent, getCatalogRoots(), launchParams);
 
   // 2. Merge BCE envVars with init-time values
   const envVars: Record<string, string> = {

--- a/src/orchestrator/template-engine.ts
+++ b/src/orchestrator/template-engine.ts
@@ -6,14 +6,17 @@ import { buildProjectFromBce, listBceTemplates } from "../bridge.js";
 export function buildProject(
   templateId: string,
   context: ProjectContext,
-  options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>> },
+  options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>>; catalogs?: string[] },
   projectPath?: string,
 ): MiniProject {
   return buildProjectFromBce(templateId, context, options, projectPath) as unknown as MiniProject;
 }
 
-export function listTemplates(projectPath?: string): { id: string; name: string; description: string }[] {
-  return listBceTemplates(projectPath);
+export function listTemplates(
+  projectPath?: string,
+  opts?: { catalogs?: string[] },
+): { id: string; name: string; description: string }[] {
+  return listBceTemplates(projectPath, opts);
 }
 
 

--- a/src/pipeline/schema.ts
+++ b/src/pipeline/schema.ts
@@ -22,9 +22,16 @@ export interface PipelineStep {
 export interface PipelineDef {
   name: string;
   steps: PipelineStep[];
+  /**
+   * Catalogues externes appliqués à TOUS les steps (chemins relatifs au fichier
+   * pipeline). Sans ça, un pipeline dont les templates vivent hors du catalogue
+   * bundlé dépendrait d'une variable d'environnement — et un `catalog:` écrit dans
+   * le YAML serait silencieusement jeté en « unknown key (ignored) ».
+   */
+  catalog?: string[];
 }
 
-const KNOWN_TOP_KEYS = new Set(["name", "steps"]);
+const KNOWN_TOP_KEYS = new Set(["name", "steps", "catalog"]);
 const KNOWN_STEP_KEYS = new Set([
   "name",
   "template",
@@ -69,7 +76,19 @@ export function loadPipeline(filePath: string): PipelineDef {
     parseStep(s, i, baseDir),
   );
 
-  return { name: doc.name, steps };
+  // Chemins relatifs au FICHIER pipeline, pas au cwd : un pipeline doit rester
+  // lançable depuis n'importe où.
+  const rawCatalog = (doc as Record<string, unknown>).catalog;
+  const catalog = rawCatalog === undefined
+    ? undefined
+    : (Array.isArray(rawCatalog) ? rawCatalog : [rawCatalog]).map((c) => {
+        if (typeof c !== "string" || !c.trim()) {
+          throw new Error(`'catalog' must be a path (or a list of paths)`);
+        }
+        return resolve(baseDir, c);
+      });
+
+  return { name: doc.name, steps, catalog };
 }
 
 function parseStep(raw: unknown, index: number, baseDir: string): PipelineStep {

--- a/src/template-loader.ts
+++ b/src/template-loader.ts
@@ -3,7 +3,7 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import { join, basename } from "path";
 import { parse } from "yaml";
-import { getTemplatesDir } from "../cli/bce-resolver.js";
+import { getTemplatesDirs, type CatalogOptions } from "../cli/bce-resolver.js";
 
 // Template definitions map template IDs to BCE presets + orchestration config.
 export interface TemplateDefinition {
@@ -96,9 +96,15 @@ function loadDir(dir: string, out: Record<string, TemplateDefinition>): void {
  * project's .essaim/templates/ — project entries override catalog ones.
  * No cache: called once per run, and tests need fresh reads.
  */
-export function loadTemplates(projectPath?: string): Record<string, TemplateDefinition> {
+export function loadTemplates(
+  projectPath?: string,
+  opts: CatalogOptions = {},
+): Record<string, TemplateDefinition> {
   const out: Record<string, TemplateDefinition> = {};
-  loadDir(getTemplatesDir(), out);
-  if (projectPath) loadDir(join(projectPath, ".essaim", "templates"), out);
+  // Precedence order — the last root wins, and `.essaim/templates/` of the target
+  // project is already the last root when projectPath is given.
+  for (const dir of getTemplatesDirs({ ...opts, projectPath })) {
+    loadDir(dir, out);
+  }
   return out;
 }

--- a/tests/unit/bce-coverage.test.ts
+++ b/tests/unit/bce-coverage.test.ts
@@ -26,6 +26,7 @@ function makeBehavior(overrides: Partial<Behavior> & { name: string; sections: B
     params: {},
     hooks: {},
     mcp_tools: [],
+    side_car_files: {},
     ...overrides,
   };
 }
@@ -76,6 +77,7 @@ describe('writer.ts — writeOutput', () => {
     hooks: {},
     mcpTools: [],
     envVars: {},
+      sideCarFiles: {},
   };
 
   it('writes prompt, mcp json, and env file to target dir', () => {
@@ -231,6 +233,7 @@ describe('writer.ts — writeOutput', () => {
       hooks: {},
       mcpTools: circularObj as unknown as string[],
       envVars: {},
+      sideCarFiles: {},
     };
 
     expect(() => writeOutput(targetDir, output)).toThrow();

--- a/tests/unit/catalogue-externe.test.ts
+++ b/tests/unit/catalogue-externe.test.ts
@@ -1,0 +1,179 @@
+// tests/unit/catalogue-externe.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join, delimiter } from 'path';
+import { tmpdir } from 'os';
+import { getCatalogRoots, getBundledRoot } from '../../cli/bce-resolver.js';
+import { buildProject, listTemplates } from '../../src/orchestrator/template-engine.js';
+import type { ProjectContext } from '../../src/orchestrator/types.js';
+
+const made: string[] = [];
+afterEach(() => {
+  for (const p of made) rmSync(p, { recursive: true, force: true });
+  made.length = 0;
+  delete process.env.ESSAIM_CATALOG;
+});
+beforeEach(() => { delete process.env.ESSAIM_CATALOG; });
+
+function tmpCatalog(suffix: string): string {
+  const root = join(tmpdir(), `essaim-cat-${Date.now()}-${Math.random().toString(36).slice(2)}-${suffix}`);
+  for (const d of ['behaviors', 'presets', 'compositions', 'templates']) {
+    mkdirSync(join(root, d), { recursive: true });
+  }
+  made.push(root);
+  return root;
+}
+
+const CONTEXT: ProjectContext = {
+  path: '.', language: 'typescript', test_command: 'npm test',
+  source_dirs: ['src'], test_dirs: ['tests'], source_files: [],
+  has_git: true, is_clean: true, modules: ['core'], applicable_templates: [],
+};
+
+// #32 du plan catalogue-externe — aujourd'hui, un template projet-local peut
+// RECOMBINER les presets bundlés, mais dès qu'il référence un preset maison :
+// « Preset not found in registry ». Toute organisation qui veut son propre preset
+// doit donc patcher le repo essaim. C'est très exactement pour ça que 21 artefacts
+// Mekova y vivent.
+
+describe('getCatalogRoots', () => {
+  it('sans rien, c\'est le catalogue bundlé seul (non-régression)', () => {
+    expect(getCatalogRoots()).toEqual([getBundledRoot()]);
+  });
+
+  it('ESSAIM_CATALOG ajoute des racines, séparées par le délimiteur de la plateforme', () => {
+    // JAMAIS ':' en dur : ça couperait "C:\..." en deux sous Windows.
+    const a = tmpCatalog('a');
+    const b = tmpCatalog('b');
+    process.env.ESSAIM_CATALOG = [a, b].join(delimiter);
+
+    expect(getCatalogRoots()).toEqual([getBundledRoot(), a, b]);
+  });
+
+  it('--catalog l\'emporte sur ESSAIM_CATALOG — l\'explicite bat l\'ambiant', () => {
+    const env = tmpCatalog('env');
+    const flag = tmpCatalog('flag');
+    process.env.ESSAIM_CATALOG = env;
+
+    // Dernier gagne : le flag doit arriver APRÈS l'env.
+    expect(getCatalogRoots({ catalogs: [flag] })).toEqual([getBundledRoot(), env, flag]);
+  });
+
+  it('le catalogue projet-local (.essaim/) gagne sur tout — c\'est le plus local', () => {
+    const flag = tmpCatalog('flag');
+    const proj = tmpCatalog('proj');
+    const local = join(proj, '.essaim');
+    mkdirSync(join(local, 'presets'), { recursive: true });
+
+    const roots = getCatalogRoots({ catalogs: [flag], projectPath: proj });
+    expect(roots[roots.length - 1]).toBe(local);
+  });
+
+  it('un projet sans .essaim/ n\'ajoute rien', () => {
+    const proj = tmpCatalog('proj');
+    expect(getCatalogRoots({ projectPath: proj })).toEqual([getBundledRoot()]);
+  });
+
+  it('un --catalog inexistant ÉCHOUE, avec le chemin dans le message', () => {
+    // Une faute de frappe ne doit jamais dégénérer en no-op silencieux : le
+    // catalogue serait simplement ignoré et l'erreur ressortirait deux écrans plus
+    // loin en « Unknown template ».
+    const bidon = join(tmpdir(), 'catalogue-qui-nexiste-pas-xyz');
+    expect(() => getCatalogRoots({ catalogs: [bidon] })).toThrow(/catalogue-qui-nexiste-pas-xyz/);
+  });
+
+  it('deux résolutions successives avec des catalogues différents ne se contaminent pas', () => {
+    // Le cache module-level ne doit mettre en cache QUE la racine bundlée. Sinon le
+    // 2e step d'un pipeline (ou le 2e test d'un fichier) réutilise le catalogue du 1er.
+    const a = tmpCatalog('a');
+    const b = tmpCatalog('b');
+
+    expect(getCatalogRoots({ catalogs: [a] })).toEqual([getBundledRoot(), a]);
+    expect(getCatalogRoots({ catalogs: [b] })).toEqual([getBundledRoot(), b]);
+  });
+});
+
+describe('catalogue externe — bout en bout', () => {
+  it('template externe → preset externe → behavior BUNDLÉ : le cas qui échoue aujourd\'hui', () => {
+    const cat = tmpCatalog('maison');
+
+    // Un preset maison qui réutilise un behavior du catalogue bundlé.
+    writeFileSync(join(cat, 'presets', 'mon-preset.yaml'), [
+      'name: mon-preset',
+      'description: "preset maison"',
+      'profile: codeur',
+      'behaviors:',
+      '  - project-context', // bundlé
+      '  - mon-behavior',    // maison
+    ].join('\n'));
+
+    writeFileSync(join(cat, 'behaviors', 'mon-behavior.yaml'), [
+      'name: mon-behavior',
+      'description: "behavior maison"',
+      'sections:',
+      '  "030-mission":',
+      '    prompt: "MISSION MAISON"',
+    ].join('\n'));
+
+    writeFileSync(join(cat, 'templates', 'mon-template.yaml'), [
+      'name: Mon Template',
+      'description: "template maison"',
+      'phase: 1',
+      'workspace: shared',
+      'stagger: { mode: fixed, delay: [0, 0] }',
+      'timeout_minutes: 5',
+      'metrics: []',
+      'compare_mode: false',
+      'agents:',
+      '  - idPrefix: maison',
+      '    namePrefix: Maison',
+      '    preset: mon-preset',
+      '    profile: codeur',
+      '    count: 1',
+    ].join('\n'));
+
+    const project = buildProject('mon-template', CONTEXT, { catalogs: [cat] });
+
+    expect(project.agents).toHaveLength(1);
+    expect(project.agents[0].prompt).toContain('MISSION MAISON'); // behavior maison
+    expect(project.agents[0].prompt).toContain('Contexte du projet'); // behavior bundlé
+  });
+
+  it('un template externe apparaît dans listTemplates', () => {
+    const cat = tmpCatalog('liste');
+    writeFileSync(join(cat, 'templates', 'visible.yaml'), [
+      'name: Visible', 'description: "d"', 'phase: 1', 'workspace: shared',
+      'stagger: { mode: fixed, delay: [0, 0] }', 'timeout_minutes: 5',
+      'metrics: []', 'compare_mode: false',
+      'agents:',
+      '  - { idPrefix: a, namePrefix: A, preset: raid, profile: codeur, count: 1 }',
+    ].join('\n'));
+
+    const ids = listTemplates(undefined, { catalogs: [cat] }).map((t) => t.id);
+    expect(ids).toContain('visible');
+    // Sans le catalogue, il n'existe pas.
+    expect(listTemplates().map((t) => t.id)).not.toContain('visible');
+  });
+
+  it('un preset externe peut ÉCRASER un preset bundlé (dernier gagne)', () => {
+    const cat = tmpCatalog('override');
+    writeFileSync(join(cat, 'behaviors', 'project-context.yaml'), [
+      'name: project-context',
+      'description: "surcharge maison"',
+      'sections:',
+      '  "000-ctx":',
+      '    prompt: "CONTEXTE SURCHARGE"',
+    ].join('\n'));
+
+    writeFileSync(join(cat, 'templates', 'o.yaml'), [
+      'name: O', 'description: "d"', 'phase: 1', 'workspace: shared',
+      'stagger: { mode: fixed, delay: [0, 0] }', 'timeout_minutes: 5',
+      'metrics: []', 'compare_mode: false',
+      'agents:',
+      '  - { idPrefix: a, namePrefix: A, preset: raid, profile: codeur, count: 1 }',
+    ].join('\n'));
+
+    const project = buildProject('o', CONTEXT, { catalogs: [cat] });
+    expect(project.agents[0].prompt).toContain('CONTEXTE SURCHARGE');
+  });
+});


### PR DESCRIPTION
Requiert **@swoofer/promptweave ^0.3.0** (multi-racines, swoofer/promptweave#9 — publiée).

## Le manque

essaim ne sait charger **qu''un** catalogue : le sien.

Les **templates** ont une surcharge projet-locale (`.essaim/templates/`). Les **presets** et **behaviors**, non. Donc un template maison ne peut que **recombiner ce qu''essaim livre déjà** — dès qu''il référence un preset maison :

```
Preset "mon-preset" not found in registry. Available: arene-player, babel-reviewer, …
```

Toute organisation qui veut ses propres presets doit **patcher le repo**. C''est exactement pour ça que 21 artefacts d''une seule organisation vivent aujourd''hui dans le catalogue bundlé.

## Précédence — le dernier gagne

```
bundlé  <  ESSAIM_CATALOG  <  --catalog  <  <projet>/.essaim
```

Du plus général au plus local. **L''explicite bat l''ambiant** : une variable d''environnement posée il y a des mois ne doit pas silencieusement l''emporter sur ce que l''utilisateur vient de taper.

## Ce qui aurait cassé en silence — et qui ne le peut plus

- **Le cache de résolution** ne garde que la racine **bundlée**. Sinon le 2ᵉ step d''un pipeline (ou le 2ᵉ test d''un fichier) hériterait des catalogues du 1ᵉʳ et assemblerait des prompts depuis un catalogue que personne n''a choisi.
- **Un `--catalog` inexistant échoue**, chemin dans le message. Le registry tolère un dossier absent (un overlay n''a pas à porter les trois), mais un chemin que l''utilisateur a **tapé** ne doit jamais dégénérer en no-op : la faute de frappe ressortirait deux écrans plus loin en « Unknown template », et on chercherait le bug dans le template.
- **« Unknown template » liste les catalogues consultés.**
- **`buildParamTypeMap` lit toutes les racines.** Sinon le type déclaré d''un param d''un behavior externe est perdu, et `--set mon-behavior.projet=2026` passe par `JSON.parse` : le slug `"2026"` devient le **nombre** 2026. Aucune erreur, juste un prompt subtilement faux.
- **`$BCE_SCRIPTS_DIR`** cherche le script dans toutes les racines. Claude Code **n''échoue pas fort** sur un hook manquant : un hook déclaré par un behavior externe pointerait dans le vide, sans un mot.
- **`ESSAIM_CATALOG` est splitté sur `path.delimiter`**, jamais sur `:` — ça couperait `C:\...` en deux sous Windows, où ce repo est développé.
- **Les pipelines peuvent déclarer `catalog:`** (chemins relatifs au fichier pipeline). Sans ça, la clé aurait été jetée en « unknown key (ignored) ».

## Le piège du caret

`"@swoofer/promptweave": "^0.1.0"` **ne monte pas** en 0.3.0 (sémantique du caret sur les versions `0.x`). L''oublier donne un essaim qui **compile** (types locaux) et **ignore les catalogues externes en silence**. Le bump est dans ce PR.

## Compatibilité

Sans `--catalog` ni `ESSAIM_CATALOG`, le comportement est **strictement inchangé**. `readBceAsset` supprimé au passage (code mort, aucun appelant).

## Vérification

10 tests, dont le cas qui échoue aujourd''hui : **template externe → preset externe → behavior bundlé**. `npm test` → **420 verts**, build propre.

Et vérifié **en CLI de bout en bout** — ce qui a révélé un vrai bug que les tests unitaires n''auraient pas vu : `--catalog` **n''était pas transmis à `executeRun`**. Le pré-vol validait le template, puis le run perdait le catalogue. `ESSAIM_CATALOG` marchait, le flag non.