### PR TITLE
fix(work-stealing): re-fetch active threads after a lost claim race to narrow the one-file-one-agent TOCTOU

### DIFF
--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -110,16 +110,11 @@ export async function postDiscoveries(
 }
 
 /**
- * Atomically claim the next available task from the coordinator.
- * Uses POST /api/claim-task which does UPDATE WHERE claimed_by IS NULL.
- * Returns null if no tasks available.
+ * Fetch active threads from the coordinator, scoped to the current run.
+ * Returns null on any failure (unreachable coordinator or non-ok response) —
+ * callers treat that as "nothing to claim right now".
  */
-export async function claimNextTask(
-  coordinatorUrl: string,
-  agentId: string,
-): Promise<Task | null> {
-  // Get all active threads
-  let threads: Array<Record<string, unknown>>;
+async function fetchActiveThreads(coordinatorUrl: string): Promise<Array<Record<string, unknown>> | null> {
   try {
     const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
       method: "POST",
@@ -129,31 +124,49 @@ export async function claimNextTask(
       // visible — the coordinator's filter keeps them on purpose.
       body: JSON.stringify({ run_id: currentRunId() }),
     });
-    if (!resp.ok) { log.warn("claimNextTask: threads-active failed", { status: resp.status }); return null; }
+    if (!resp.ok) { log.warn("fetchActiveThreads: threads-active failed", { status: resp.status }); return null; }
     const data = await resp.json();
-    threads = Array.isArray(data) ? data : [];
+    return Array.isArray(data) ? data : [];
   } catch (err) {
-    log.warn("claimNextTask: coordinator unreachable", { error: (err as Error).message });
+    log.warn("fetchActiveThreads: coordinator unreachable", { error: (err as Error).message });
     return null;
   }
+}
 
-  const open = threads.filter((t) => t.status === "open");
-  const unclaimed = open.filter((t) => !t.claimed_by);
-  log.debug(`claimNextTask: ${threads.length} active, ${open.length} open, ${unclaimed.length} unclaimed`);
-
-  // One agent per file (#30). Three hunters that each posted their own discovery
-  // for a single bug produce three threads on the same file; claiming is atomic
-  // per THREAD, so each hunter took one and all three wrote a near-identical
-  // repro test. Excluding files another agent is actively working makes the
-  // de-duplication structural instead of asking the LLM to notice — which is
-  // also, exactly, what the coordinator exists to do.
+// One agent per file (#30). Three hunters that each posted their own discovery
+// for a single bug produce three threads on the same file; claiming is atomic
+// per THREAD, so each hunter took one and all three wrote a near-identical
+// repro test. Excluding files another agent is actively working makes the
+// de-duplication structural instead of asking the LLM to notice — which is
+// also, exactly, what the coordinator exists to do.
+function computeBusyFiles(openThreads: Array<Record<string, unknown>>, agentId: string): Set<string> {
   const busyFiles = new Set<string>();
-  for (const t of open) {
+  for (const t of openThreads) {
     const owner = t.claimed_by as string | null | undefined;
     if (owner && owner !== agentId) {
       for (const f of threadFiles(t)) busyFiles.add(f);
     }
   }
+  return busyFiles;
+}
+
+/**
+ * Atomically claim the next available task from the coordinator.
+ * Uses POST /api/claim-task which does UPDATE WHERE claimed_by IS NULL.
+ * Returns null if no tasks available.
+ */
+export async function claimNextTask(
+  coordinatorUrl: string,
+  agentId: string,
+): Promise<Task | null> {
+  const threads = await fetchActiveThreads(coordinatorUrl);
+  if (threads === null) return null;
+
+  const open = threads.filter((t) => t.status === "open");
+  const unclaimed = open.filter((t) => !t.claimed_by);
+  log.debug(`claimNextTask: ${threads.length} active, ${open.length} open, ${unclaimed.length} unclaimed`);
+
+  let busyFiles = computeBusyFiles(open, agentId);
 
   // What has already LANDED on each file this run, so the executing agent can
   // recognise a duplicate rather than re-committing it.
@@ -208,6 +221,18 @@ export async function claimNextTask(
         };
       }
       log.info(`claim race lost thread=${threadId} to ${(result as Record<string, unknown>).claimed_by as string}: ${subject.slice(0, 60)}`);
+      // Lost the race: another agent's claim landed between our snapshot and
+      // this attempt, so busyFiles may already be stale for the NEXT
+      // candidate. Re-fetch and recompute before evaluating it. This narrows
+      // the TOCTOU window (#30 doesn't get worse) — it does NOT close it:
+      // claim-task is atomic only on thread_id, not on file, so a race can
+      // still land in the gap between this refetch and the next claim
+      // attempt. Closing it fully needs server-side atomicity over the file,
+      // i.e. a coordinator change — out of scope here.
+      const refreshed = await fetchActiveThreads(coordinatorUrl);
+      if (refreshed !== null) {
+        busyFiles = computeBusyFiles(refreshed.filter((t) => t.status === "open"), agentId);
+      }
     } catch (err) {
       log.warn(`claim error: ${threadId}`, { error: (err as Error).message });
     }

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -95,3 +95,45 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
     expect(task?.relatedDone?.join(' ')).toContain('receipt_date');
   });
 });
