### PR TITLE
fix(mqtt): preserve coordinator URL path when deriving the WS URL

### DIFF
--- a/src/orchestrator/agent-launcher.ts
+++ b/src/orchestrator/agent-launcher.ts
@@ -92,10 +92,13 @@ export function launchAgent(
  * Derive the MQTT WebSocket URL from the coordinator HTTP URL.
  * http://localhost:3100 → ws://localhost:3100/mqtt
  */
-function mqttWsUrl(coordinatorUrl: string): string {
+export function mqttWsUrl(coordinatorUrl: string): string {
   const u = new URL(coordinatorUrl);
   const protocol = u.protocol === "https:" ? "wss:" : "ws:";
-  return `${protocol}//${u.host}/mqtt`;
+  // Preserve any path prefix (coordinator served under a sub-path behind an
+  // ingress); strip a trailing slash so we don't emit `//mqtt`.
+  const base = u.pathname.replace(/\/+$/, "");
+  return `${protocol}//${u.host}${base}/mqtt`;
 }
 
 /**

--- a/tests/unit/mqtt-ws-url.test.ts
+++ b/tests/unit/mqtt-ws-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { mqttWsUrl } from "../../src/orchestrator/agent-launcher.js";
+
+describe("mqttWsUrl", () => {
+  it("maps http coordinator to ws /mqtt", () => {
+    expect(mqttWsUrl("http://localhost:3100")).toBe("ws://localhost:3100/mqtt");
+  });
+
+  it("maps https coordinator to wss /mqtt", () => {
+    expect(mqttWsUrl("https://coordinator.example.com")).toBe(
+      "wss://coordinator.example.com/mqtt",
+    );
+  });
+
+  it("keeps an explicit port", () => {
+    expect(mqttWsUrl("https://host.example.com:8443")).toBe("wss://host.example.com:8443/mqtt");
+  });
+
+  it("preserves a path prefix (coordinator served under a sub-path)", () => {
+    // Regression: mqttWsUrl used to drop the path, producing wss://host/mqtt
+    // and breaking the WS upgrade behind a path-prefixed ingress.
+    expect(mqttWsUrl("https://gw.example.com/coordinator")).toBe(
+      "wss://gw.example.com/coordinator/mqtt",
+    );
+  });
+
+  it("does not double the slash when the base URL has a trailing slash", () => {
+    expect(mqttWsUrl("https://gw.example.com/coordinator/")).toBe(
+      "wss://gw.example.com/coordinator/mqtt",
+    );
+  });
+
+  it("a root path stays a single /mqtt (no empty segment)", () => {
+    expect(mqttWsUrl("http://localhost:3100/")).toBe("ws://localhost:3100/mqtt");
+  });
+});


### PR DESCRIPTION
## Why

`mqttWsUrl()` derived the MQTT-over-WebSocket URL from the coordinator URL using only `u.host`, dropping any path prefix. A coordinator served under a sub-path (e.g. `https://gw.example.com/coordinator` behind a path-routing ingress) produced `wss://gw.example.com/mqtt` instead of `wss://gw.example.com/coordinator/mqtt` — a broken upgrade target. Surfaced while investigating the MQTT reconnect loop (#33).

## Fix

Preserve `u.pathname` (trailing slash stripped so a root path still yields a single `/mqtt`):

```
wss://host            /mqtt          (root — unchanged)
wss://host/coordinator/mqtt          (sub-path — now correct)
```

The function is now exported so it can be unit-tested.

## Tests

New `tests/unit/mqtt-ws-url.test.ts` — 6 cases: http→ws, https→wss, explicit port, path-prefix preservation (the regression), trailing-slash no-double, and root path. All pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
