### PR TITLE
fix(mqtt): honor the reconnect budget on post-connect errors and catch up consultations missed while offline

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -431,6 +431,7 @@ export async function runAgentLoop(
     url: config.mqttUrl,
     agentId: config.agentId,
     agentModules: config.modules,
+    coordinatorUrl: config.coordinatorUrl,
   });
 
   const protocol: CoordinationProtocol = createCoordinationProtocol(config.agentId);

--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -1,7 +1,8 @@
 import mqtt from "mqtt";
 import { Duplex } from "stream";
 import { createLogger } from "../logger.js";
-import { coordinatorToken } from "../coordinator-auth.js";
+import { coordinatorToken, authHeaders } from "../coordinator-auth.js";
+import { currentRunId } from "../run-id.js";
 const log = createLogger("mqtt-listener");
 
 const isBun = !!(process.versions as Record<string, string>)?.bun;
@@ -65,6 +66,11 @@ export interface MqttListenerOptions {
   url: string;             // mqtt://localhost:1883 (TCP) or ws://localhost:3100/mqtt (WebSocket)
   agentId: string;
   agentModules: string[];
+  // Coordinator REST base URL. When set, enables a catch-up fetch of
+  // currently open consultations on every (re)connect (see #113 below).
+  // Optional so callers that only need push notifications (or tests) can
+  // omit it — catch-up simply stays disabled in that case.
+  coordinatorUrl?: string;
 }
 
 export type InterruptType =
