### PR TITLE
fix(agent-loop): release claim and stop reporting success when still rate-limited after retry

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -1000,6 +1000,9 @@ export async function runAgentLoop(
                   }
                 } else {
                   logger.error("Work-stealing: still rate limited after wait — stopping");
+                  await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
+                  claimedThreadIds.delete(task.id);
+                  exitReason = "rate_limited";
                   break;
                 }
                 continue;

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1375,6 +1375,47 @@ describe("runAgentLoop — phased mode", () => {
     );
   });
 
+  it("unclaims task and does not report success when still rate limited after retry", async () => {
+    vi.useFakeTimers();
+
+    let claimCall = 0;
+    mockClaimNextTask.mockImplementation(async () => {
+      claimCall++;
+      if (claimCall === 1) return { id: "t-stuck", description: "task that stays rate limited", file: undefined, severity: undefined };
+      return null;
+    });
+
+    // Discovery phase
+    mockSend.mockResolvedValueOnce({ content: "DISCOVERY:\nitem", toolCalls: [], costUsd: 0.01, durationMs: 100, sessionId: "s1" });
+    mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
+
+    // Execute phase: first attempt rate limited, retry after wait still rate limited
+    mockSend.mockResolvedValueOnce({ content: "", toolCalls: [], costUsd: 0, durationMs: 100, sessionId: "s1", rateLimited: true, rateLimitResetsAt: undefined });
+    mockSend.mockResolvedValueOnce({ content: "", toolCalls: [], costUsd: 0, durationMs: 100, sessionId: "s1", rateLimited: true, rateLimitResetsAt: undefined });
+
+    const config = makeConfig({
+      phases: [
+        { name: "discover", prompt: "Scan", toolsMode: "read_only", loop: false, effort: "low" },
+        { name: "execute",  prompt: "Fix",  toolsMode: "full",      loop: true,  effort: "high" },
+      ],
+    });
+
+    const loopPromise = runAgentLoop(config, silentLogger);
+    // Fallback rate-limit wait is 5min; advance well past it plus retry margins.
+    for (let i = 0; i < 40; i++) await vi.advanceTimersByTimeAsync(10_000);
+    const result = await loopPromise;
+
+    // The task must be released, not left claimed forever.
+    expect(mockUnclaimTask).toHaveBeenCalledWith(
+      "http://localhost:3100",
+      "t-stuck",
+      "test-agent",
+    );
+    expect(mockCompleteTask).not.toHaveBeenCalled();
+    // A run that never got past a rate limit must not be stamped as a success.
+    expect(result.exitReason).not.toBe("done");
+  });
+
   it("does NOT cycle when maxDiscoverCycles is absent (default)", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
Fixes a false-success + leaked-claim bug on the work-stealing rate-limit path.

## The bug

`runAgentLoop`'s rate-limit handling has three branches. Two of them, on giving up, correctly release the claimed task before `break`: they `unclaimTask(...)`, `claimedThreadIds.delete(task.id)`, and set `exitReason`. The third — "still rate limited after wait — stopping" — only logged and broke. So:

- the task stayed **claimed** at the coordinator (no other agent could pick it up), and
- because `exitReason` stays at its initial `"done"`, the run was stamped as a **success** in the summary even though it stopped without doing the work.

## Fix

Mirror the two sibling branches on the still-rate-limited path: `await unclaimTask(config.coordinatorUrl, task.id, config.agentId)`, `claimedThreadIds.delete(task.id)`, and `exitReason = "rate_limited"` before `break`. No other logic changed.

## Tests

`tests/unit/agent-loop.test.ts`: a new test drives the loop into rate-limited → retry → still-rate-limited and asserts the task is unclaimed and the run is not reported as `"done"`. Written test-first (red before the fix, green after). `npm run build` clean; full suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