+
+describe('claimNextTask — refetch après course perdue (fenêtre TOCTOU réduite, pas fermée)', () => {
+  it('après un claim perdu, re-fetch threads-active et exclut le fichier devenu occupé avant le candidat suivant', async () => {
+    let threadsActiveCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/threads-active')) {
+        threadsActiveCalls++;
+        if (threadsActiveCalls === 1) {
+          // Snapshot initial : les deux fichiers sont libres.
+          return new Response(JSON.stringify([
+            { id: 't1', status: 'open', claimed_by: null, target_files: ['fileA.ts'] },
+            { id: 't2', status: 'open', claimed_by: null, target_files: ['fileB.ts'] },
+          ]), { status: 200 });
+        }
+        // Re-fetch déclenché après la course perdue sur t1 : entre-temps, un
+        // autre agent a claim un thread sur fileB — invisible dans le snapshot
+        // initial, mais visible ici.
+        return new Response(JSON.stringify([
+          { id: 't1', status: 'open', claimed_by: 'autre-agent', target_files: ['fileA.ts'] },
+          { id: 't2', status: 'open', claimed_by: null, target_files: ['fileB.ts'] },
+          { id: 't3', status: 'open', claimed_by: 'autre-agent', target_files: ['fileB.ts'] },
+        ]), { status: 200 });
+      }
+      if (url.endsWith('/api/claim-task')) {
+        const body = JSON.parse((init!.body as string)) as { thread_id: string };
+        // t1 perd toujours la course ; t2 ne devrait jamais être tenté une fois
+        // que le refetch a révélé que fileB est occupé.
+        const ok = body.thread_id !== 't1';
+        return new Response(JSON.stringify({ success: ok, claimed_by: ok ? null : 'autre-agent' }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task).toBeNull();
+    expect(threadsActiveCalls).toBeGreaterThanOrEqual(2);
+    const claimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/claim-task'));
+    expect(claimed).toHaveLength(1); // t2 correctement écarté après le refetch
+  });
+});


### PR DESCRIPTION
Narrows a TOCTOU race in the "one file, one agent" work-stealing guard.

## The race

`claimNextTask` built its `busyFiles` set **once**, from a single `/api/threads-active` snapshot taken before the claim loop, then checked every candidate for the whole loop against that stale set. Between the snapshot and a later claim attempt, another agent can claim a thread on a file this agent still believes is free — so two agents end up working the same file on different threads (`/api/claim-task` is atomic on `thread_id`, not on the file).

## Fix

Extracted the existing inline fetch and busy-file computation into `fetchActiveThreads()` / `computeBusyFiles()` (no behavior change), and — new — after any claim attempt that loses the race (`success:false`), re-fetch `/api/threads-active` and recompute `busyFiles` before evaluating the next candidate. The success path is unchanged.

**Scope (intentionally honest):** this *narrows* the window, it does not close it — a race can still land between the re-fetch and the next claim, because the coordinator is atomic only per thread. Fully closing it needs server-side atomicity over the file (a coordinator change), which is out of scope for this repo. The code comment says the same.

## Tests

`tests/unit/claim-dedup.test.ts`: a call-count-aware test simulates a lost race on the first candidate followed by a re-fetch that reveals the second candidate's file just became busy, and asserts `claim-task` is called only once and the result is `null`. Red before the fix (old code claimed the second thread), green after. `npm run build` clean; suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
