### PR TITLE
fix(pipeline): descriptive validation errors for non-array hooks and non-scalar schema values

### DIFF
--- a/src/pipeline/schema.ts
+++ b/src/pipeline/schema.ts
@@ -129,7 +129,7 @@ function parseStep(raw: unknown, index: number, baseDir: string): PipelineStep {
   };
 
   if (hasModules) {
-    step.modules = (s.modules as unknown[]).map((m) => String(m));
+    step.modules = (s.modules as unknown[]).map((m, i) => coerceScalar(m, where, `modules[${i}]`));
   } else if (hasModulesFile) {
     step.modules = readModulesFile(s.modules_file as string, baseDir);
   }
@@ -162,7 +162,7 @@ function coerceStringMap(
   }
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-    out[k] = String(v);
+    out[k] = coerceScalar(v, where, `${field}.${k}`);
   }
   return out;
 }
@@ -173,7 +173,25 @@ function parseHooks(raw: unknown, where: string): { before?: string[]; after?: s
   }
   const h = raw as Record<string, unknown>;
   const out: { before?: string[]; after?: string[] } = {};
-  if (h.before !== undefined) out.before = (h.before as unknown[]).map((c) => String(c));
-  if (h.after !== undefined) out.after = (h.after as unknown[]).map((c) => String(c));
+  for (const key of ["before", "after"] as const) {
+    const value = h[key];
+    if (value === undefined) continue;
+    if (!Array.isArray(value)) {
+      throw new Error(`Step ${where}: 'hooks.${key}' must be a list of commands`);
+    }
+    out[key] = value.map((c, i) => coerceScalar(c, where, `hooks.${key}[${i}]`));
+  }
   return out;
+}
+
+/**
+ * Coerce a scalar YAML value (string/number/boolean) to a string. Rejects
+ * non-null objects/arrays so a mistyped nested value fails loudly instead of
+ * silently stringifying to "[object Object]" or "a,b".
+ */
+function coerceScalar(value: unknown, where: string, field: string): string {
+  if (typeof value === "object" && value !== null) {
+    throw new Error(`Step ${where}: '${field}' must be a scalar (string, number, or boolean)`);
+  }
+  return String(value);
 }

--- a/tests/unit/pipeline-schema.test.ts
+++ b/tests/unit/pipeline-schema.test.ts
@@ -124,4 +124,54 @@ steps:
     const def = loadPipeline(p);
     expect(def.steps[0]!.hooks).toEqual({ before: ["echo hi"], after: ["npm run build"] });
   });
+
+  it("throws a descriptive error when hooks.before is a scalar instead of a list", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    hooks:\n      before: npm run lint\n`,
+    );
+    expect(() => loadPipeline(p)).toThrow(/hooks\.before/);
+  });
+
+  it("throws a descriptive error when hooks.after is a scalar instead of a list", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    hooks:\n      after: npm run build\n`,
+    );
+    expect(() => loadPipeline(p)).toThrow(/hooks\.after/);
+  });
+
+  it("throws a descriptive error when a modules entry is a map, not a scalar", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    modules:\n      - a\n      - key: value\n`,
+    );
+    expect(() => loadPipeline(p)).toThrow(/modules/i);
+  });
+
+  it("throws a descriptive error when a set value is a map, not a scalar", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    set:\n      behavior.param:\n        nested: value\n`,
+    );
+    expect(() => loadPipeline(p)).toThrow(/set/i);
+  });
+
+  it("throws a descriptive error when a set_file value is a map, not a scalar", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    set_file:\n      behavior.param:\n        nested: value\n`,
+    );
+    expect(() => loadPipeline(p)).toThrow(/set_file/i);
+  });
+
+  it("still coerces legitimate scalar modules/set values (regression)", () => {
+    const p = write(
+      "p.yaml",
+      `name: x\nsteps:\n  - name: s\n    template: t\n    project: .\n    modules: [a, 1, true]\n    set:\n      behavior.count: 42\n      behavior.enabled: true\n`,
+    );
+    const def = loadPipeline(p);
+    expect(def.steps[0]!.modules).toEqual(["a", "1", "true"]);
+    expect(def.steps[0]!.set).toEqual({ "behavior.count": "42", "behavior.enabled": "true" });
+  });
 });


### PR DESCRIPTION
Replaces two silent/opaque schema-parsing failures with descriptive validation errors.

## Fix A — `parseHooks` threw a raw TypeError on non-array `hooks.before`/`hooks.after`

Only the outer `hooks` container was guarded; `h.before`/`h.after` were cast `as unknown[]` and `.map()`'d directly. A scalar YAML value (`before: npm run lint` instead of a list) threw a raw `TypeError: h.before.map is not a function` with no context. Now each of `before`/`after`, when present, is checked with `Array.isArray` and otherwise throws `Step ${where}: 'hooks.${key}' must be a list of commands`.

## Fix B — silent stringification of non-scalar values

`modules[i]`, `set`/`set_file` map values (`coerceStringMap`), and hook commands were coerced with a bare `String(...)`, so a YAML map or array value silently became `"[object Object]"` or `"a,b"` instead of erroring. Extracted a shared `coerceScalar(value, where, field)` used at all three sites: it rejects non-null objects/arrays with `Step ${where}: '${field}' must be a scalar (string, number, or boolean)` (naming the offending index/key), and coerces legitimate scalars exactly as before.

## Tests

`tests/unit/pipeline-schema.test.ts` (5 new, test-first red→green): scalar `hooks.before` and `hooks.after` each throw an Error naming the field (not a raw TypeError); a `modules` entry that is a map/array and a `set`/`set_file` value that is a map each throw a descriptive error; legitimate scalar inputs still coerce correctly. `npm run build` clean; suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.