@@ -180,12 +186,18 @@ const RECONNECT_PERIOD_MS = 5_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 
 export function createMqttListener(options: MqttListenerOptions): MqttListener {
-  const { url, agentId } = options;
+  const { url, agentId, coordinatorUrl } = options;
   let client: mqtt.MqttClient | null = null;
   let isConnected = false;
+  let hasConnected = false;
   let reconnectAttempts = 0;
   let gaveUp = false;
   const queue: MqttInterrupt[] = [];
+
+  // Thread/consultation ids already delivered to this listener — via a live
+  // MQTT message or a previous catch-up — so the catch-up fetch below never
+  // re-queues the same consultation twice across reconnects.
+  const seenThreadIds = new Set<string>();
 
   /** Tear the client down for good — stops mqtt.js's endless auto-reconnect. */
   function giveUp(reason: string): void {
@@ -213,8 +225,63 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
     if (!type) return;
 
     const interrupt = buildInterrupt(type, topic, payload);
+    if (interrupt.threadId) seenThreadIds.add(interrupt.threadId);
     log.debug("message", { type, threadId: interrupt.threadId });
     queue.push(interrupt);
+  }
+
+  // mqtt.js subscribes at QoS 0 with clean:true and a randomized clientId per
+  // connect (below), so no broker session survives a disconnect — anything
+  // published to `coordinator/consultations/*` while this client was offline
+  // is gone with no redelivery. QoS/clean-session changes alone can't fix
+  // that without broker-side persistence we don't control here. Instead, on
+  // every (re)connect we do a catch-up fetch of currently open consultations
+  // via the coordinator's existing /api/threads-active endpoint — the same
+  // one work-stealing.ts already polls for open threads — and re-queue
+  // anything this listener hasn't seen yet.
+  async function catchUpOpenConsultations(): Promise<void> {
+    if (!coordinatorUrl) return; // no REST base configured — nothing to catch up on
+
+    let threads: Array<Record<string, unknown>>;
+    try {
+      const resp = await fetch(`${coordinatorUrl}/api/threads-active`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders() },
+        body: JSON.stringify({ run_id: currentRunId() }),
+      });
+      if (!resp.ok) {
+        log.debug("catch-up: threads-active failed", { status: resp.status });
+        return;
+      }
+      const data = await resp.json();
+      threads = Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
+    } catch (err) {
+      log.debug("catch-up: coordinator unreachable", { error: (err as Error).message });
+      return;
+    }
+
+    let recovered = 0;
+    for (const thread of threads) {
+      if (thread.status !== "open") continue;
+      if (thread.agent_id === agentId) continue; // filter self, same as handleMessage
+
+      const threadId = thread.id as string | undefined;
+      if (!threadId || seenThreadIds.has(threadId)) continue;
+      seenThreadIds.add(threadId);
+
+      queue.push({
+        type: "consultation_new",
+        threadId,
+        subject: typeof thread.subject === "string" ? thread.subject : undefined,
+        targetModules: Array.isArray(thread.target_modules) ? (thread.target_modules as string[]) : undefined,
+        timestamp: Date.now(),
+        raw: thread,
+      });
+      recovered++;
+    }
+    if (recovered > 0) {
+      log.info("catch-up: recovered open consultations missed while offline", { count: recovered });
+    }
   }
 
   return {
@@ -259,8 +326,10 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
 
         client.on("connect", () => {
           clearTimeout(timeout);
+          hasConnected = true;
           isConnected = true;
           reconnectAttempts = 0; // a successful connect earns a fresh budget
+          void catchUpOpenConsultations();
           client!.subscribe(TOPICS, (err) => {
             if (err) {
               reject(err);
@@ -274,6 +343,16 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         client.on("message", handleMessage);
 
         client.on("error", (err) => {
+          if (hasConnected) {
+            // A transient error after a successful connect (e.g. a network
+            // blip). mqtt.js will follow up with "close" then "reconnect",
+            // and the MAX_RECONNECT_ATTEMPTS budget on that handler below
+            // already governs whether we keep retrying — giving up and
+            // rejecting here would bypass that budget and kill the listener
+            // on a single post-connect error.
+            log.warn("post-connect error — reconnect budget governs retry", { error: (err as Error).message });
+            return;
+          }
           clearTimeout(timeout);
           log.warn("connection failed", { error: (err as Error).message });
           // Without this teardown the client keeps auto-reconnecting in the

--- a/tests/unit/mqtt-backoff.test.ts
+++ b/tests/unit/mqtt-backoff.test.ts
@@ -65,4 +65,31 @@ describe('mqtt-listener — backoff et abandon (#33)', () => {
     for (let i = 0; i < 3; i++) fake.emit('reconnect');
     expect(fake.end).not.toHaveBeenCalled();
   });
+
+  // Regression — a post-connect "error" (a plain network blip) used to call
+  // giveUp()+reject() immediately, never consulting the MAX_RECONNECT_ATTEMPTS
+  // budget the "reconnect" handler is meant to govern.
+  it('a post-connect error does not give up — the reconnect budget stays in charge', async () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    const promise = listener.connect();
+    fake.emit('connect');
+    await promise;
+    expect(listener.connected).toBe(true);
+
+    fake.emit('error', new Error('transient network blip'));
+    expect(fake.end).not.toHaveBeenCalled();
+
+    // The reconnect budget still governs attempts afterwards.
+    for (let i = 0; i < 10; i++) fake.emit('reconnect');
+    expect(fake.end).toHaveBeenCalled();
+  });
+
+  it('an error before any connection still gives up immediately', async () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    const promise = listener.connect();
+    fake.emit('error', new Error('initial refusal'));
+    await expect(promise).rejects.toThrow('initial refusal');
+    expect(fake.end).toHaveBeenCalled();
+    expect(listener.connected).toBe(false);
+  });
 });

--- a/tests/unit/mqtt-listener.test.ts
+++ b/tests/unit/mqtt-listener.test.ts
@@ -294,5 +294,87 @@ describe("MqttListener", () => {
       expect(msgs[0].raw).toEqual(payload);
     });
   });
+
+  // Regression — QoS 0 + clean:true + a fresh clientId per connect means no
+  // broker session survives a disconnect, so anything published while this
+  // client was offline was lost with no redelivery. A catch-up fetch of
+  // currently open consultations on (re)connect recovers what was missed.
+  describe("catch-up on connect", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    async function connectWithCatchUp(fetchMock: ReturnType<typeof vi.fn>) {
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const listener = createMqttListener({ ...OPTIONS, coordinatorUrl: "http://coordinator.local" });
+      const connectPromise = listener.connect();
+      mockClient.emit("connect");
+      await connectPromise;
+      // Let the fire-and-forget catch-up fetch resolve.
+      await new Promise((r) => setTimeout(r, 0));
+      return listener;
+    }
+
+    it("processes a missed open consultation exactly once on connect", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { id: "t-100", status: "open", subject: "Missed while offline", agent_id: "agent-2" },
+          { id: "t-101", status: "resolved", subject: "Already done", agent_id: "agent-2" },
+        ],
+      });
+
+      const listener = await connectWithCatchUp(fetchMock);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://coordinator.local/api/threads-active",
+        expect.objectContaining({ method: "POST" }),
+      );
+      const msgs = listener.drain();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("consultation_new");
+      expect(msgs[0].threadId).toBe("t-100");
+      expect(msgs[0].subject).toBe("Missed while offline");
+    });
+
+    it("does not reprocess a consultation already seen via a live message", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ id: "t-1", status: "open", subject: "Auth redesign", agent_id: "agent-2" }],
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const listener = createMqttListener({ ...OPTIONS, coordinatorUrl: "http://coordinator.local" });
+      const connectPromise = listener.connect();
+      mockClient.emit("connect");
+      await connectPromise;
+
+      // The live message arrives (and is queued) before the catch-up fetch resolves.
+      simulateMessage("coordinator/consultations/new", {
+        agent_id: "agent-2",
+        thread_id: "t-1",
+        subject: "Auth redesign",
+      });
+      expect(listener.peek()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Catch-up must not queue a duplicate for t-1.
+      expect(listener.peek()).toBe(1);
+    });
+
+    it("skips the catch-up fetch entirely when no coordinatorUrl is configured", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const listener = await connectListener(); // OPTIONS has no coordinatorUrl
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(listener.peek()).toBe(0);
+    });
+  });
 });
 


