### PR TITLE
fix(coordination): request the decision LLM at most once per round

### DIFF
--- a/src/agent-loop/coordination-protocol.ts
+++ b/src/agent-loop/coordination-protocol.ts
@@ -30,6 +30,7 @@ export interface ThreadState {
   expectedRespondents: string[];
   respondedAgents: string[];
   round: number;
+  decideRequested: boolean;
 }
 
 // â”€â”€ Protocol actions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -141,6 +142,7 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
         expectedRespondents: result.expectedRespondents,
         respondedAgents: [],
         round: 1,
+        decideRequested: false,
       };
       threads.set(result.threadId, thread);
       messageBuffer.set(result.threadId, []);
@@ -171,8 +173,10 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
         thread.respondedAgents.push(fromAgentId);
       }
 
-      // If all respondents replied, ask the LLM to decide
-      if (allRespondentsReplied(thread)) {
+      // If all respondents replied, ask the LLM to decide — but only once
+      // per round, so a duplicate/replayed message doesn't re-enqueue it.
+      if (allRespondentsReplied(thread) && !thread.decideRequested) {
+        thread.decideRequested = true;
         enqueue({
           type: "ask_llm_decide",
           threadId,
@@ -225,6 +229,7 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
       // Back to waiting for a new round
       thread.round += 1;
       thread.respondedAgents = [];
+      thread.decideRequested = false;
       thread.status = "waiting";
       phase = "waiting";
       messageBuffer.set(threadId, []);

--- a/tests/unit/coordination-protocol.test.ts
+++ b/tests/unit/coordination-protocol.test.ts
@@ -386,15 +386,71 @@ describe("CoordinationProtocol", () => {
     const action1 = protocol.nextAction();
     expect(action1?.type).toBe("ask_llm_decide");
 
-    // Second message from same agent — respondent already tracked
+    // Second message from same agent — respondent already tracked, and a
+    // decision was already requested for this round, so no re-enqueue
     protocol.onThreadMessage("t-9", "agent-2", "follow-up");
-    // Still triggers another ask_llm_decide since all respondents are still complete
     const action2 = protocol.nextAction();
-    expect(action2?.type).toBe("ask_llm_decide");
+    expect(action2).toBeNull();
 
     // Thread state shows the agent only once in respondedAgents
     const thread = protocol.getThreadState("t-9");
     expect(thread?.respondedAgents).toEqual(["agent-2"]);
+  });
+
+  it("does not re-enqueue ask_llm_decide for a replayed thread message after quorum", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-9b",
+      status: "open",
+      expectedRespondents: ["agent-2", "agent-3"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    protocol.onThreadMessage("t-9b", "agent-2", "first from agent-2");
+    expect(protocol.nextAction()).toBeNull(); // not all responded yet
+
+    protocol.onThreadMessage("t-9b", "agent-3", "first from agent-3");
+    const decideAction = protocol.nextAction();
+    expect(decideAction?.type).toBe("ask_llm_decide"); // quorum reached
+
+    // A replayed/duplicate message arrives after the decision was already requested
+    protocol.onThreadMessage("t-9b", "agent-3", "replayed message");
+    expect(protocol.nextAction()).toBeNull();
+  });
+
+  it("allows a fresh ask_llm_decide after a contestation opens a new round", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-9c",
+      status: "open",
+      expectedRespondents: ["agent-2"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    // Round 1: reach quorum, decide, work, propose, contest
+    protocol.onThreadMessage("t-9c", "agent-2", "ok");
+    expect(protocol.nextAction()?.type).toBe("ask_llm_decide");
+    protocol.decideContinue();
+    drainActions(protocol);
+    protocol.workDone();
+    drainActions(protocol);
+    protocol.onResolutionProposed("t-9c");
+    drainActions(protocol);
+    protocol.onContestation("t-9c", "agent-2", "still conflicting");
+    drainActions(protocol);
+
+    expect(protocol.getThreadState("t-9c")?.round).toBe(2);
+
+    // Round 2: quorum should trigger a fresh ask_llm_decide
+    protocol.onThreadMessage("t-9c", "agent-2", "ok again");
+    const action = protocol.nextAction();
+    expect(action?.type).toBe("ask_llm_decide");
   });
 
   // ── Unknown thread ────────────────────────────────────────────────


### PR DESCRIPTION
Stops a redundant coordination-LLM call when a thread message is duplicated or replayed after quorum.

## The bug

In `onThreadMessage`, once `allRespondentsReplied(thread)` is true the protocol enqueued `ask_llm_decide` **every** time that condition re-evaluated true. `respondedAgents` de-dups the agent list, but the enqueue itself had no "already asked" guard — so a duplicate or replayed thread message arriving after all respondents had replied re-enqueued another `ask_llm_decide`, making the agent re-run the decision LLM needlessly.

## Fix

Added a `decideRequested: boolean` to `ThreadState` (initialised `false`). `ask_llm_decide` is now enqueued only when quorum is reached **and** `!thread.decideRequested`, setting the flag on enqueue — so the decision is requested at most once per round. `onContestation`, which already resets `respondedAgents` and bumps `round` to reopen the waiting phase, now also clears `decideRequested` so a legitimately re-opened round can ask again.

## Tests

`tests/unit/coordination-protocol.test.ts`:
- New: a replayed message after quorum enqueues **no** second `ask_llm_decide`.
- New: a contestation that opens a fresh round **does** allow a new `ask_llm_decide`.
- Corrected one pre-existing test whose assertion (and its own comment, "Still triggers another ask_llm_decide…") pinned the exact buggy behaviour — it reached quorum on the first message with a single expected respondent and then asserted a *second* decide on a duplicate. It now asserts no re-enqueue.

Test-first (red→green). `npm run build` clean; suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
