### PR TITLE
fix(agent-launcher): resolve the claude binary and handle spawn errors instead of hanging

### DIFF
--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -215,7 +215,7 @@ export function createStreamParser(emitter: EventEmitter, readable: NodeJS.Reada
 
 // ── Resolve claude binary ─────────────────────────────────────────────
 
-function resolveClaudeBin(): string {
+export function resolveClaudeBin(): string {
   const envPath = process.env.CLAUDE_BIN;
   if (envPath) return envPath;
   const candidates = [

--- a/src/orchestrator/agent-launcher.ts
+++ b/src/orchestrator/agent-launcher.ts
@@ -2,6 +2,7 @@
 import { spawn, ChildProcess } from "child_process";
 import type { AgentConfig } from "./types.js";
 import { runAgentLoop, type AgentLoopConfig, type AgentLoopResult } from "../agent-loop/agent-loop.js";
+import { resolveClaudeBin } from "../agent-loop/claude-stream.js";
 
 const MCP_COORDINATOR_PREFIX = "mcp__coordinator__";
 
@@ -76,7 +77,7 @@ export function launchAgent(
     args.push("--mcp-config", mcpConfigPath);
   }
 
-  return spawn("claude", args, {
+  return spawn(resolveClaudeBin(), args, {
     cwd: workspacePath,
     env,
     stdio: ["ignore", "pipe", "pipe"],
@@ -191,9 +192,22 @@ export function waitForProcess(child: ChildProcess): Promise<{ stdout: string; s
   return new Promise((resolve) => {
     let stdout = "";
     let stderr = "";
+    let settled = false;
     child.stdout?.on("data", (d: Buffer) => (stdout += d.toString()));
     child.stderr?.on("data", (d: Buffer) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ stdout, stderr, code: code || 0 }));
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      resolve({ stdout, stderr, code: code || 0 });
+    });
+    // A spawn failure (e.g. binary not found) emits "error" instead of — or
+    // in addition to — "close". Without this handler the failure is either
+    // an unhandled Node error or leaves the promise hanging forever.
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      resolve({ stdout, stderr: stderr + (stderr ? "\n" : "") + err.message, code: 1 });
+    });
   });
 }
 

--- a/tests/unit/agent-launcher.test.ts
+++ b/tests/unit/agent-launcher.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter, Readable } from "stream";
+
+// ── Mock claude-stream's binary resolver so launchAgent reuses it ──────
+vi.mock("../../src/agent-loop/claude-stream.js", () => ({
+  resolveClaudeBin: vi.fn(() => "/resolved/path/to/claude"),
+}));
+
+function makeMockChild() {
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    stderr: Readable;
+  };
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  return proc;
+}
+
+let mockChildren: ReturnType<typeof makeMockChild>[] = [];
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(() => {
+    const child = makeMockChild();
+    mockChildren.push(child);
+    return child;
+  }),
+}));
+
+import { waitForProcess, launchAgent } from "../../src/orchestrator/agent-launcher.js";
+import type { AgentConfig } from "../../src/orchestrator/types.js";
+
+describe("waitForProcess", () => {
+  it("resolves with a failed result when spawn emits an error (does not hang or throw)", async () => {
+    const child = makeMockChild();
+    const p = waitForProcess(child as unknown as import("child_process").ChildProcess);
+
+    child.emit("error", new Error("spawn claude ENOENT"));
+
+    const result = await p;
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("spawn claude ENOENT");
+  });
+
+  it("still resolves normally on close", async () => {
+    const child = makeMockChild();
+    const p = waitForProcess(child as unknown as import("child_process").ChildProcess);
+
+    child.emit("close", 0);
+
+    const result = await p;
+    expect(result.code).toBe(0);
+  });
+
+  it("does not resolve twice if both error and close fire", async () => {
+    const child = makeMockChild();
+    const p = waitForProcess(child as unknown as import("child_process").ChildProcess);
+
+    child.emit("error", new Error("spawn claude ENOENT"));
+    child.emit("close", null);
+
+    const result = await p;
+    // The error path wins — code stays non-zero, not overwritten by the
+    // later close(null) → code:0 coercion.
+    expect(result.code).not.toBe(0);
+  });
+});
+
+describe("launchAgent", () => {
+  beforeEach(() => {
+    mockChildren = [];
+    vi.clearAllMocks();
+  });
+
+  it("spawns the resolved claude binary instead of a bare 'claude' string", async () => {
+    const { spawn } = await import("child_process");
+    const agent: AgentConfig = {
+      id: "a1",
+      name: "Agent One",
+      prompt: "do work",
+    } as AgentConfig;
+
+    launchAgent(agent, "/workspace", "http://localhost:3100", null);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [bin] = (spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(bin).toBe("/resolved/path/to/claude");
+  });
+});


### PR DESCRIPTION
Makes the orchestrator's agent spawn path fail gracefully instead of hanging or throwing unhandled.

## The problem

`launchAgent` called `spawn("claude", …)` with a bare binary name and no `shell`, and `waitForProcess` registered only a `close` listener — no `error` listener. So when the `claude` binary can't be spawned (not on PATH, non-login shell, Windows resolution quirks), Node emits an `error` event with no handler: the failure is unhandled and/or the `waitForProcess` promise never settles and the launch hangs. The agent-loop path (`claude-stream.ts`) already resolves the binary robustly and handles spawn errors — the orchestrator path didn't.

## Fix

- Reuse the existing `resolveClaudeBin()` from `claude-stream.ts` (now `export`ed; no behavior change) so `launchAgent` spawns the resolved path instead of a bare `"claude"` string. Binary-path resolution is preferred over `shell:true` — no shell-injection surface.
- `waitForProcess` now also listens for `child.on("error", …)` and resolves with a failed result (`code: 1`, the error message appended to `stderr`) instead of hanging/throwing. A `settled` flag guards against a double-resolve if both `error` and `close` fire.

## Tests

New `tests/unit/agent-launcher.test.ts`: a spawn `error` resolves `waitForProcess` to a failed result (no hang, no throw); a normal `close` still resolves as before; an error/close race does not double-resolve; and `launchAgent` spawns the resolved binary path rather than a bare string. Test-first (red→green). `npm run build` clean; full suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