### PR DESCRIPTION
Two independent MQTT-resilience fixes in the agent-loop listener.

## Fix A — post-connect errors no longer bypass the reconnect budget

`client.on("error", …)` unconditionally tore the client down and rejected on the **first** error. But mqtt.js follows a transient drop with `close` → `reconnect`, and the `reconnect` handler already enforces a `MAX_RECONNECT_ATTEMPTS` budget — which the error path never consulted. So a single post-connect network blip killed the listener outright, defeating the budget.

Now a `hasConnected` flag distinguishes the two cases: an error **after** a successful connect is logged and left to the `close`/`reconnect` machinery (which governs retries via the budget); an error **before** ever connecting keeps today's give-up-and-reject behavior. `reconnectAttempts` still resets to 0 on each successful connect.

## Fix B — catch up consultations missed while offline

The subscription is QoS 0 with `clean:true` and a randomized clientId per connect, so no broker session survives a disconnect — any consultation published while this client was offline is lost with no redelivery (QoS/clean-session changes alone can't fix that without broker-side persistence). On every `connect`/reconnect the listener now does a catch-up fetch of currently-open consultations via the coordinator's existing `POST /api/threads-active` endpoint (the same one `work-stealing.ts` already polls) and re-queues any this listener hasn't seen. A `seenThreadIds` set (populated by both live messages and catch-up) makes it idempotent across reconnects, and self-owned threads are filtered out. `coordinatorUrl` is a new optional listener option (wired from the agent-loop config); when unset, catch-up is simply disabled.

**Scope (honest):** catch-up recovers open-thread consultation state, not full per-message history — `threads-active` doesn't expose message history, so recovering that would need a coordinator-side change (out of scope here). Catch-up runs fire-and-forget relative to `connect()` (best-effort recovery; it never rejects the connect).

## Tests

`tests/unit/mqtt-backoff.test.ts` (Fix A): a post-connect `error` does not give up/reject and the listener survives under the budget; a pre-connect `error` still gives up. `tests/unit/mqtt-listener.test.ts` (Fix B): on reconnect the catch-up runs, a missed open consultation is queued exactly once, and already-seen threads are not re-queued. All test-first (red→green). `npm run build` clean; full suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
