### PR TITLE
fix(claude-stream): decode stdout with setEncoding to stop multi-byte UTF-8 corruption across chunk boundaries

### DIFF
--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -184,8 +184,15 @@ export function buildArgs(opts: ClaudeStreamOptions, prompt: string, resume: boo
 export function createStreamParser(emitter: EventEmitter, readable: NodeJS.ReadableStream): void {
   let buffer = "";
 
-  readable.on("data", (chunk: Buffer) => {
-    buffer += chunk.toString();
+  // Decode as UTF-8 at the stream level so Node buffers any partial
+  // multi-byte sequence internally and only hands the "data" handler
+  // complete codepoints — otherwise a multi-byte character split across
+  // two chunks (e.g. by a TCP/pipe boundary) decodes as garbage on each
+  // half independently.
+  readable.setEncoding("utf8");
+
+  readable.on("data", (chunk: string) => {
+    buffer += chunk;
     const lines = buffer.split("\n");
     buffer = lines.pop()!;
 

--- a/tests/unit/claude-stream.test.ts
+++ b/tests/unit/claude-stream.test.ts
@@ -279,6 +279,21 @@ describe("createStreamParser", () => {
     await tick();
     expect(events).toHaveLength(1);
   });
+
+  it("correctly decodes a multi-byte UTF-8 character split across raw Buffer chunks", async () => {
+    createStreamParser(emitter, readable);
+    // "café" — the "é" is 2 bytes (0xC3 0xA9) in UTF-8. Split those two bytes
+    // across two separate Buffer chunks to simulate a TCP/pipe boundary landing
+    // mid-codepoint.
+    const prefix = Buffer.from('{"type":"system","subtype":"init","note":"caf', "utf8");
+    const suffix = Buffer.from('"}\n', "utf8");
+    const accent = Buffer.from("é", "utf8");
+    readable.push(Buffer.concat([prefix, accent.subarray(0, 1)]));
+    readable.push(Buffer.concat([accent.subarray(1), suffix]));
+    await tick();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "system", subtype: "init", note: "café" });
+  });
 });
 
 // ── createClaudeStream (spawn-per-turn model) ────────────────────────


### PR DESCRIPTION
Fixes multi-byte UTF-8 corruption in the Claude stdout stream parser.

## The bug

`createStreamParser` accumulated the child's stdout with `buffer += chunk.toString()` on each raw `Buffer` chunk, with no `setEncoding`/`StringDecoder`. When a multi-byte UTF-8 codepoint (e.g. "é", an emoji) is split across two chunk boundaries, each half is decoded independently and yields replacement characters — corrupting the streamed text.

## Fix

Call `readable.setEncoding("utf8")` once at the top of `createStreamParser`. Node then buffers partial multi-byte sequences internally and delivers already-decoded `string` chunks that never split a codepoint. The `data` handler's chunk type becomes `string` (dropping `.toString()`); no other parsing logic changed, and the single-byte/ASCII path is unaffected.

## Tests

`tests/unit/claude-stream.test.ts`: a new test pushes raw `Buffer`s through the real `Readable`, splitting the two bytes of "é" across separate `push()` calls inside a valid JSON line, and asserts the parsed output contains "é" — not replacement chars. (The existing "split chunks" test pushed decoded strings and so never exercised this.) Red before the fix (`caf��`), green after. `npm run build` clean; suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
