### PR TITLE
fix(track-activity): withhold sensitive file contents and authenticate the coordinator POST

### DIFF
--- a/scripts/track_activity.sh
+++ b/scripts/track_activity.sh
@@ -7,6 +7,41 @@ COORDINATOR_URL="${COORDINATOR_URL:-http://localhost:3100}"
 AGENT_ID="${COORDINATOR_AGENT_ID:-unknown}"
 AGENT_NAME="${COORDINATOR_AGENT_NAME:-unknown}"
 
+# Auth: when COORDINATOR_TOKEN is set, send it as a bearer token (same
+# convention as the TS side — see src/coordinator-auth.ts). Unset = no header.
+AUTH_HEADER=()
+if [ -n "${COORDINATOR_TOKEN:-}" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer $COORDINATOR_TOKEN")
+fi
+
+# Returns success (0) if FILE_PATH looks like it may hold secrets, in which
+# case its raw content must never be shipped to the coordinator — team-mode
+# sends this payload to a different host. File-activity tracking still
+# happens; only the content field is withheld.
+is_sensitive_path() {
+  local path="$1"
+  local base path_lc base_lc
+  base=$(basename -- "$path")
+  path_lc=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  base_lc=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+
+  case "$path_lc" in
+    */.ssh/*|.ssh/*|*/.aws/*|.aws/*) return 0 ;;
+  esac
+
+  case "$base_lc" in
+    .env|.env.*) return 0 ;;
+    *.pem|*.key|*.p12|*.pfx|*.keystore) return 0 ;;
+    id_rsa|id_rsa.*|id_dsa|id_dsa.*|id_ecdsa|id_ecdsa.*|id_ed25519|id_ed25519.*) return 0 ;;
+    kubeconfig|*.kubeconfig) return 0 ;;
+    credentials|credentials.*) return 0 ;;
+    .netrc|.npmrc|.pypirc) return 0 ;;
+    *secret*) return 0 ;;
+  esac
+
+  return 1
+}
+
 INPUT=$(cat 2>/dev/null)
 if [ -z "$INPUT" ]; then
   exit 0
@@ -36,15 +71,18 @@ if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
   FILE_PATH="${FILE_PATH//\\//}"
 fi
 
-# v0.6: include file content in the payload if under 256 KB
+# v0.6: include file content in the payload if under 256 KB and not sensitive
 SIZE=$(stat -c%s "$FILE_PATH" 2>/dev/null || stat -f%z "$FILE_PATH" 2>/dev/null || echo 999999)
-if [ "$SIZE" -lt 262144 ] && [ -f "$FILE_PATH" ]; then
+if is_sensitive_path "$FILE_PATH"; then
+  CONTENT="null"
+elif [ "$SIZE" -lt 262144 ] && [ -f "$FILE_PATH" ]; then
   CONTENT=$(jq -Rs . < "$FILE_PATH" 2>/dev/null || echo "null")
 else
   CONTENT="null"
 fi
 
 curl -s --max-time 1 -X POST "$COORDINATOR_URL/api/log-file" \
+  "${AUTH_HEADER[@]}" \
   -H "Content-Type: application/json" \
   -d "$(jq -n \
     --arg sid "$SESSION_ID" \

--- a/tests/track_activity_secret_filtering.test.sh
+++ b/tests/track_activity_secret_filtering.test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Unit test for track_activity.sh's is_sensitive_path denylist.
+# Extracts the function from the script (single source of truth) and exercises it.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$SCRIPT_DIR/scripts/track_activity.sh"
+
+# Pull just the function definition out of the hook script and load it, so the
+# test never runs the hook's stdin/curl side effects.
+eval "$(sed -n '/^is_sensitive_path()/,/^}/p' "$SRC")"
+
+fail=0
+assert_sensitive() {
+  if is_sensitive_path "$1"; then :; else echo "FAIL: expected sensitive: $1"; fail=1; fi
+}
+assert_ok() {
+  if is_sensitive_path "$1"; then echo "FAIL: expected NON-sensitive: $1"; fail=1; else :; fi
+}
+
+# Sensitive
+assert_sensitive ".env"
+assert_sensitive "config/.env.production"
+assert_sensitive "certs/server.pem"
+assert_sensitive "tls/server.key"
+assert_sensitive "home/user/.ssh/id_rsa"
+assert_sensitive "id_ed25519"
+assert_sensitive "deploy/kubeconfig"
+assert_sensitive "clusters/prod.kubeconfig"
+assert_sensitive "aws/credentials"
+assert_sensitive "app/my-secrets.yaml"
+assert_sensitive ".netrc"
+assert_sensitive "project/.npmrc"
+assert_sensitive "/home/u/.aws/config"
+assert_sensitive "vault.p12"
+
+# Non-sensitive
+assert_ok "src/index.ts"
+assert_ok "README.md"
+assert_ok "docs/design.md"
+assert_ok "package.json"
+
+if [ "$fail" -eq 0 ]; then echo "PASS: all is_sensitive_path cases"; else echo "TEST FAILURES"; exit 1; fi


### PR DESCRIPTION
Stops the activity-tracking hook from shipping secret file contents to the coordinator.

## The problem

`scripts/track_activity.sh` unconditionally slurped the full raw content of any edited file under 256KB and POSTed it to `$COORDINATOR_URL/api/log-file` with **no filtering and no auth header**. Team-mode sends that payload to a different host, so `.env` files, private keys, kubeconfig, credentials, etc. were exposed verbatim.

## Fix (scoped to the content-leak)

- **`is_sensitive_path()` denylist**, checked before the content slurp: `.ssh`/`.aws` path segments; `.env`/`.env.*`; `*.pem`/`*.key`/`*.p12`/`*.pfx`/`*.keystore`; `id_rsa`/`id_ed25519` and other private keys; `kubeconfig`/`*.kubeconfig`; `credentials`/`credentials.*`; `.netrc`/`.npmrc`/`.pypirc`; any basename containing `secret` (case-insensitive). A matched file still gets its **activity** tracked — only the `content` field is withheld (`null`). Non-sensitive files are unchanged.
- **Auth header**: send `Authorization: Bearer $COORDINATOR_TOKEN` on the `log-file` POST when the token is set (same convention as `src/coordinator-auth.ts`), unchanged when unset.

**Deliberately out of scope** (left as follow-ups so this stays a non-breaking security patch): gating content-shipping behind a new opt-in flag (would change the default and disable the feature for existing users) and forcing HTTPS.

## Tests

`tests/track_activity_secret_filtering.test.sh` extracts `is_sensitive_path` from the hook (single source of truth) and asserts it flags `.env`, `.env.production`, `*.pem`, `*.key`, `.ssh/id_rsa`, `id_ed25519`, `kubeconfig`, `*.kubeconfig`, `credentials`, `*secret*`, `.netrc`, `.npmrc`, `.aws/*`, `*.p12` as sensitive and leaves `src/index.ts`, `README.md`, `package.json` shippable. (vitest only runs `*.test.ts`, so this shell test is a runnable local check, not part of the CI job — the CI `test`/`build` jobs are unaffected because no TypeScript changed.)
