### PR TITLE
fix(orchestrator): skip unregistered agents, scope metrics to the run, drain before teardown, guard resolution counts

### DIFF
--- a/src/orchestrator/metrics.ts
+++ b/src/orchestrator/metrics.ts
@@ -48,13 +48,25 @@ export function computeMetrics(events: SseEvent[]): CoordinatorMetrics {
   const introspectionRequested = events.filter((e) => e.type === "introspection_requested");
   const introspectionCompleted = events.filter((e) => e.type === "introspection_completed");
   const resolutionProposed = events.filter((e) => e.type === "resolution_proposed");
+  // A thread that cycles contest → re-propose emits MULTIPLE resolution_proposed
+  // events for the same thread_id. Counting them flat both inflates
+  // threads_resolved_consensus and can push threads_auto_resolved negative
+  // (#117) — dedup by thread_id first.
+  const resolvedThreadIds = new Set(
+    resolutionProposed
+      .map((e) => e.data.thread_id)
+      .filter((id): id is string => typeof id === "string"),
+  );
 
   return {
     agents_count: 0,
     duration_total_ms: 0,
     threads_opened: threadOpened.length,
-    threads_resolved_consensus: resolutionProposed.length,
-    threads_auto_resolved: threadOpened.length - resolutionProposed.length,
+    threads_resolved_consensus: resolvedThreadIds.size,
+    // Guarded: even after dedup this can go negative when the observed event
+    // window doesn't include a thread's own thread_opened event (e.g. it opened
+    // just before an SSE replay cursor) but does include its resolution.
+    threads_auto_resolved: Math.max(0, threadOpened.length - resolvedThreadIds.size),
     messages_exchanged: messagesPosted.length,
     conflicts_by_layer,
     introspections_triggered: introspectionRequested.length,
@@ -84,12 +96,53 @@ async function getWithTimeout(url: string, init: RequestInit, timeoutMs: number)
   }
 }
 
-export async function fetchCoordinatorMetrics(coordinatorUrl: string): Promise<CoordinatorMetrics> {
-  let sseRaw = "";
+/**
+ * Capture the coordinator's current max event id, to be used as the
+ * `Last-Event-ID` cursor baseline for a run that's about to start (#108).
+ *
+ * Reuses the same replay the SSE endpoint always sends on connect: a
+ * `Last-Event-ID: 0` GET returns the last 50 buffered events (fewer if less
+ * history exists) in ascending id order — so the max id among them IS the
+ * coordinator's current max, regardless of how much history precedes it.
+ */
+export async function fetchLatestEventId(coordinatorUrl: string): Promise<number> {
   try {
     const resp = await getWithTimeout(
       `${coordinatorUrl}/api/events`,
-      { headers: { "Last-Event-ID": "1", ...authHeaders() } },
+      { headers: { "Last-Event-ID": "0", ...authHeaders() } },
+      3000,
+    );
+    if (!resp.ok) return 0;
+    const events = parseSseEvents(await resp.text());
+    return events.reduce((max, e) => Math.max(max, e.id), 0);
+  } catch {
+    // Coordinator unreachable — degrade to "no baseline" (0), matching the
+    // fail-open posture of fetchCoordinatorMetrics itself.
+    return 0;
+  }
+}
+
+/**
+ * @param sinceEventId Cursor baseline captured via fetchLatestEventId right
+ * before this run's agents started. Only events with a strictly greater id
+ * are replayed, so a run no longer reads the coordinator's ENTIRE history —
+ * only what happened since. This isolates SEQUENTIAL runs sharing one
+ * coordinator; it does NOT isolate CONCURRENT runs, whose event ids
+ * interleave in the same stream — full isolation needs coordinator-side
+ * run_id filtering, which is out of scope here.
+ */
+export async function fetchCoordinatorMetrics(coordinatorUrl: string, sinceEventId = 0): Promise<CoordinatorMetrics> {
+  let sseRaw = "";
+  try {
+    // Never send "0" literally: the endpoint special-cases lastEventId<=0 as
+    // "give me the last 50 buffered events" rather than "since the start",
+    // which would silently cap a long/busy run's metrics. Clamp to at least 1
+    // (the previous hardcoded value) so a fresh coordinator with no prior
+    // events still gets the full replay instead of the last-50 fallback.
+    const cursor = Math.max(sinceEventId, 1);
+    const resp = await getWithTimeout(
+      `${coordinatorUrl}/api/events`,
+      { headers: { "Last-Event-ID": String(cursor), ...authHeaders() } },
       3000,
     );
     if (resp.ok) {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -76,10 +76,6 @@ const DEFAULT_BASE = process.cwd(); // default to current working directory
 // only fires on the timeout path, where the run has already blown its budget.
 const AGENT_DRAIN_GRACE_MS = 5000;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export interface RunProjectOptions {
   /** Override max quota utilization % for the pre-flight check. */
   maxQuotaPct?: number;
@@ -438,10 +434,22 @@ async function _runProjectBody(
     // mid-flight. Give them a bounded grace window to drain first. This is a
     // no-op on a normal (non-timeout) completion: every `p` is already settled
     // by the time we get here, so allSettled resolves immediately.
-    await Promise.race([
-      Promise.allSettled(originalPromises.map((p) => p.catch(() => {}))),
-      sleep(AGENT_DRAIN_GRACE_MS),
-    ]);
+    // Use a cancelable timer so the grace window doesn't keep the event loop
+    // alive after the drain wins the race (the common case): an uncleared
+    // setTimeout would leave a ref'd Node timer dangling for up to the full
+    // grace on every run.
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    const gracePromise = new Promise<void>((resolve) => {
+      graceTimer = setTimeout(resolve, AGENT_DRAIN_GRACE_MS);
+    });
+    try {
+      await Promise.race([
+        Promise.allSettled(originalPromises.map((p) => p.catch(() => {}))),
+        gracePromise,
+      ]);
+    } finally {
+      if (graceTimer) clearTimeout(graceTimer);
+    }
   } else {
     // Legacy mode: wait for child processes
     const legacyResults = await Promise.all(

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -20,7 +20,7 @@ const __dirname = path.dirname(__filename);
 import { createWorkspaces, cleanupWorkspaces, resetBase } from "./workspace.js";
 import { launchAgent, launchAgentLoop, waitForProcess, randomDelay, fixedDelay } from "./agent-launcher.js";
 import type { AgentLoopResult } from "../agent-loop/agent-loop.js";
-import { fetchCoordinatorMetrics } from "./metrics.js";
+import { fetchCoordinatorMetrics, fetchLatestEventId } from "./metrics.js";
 import { collectAgentResults } from "./reporter.js";
 import type { AgentConfig, MiniProject, AgentProcess, RunResult } from "./types.js";
 import { scanProject } from "./scanner.js";
@@ -66,6 +66,19 @@ async function postJson(url: string, body: unknown, timeoutMs = 5000): Promise<b
 
 const COORDINATOR_URL = process.env.COORDINATOR_URL || "http://localhost:3100";
 const DEFAULT_BASE = process.cwd(); // default to current working directory
+
+// On a run-level timeout, agent-loop promises are raced against the deadline
+// (see the "Wait for all agents" section) — the race settles the instant the
+// deadline fires, but the underlying agent-loop is still mid-abort (SIGKILLing
+// its claude children, posting a final coordinator update). This is the
+// bounded window given to let that teardown actually drain before the
+// coordinator gets stopped out from under it (#112). Deliberately small: this
+// only fires on the timeout path, where the run has already blown its budget.
+const AGENT_DRAIN_GRACE_MS = 5000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export interface RunProjectOptions {
   /** Override max quota utilization % for the pre-flight check. */
@@ -162,6 +175,18 @@ async function _runProjectBody(
   // Agents reuse the same ceiling so their in-raid check matches the pre-flight.
   const agentLoopMaxQuotaPct = mode === "with_coordinator" ? maxQuotaPct : undefined;
 
+  // Capture the coordinator's current max event id as a baseline BEFORE any
+  // agent starts (#108). fetchCoordinatorMetrics below cursors its SSE replay
+  // off this id instead of reading the coordinator's entire event history —
+  // see the comment on fetchCoordinatorMetrics for the isolation caveat
+  // (this scopes SEQUENTIAL runs on a shared coordinator; concurrent runs
+  // still interleave event ids and need coordinator-side run_id filtering).
+  let coordinatorEventBaseline = 0;
+  if (mode === "with_coordinator") {
+    coordinatorEventBaseline = await fetchLatestEventId(effectiveCoordinatorUrl);
+    log.info(`Coordinator events baseline for run ${runId}: id ${coordinatorEventBaseline}`);
+  }
+
   // 1. Reset coordinator state — only when reusing an external coordinator.
   // For in-process spawns the DB is empty; calling reset there races with
   // the orchestrator's own pre-register step (curl --max-time 2 gives up,
@@ -247,9 +272,11 @@ async function _runProjectBody(
   // Group agents by launch_delay if any agent uses it, otherwise use stagger
   const hasLaunchDelays = project.agents.some(a => a.launch_delay !== undefined);
 
-  // Pre-register all agents via REST (don't rely on LLMs to register correctly)
+  // Pre-register all agents via REST (don't rely on LLMs to register correctly).
+  // Ids that fail here are tracked so the launch loops below can skip them
+  // instead of launching an agent that can never announce_work (#107).
+  const registeredAgentIds = new Set<string>();
   if (isCoordinated) {
-    let registered = 0;
     for (const agent of project.agents) {
       // Use the agent's declared modules so consultation.ts can match it as a
       // respondent. With `[]` here, target_modules.some()/agentModules.some()
@@ -262,13 +289,23 @@ async function _runProjectBody(
         name: agent.name,
         modules,
       })) {
-        registered++;
+        registeredAgentIds.add(agent.id);
       }
     }
-    log.info(`Pre-registered ${registered}/${project.agents.length} agents`);
-    if (registered < project.agents.length) {
-      log.error(`Pre-registration incomplete (${registered}/${project.agents.length}); /api/announce will fail with FK violations.`);
+    log.info(`Pre-registered ${registeredAgentIds.size}/${project.agents.length} agents`);
+    if (registeredAgentIds.size < project.agents.length) {
+      log.error(`Pre-registration incomplete (${registeredAgentIds.size}/${project.agents.length}); skipping the unregistered agents rather than letting /api/announce fail with FK violations.`);
     }
+  }
+
+  // An agent that failed pre-registration must never be launched: every
+  // coordinator call it makes (announce_work first) would fail immediately —
+  // previously this was only logged, and the agent was launched anyway (#107).
+  function isLaunchable(agent: typeof project.agents[0]): boolean {
+    if (!isCoordinated) return true;
+    if (registeredAgentIds.has(agent.id)) return true;
+    log.error(`Skipping ${agent.name} (${agent.id}): failed to pre-register with the coordinator.`);
+    return false;
   }
 
   function setupAndLaunch(agent: typeof project.agents[0]): ChildProcess | null {
@@ -329,6 +366,7 @@ async function _runProjectBody(
       }
       elapsed = delayTarget;
       for (const agent of groups.get(delayTarget)!) {
+        if (!isLaunchable(agent)) continue;
         setupAndLaunch(agent);
       }
     }
@@ -336,6 +374,7 @@ async function _runProjectBody(
     // Standard stagger-based launching
     for (let i = 0; i < project.agents.length; i++) {
       const agent = project.agents[i];
+      if (!isLaunchable(agent)) continue;
       const proc = setupAndLaunch(agent);
 
       // Stagger
@@ -366,32 +405,58 @@ async function _runProjectBody(
 
   let processResults: Array<{ stdout: string; stderr: string; code: number }>;
   const agentLoopResults = new Map<string, AgentLoopResult>();
+  // Keyed by agent id rather than launch order: #107 can skip agents that
+  // failed pre-registration, so the collections below may hold fewer entries
+  // than project.agents — indexing by position would silently misattribute
+  // one agent's exit code/stdout to a different agent.
+  const processResultsById = new Map<string, { stdout: string; stderr: string; code: number }>();
 
   if (useAgentLoop) {
     // Agent-loop mode: await all promises, race against timeout
     const entries = [...agentLoopPromises.entries()];
+    const originalPromises = entries.map(([, p]) => p);
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutReject = () => reject(new Error("TIMEOUT"));
     });
-    const racePromises = entries.map(([, p]) => Promise.race([p, timeoutPromise]));
+    const racePromises = originalPromises.map((p) => Promise.race([p, timeoutPromise]));
     const results = await Promise.allSettled(racePromises);
-    processResults = results.map((r, i) => {
+    results.forEach((r, i) => {
+      const agentId = entries[i][0];
       if (r.status === "fulfilled") {
-        agentLoopResults.set(entries[i][0], r.value);
-        return { stdout: r.value.summary, stderr: "", code: r.value.exitReason === "done" ? 0 : 1 };
+        agentLoopResults.set(agentId, r.value);
+        processResultsById.set(agentId, { stdout: r.value.summary, stderr: "", code: r.value.exitReason === "done" ? 0 : 1 });
+      } else {
+        processResultsById.set(agentId, { stdout: "", stderr: (r.reason as Error).message, code: 1 });
       }
-      return { stdout: "", stderr: (r.reason as Error).message, code: 1 };
     });
+
+    // #112 — the race above settles the instant EITHER the agent-loop finishes
+    // OR the timeout fires. On timeout, `originalPromises` are still mid-abort
+    // (SIGKILLing claude children, posting a final coordinator update) and were
+    // never themselves awaited or cancelled — the caller's `finally` used to
+    // call coordinatorHandle.stop() right after this, cutting them off
+    // mid-flight. Give them a bounded grace window to drain first. This is a
+    // no-op on a normal (non-timeout) completion: every `p` is already settled
+    // by the time we get here, so allSettled resolves immediately.
+    await Promise.race([
+      Promise.allSettled(originalPromises.map((p) => p.catch(() => {}))),
+      sleep(AGENT_DRAIN_GRACE_MS),
+    ]);
   } else {
     // Legacy mode: wait for child processes
-    processResults = await Promise.all(
+    const legacyResults = await Promise.all(
       agentProcesses.map((ap) => {
         const seqResult = sequentialResults.get(ap.config.id);
         if (seqResult) return Promise.resolve(seqResult);
         return waitForProcess(ap.process);
       })
     );
+    agentProcesses.forEach((ap, i) => processResultsById.set(ap.config.id, legacyResults[i]));
   }
+
+  processResults = project.agents.map((agent) =>
+    processResultsById.get(agent.id) ?? { stdout: "", stderr: "Skipped: failed coordinator pre-registration", code: 1 }
+  );
 
   clearTimeout(timeoutTimer);
   if (duringRunProcess) duringRunProcess.kill();
@@ -401,7 +466,7 @@ async function _runProjectBody(
 
   // 6. Collect metrics
   const coordinatorMetrics = isCoordinated
-    ? await fetchCoordinatorMetrics(effectiveCoordinatorUrl)
+    ? await fetchCoordinatorMetrics(effectiveCoordinatorUrl, coordinatorEventBaseline)
     : {
         agents_count: project.agents.length,
         duration_total_ms: duration,

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -31,5 +31,36 @@ describe("computeMetrics", () => {
     expect(metrics.messages_exchanged).toBe(2);
     expect(metrics.conflicts_by_layer["Layer 0a"]).toBe(1);
   });
+
+  // #117 — a thread that gets contested and re-proposed emits MULTIPLE
+  // resolution_proposed events for the same thread_id. A flat count of those
+  // events both over-counts threads_resolved_consensus and can push
+  // threads_auto_resolved negative.
+  it("dedups resolution_proposed by thread_id — a re-proposed thread counts once", () => {
+    const events = [
+      { id: 1, type: "thread_opened", data: { thread_id: "t1" } },
+      { id: 2, type: "resolution_proposed", data: { thread_id: "t1" } },
+      { id: 3, type: "resolution_proposed", data: { thread_id: "t1" } }, // contest → re-propose
+      { id: 4, type: "resolution_proposed", data: { thread_id: "t1" } }, // contest → re-propose again
+    ];
+
+    const metrics = computeMetrics(events);
+    expect(metrics.threads_resolved_consensus).toBe(1);
+    expect(metrics.threads_auto_resolved).toBe(0);
+  });
+
+  it("threads_auto_resolved never goes negative even when resolutions outnumber opens", () => {
+    // e.g. the observed event window's cursor started after a thread's own
+    // thread_opened event but still includes its resolution.
+    const events = [
+      { id: 1, type: "resolution_proposed", data: { thread_id: "t1" } },
+      { id: 2, type: "resolution_proposed", data: { thread_id: "t2" } },
+    ];
+
+    const metrics = computeMetrics(events);
+    expect(metrics.threads_opened).toBe(0);
+    expect(metrics.threads_resolved_consensus).toBe(2);
+    expect(metrics.threads_auto_resolved).toBe(0);
+  });
 });
 

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -1,0 +1,227 @@
+// tests/unit/orchestrator-run.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { execSync } from "child_process";
+import type { AgentConfig, MiniProject } from "../../src/orchestrator/types.js";
+import type { AgentLoopResult } from "../../src/agent-loop/agent-loop.js";
+
+// ── Module mocks ──────────────────────────────────────────────────────────
+// Everything the orchestrator talks to over the network or as a subprocess is
+// mocked; workspace.ts/reporter.ts are left real since workspace.type "none"
+// makes them side-effect-free (no worktrees, no git diff/tsc).
+
+vi.mock("mcp-coordinator", () => ({
+  startServer: vi.fn(),
+}));
+
+vi.mock("../../src/orchestrator/agent-launcher.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/orchestrator/agent-launcher.js")>();
+  return {
+    ...actual,
+    launchAgent: vi.fn(() => {
+      throw new Error("legacy launchAgent should not be called by these agent-loop tests");
+    }),
+    launchAgentLoop: vi.fn(),
+  };
+});
+
+vi.mock("../../src/orchestrator/metrics.js", () => ({
+  fetchCoordinatorMetrics: vi.fn(async () => ({
+    agents_count: 0,
+    duration_total_ms: 0,
+    threads_opened: 0,
+    threads_resolved_consensus: 0,
+    threads_auto_resolved: 0,
+    messages_exchanged: 0,
+    conflicts_by_layer: {},
+    introspections_triggered: 0,
+    introspections_concerned: 0,
+    avg_resolution_time_ms: 0,
+    hot_files: [],
+  })),
+  fetchLatestEventId: vi.fn(async () => 0),
+}));
+
+vi.mock("../../src/orchestrator/preflight.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/orchestrator/preflight.js")>();
+  return {
+    ...actual,
+    preflightQuotaCheck: vi.fn(async () => ({ canProceed: true })),
+  };
+});
+
+const { startServer } = await import("mcp-coordinator");
+const { launchAgentLoop } = await import("../../src/orchestrator/agent-launcher.js");
+const { runProject } = await import("../../src/orchestrator/orchestrator.js");
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+function makeAgent(partial: Partial<AgentConfig> & Pick<AgentConfig, "id" | "name">): AgentConfig {
+  return {
+    prompt: "do the thing",
+    profile: "codeur",
+    hooks: {},
+    envVars: {},
+    mcpTools: ["announce_work"],
+    ...partial,
+  };
+}
+
+function makeProject(partial: Partial<MiniProject> & Pick<MiniProject, "agents">): MiniProject {
+  return {
+    id: "test-project",
+    name: "Test Project",
+    description: "orchestrator-run test fixture",
+    phase: 1,
+    workspace: { type: "none" },
+    stagger: { mode: "fixed", delay: [0, 0] },
+    metrics: [],
+    ...partial,
+  };
+}
+
+function makeLoopResult(agentId: string, exitReason: AgentLoopResult["exitReason"] = "done"): AgentLoopResult {
+  return {
+    agentId,
+    exitReason,
+    summary: "ok",
+    totalCostUsd: 0,
+    turnsCount: 1,
+    mqttMessagesProcessed: 0,
+    durationMs: 1,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 },
+    costByPhase: {},
+    costByModel: {},
+    turnDetails: [],
+  };
+}
+
+/** Dispatches the bare `fetch` calls postJson makes (register/run-config/reset). */
+function makeFetchMock(registerOk: Record<string, boolean>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const { pathname } = new URL(url);
+    if (pathname === "/api/register") {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const ok = registerOk[body.agent_id] !== false;
+      return new Response(JSON.stringify({ ok }), { status: ok ? 200 : 500 });
+    }
+    if (pathname === "/api/run-config" || pathname === "/api/reset") {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("", { status: 404 });
+  });
+}
+
+let TMP_DIR: string;
+let ORIGINAL_CWD: string;
+
+beforeEach(() => {
+  ORIGINAL_CWD = process.cwd();
+  TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "essaim-orch-run-"));
+  process.chdir(TMP_DIR); // keep the `runs/` dir this creates out of the repo
+  // createWorkspaces() (real, unmocked) does a `git rev-parse HEAD` for the
+  // diff baseline even for workspace.type "none" — give it a real (if empty)
+  // repo so that's a normal no-op instead of noisy "not a git repository"
+  // stderr from every test run.
+  execSync("git init -q && git config user.email 'test@test.com' && git config user.name 'Test'", { cwd: TMP_DIR });
+  fs.writeFileSync(path.join(TMP_DIR, ".gitkeep"), "");
+  execSync("git add . && git commit -q -m init", { cwd: TMP_DIR });
+  delete process.env.ESSAIM_RUN_ID;
+  vi.mocked(launchAgentLoop).mockReset();
+});
+
+afterEach(() => {
+  process.chdir(ORIGINAL_CWD);
+  try { fs.rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+  vi.unstubAllGlobals();
+  delete process.env.ESSAIM_RUN_ID;
+});
+
+// ── #107 — skip agents that failed pre-registration ────────────────────────
+
+describe("runProject — pre-registration failures (#107)", () => {
+  it("launches only the agents that registered; skips the one that failed", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true, a2: false }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [
+        makeAgent({ id: "a1", name: "Agent A" }),
+        makeAgent({ id: "a2", name: "Agent B" }),
+      ],
+      workspace: { type: "none", base: TMP_DIR },
+    });
+
+    const result = await runProject(project, "with_coordinator", false, {
+      coordinatorUrl: "http://coordinator.test",
+    });
+
+    const launchedIds = vi.mocked(launchAgentLoop).mock.calls.map((call) => (call[0] as AgentConfig).id);
+    expect(launchedIds).toEqual(["a1"]);
+
+    // The skipped agent still gets a result row (workspace was created for
+    // both), just marked as not run rather than misattributed another
+    // agent's outcome.
+    expect(result.agent_results).toHaveLength(2);
+    const skipped = result.agent_results.find((r) => r.agent_id === "a2")!;
+    expect(skipped.exit_code).toBe(1);
+  });
+
+  it("launches every agent when registration fully succeeds (no regression)", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true, a2: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [
+        makeAgent({ id: "a1", name: "Agent A" }),
+        makeAgent({ id: "a2", name: "Agent B" }),
+      ],
+      workspace: { type: "none", base: TMP_DIR },
+    });
+
+    await runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" });
+
+    const launchedIds = vi.mocked(launchAgentLoop).mock.calls.map((call) => (call[0] as AgentConfig).id);
+    expect(launchedIds.sort()).toEqual(["a1", "a2"]);
+  });
+});
+
+// ── #112 — drain original agent-loop promises before coordinator teardown ──
+
+describe("runProject — timeout teardown ordering (#112)", () => {
+  it("awaits the original agent-loop promise (within the grace window) before stopping the coordinator", async () => {
+    const order: string[] = [];
+    const stop = vi.fn(async () => {
+      order.push("coordinator-stopped");
+    });
+    vi.mocked(startServer).mockResolvedValue({ port: 5555, stop } as never);
+
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent, _ws, _url, _mcp, _prompt, opts) => {
+      return new Promise<AgentLoopResult>((resolve) => {
+        // Never resolves on its own — only once the orchestrator's timeout
+        // aborts it, simulating a claude child that takes a moment to drain
+        // (SIGKILL propagation + a final coordinator POST) after the signal.
+        opts?.abortSignal?.addEventListener("abort", () => {
+          setTimeout(() => {
+            order.push("agent-drained");
+            resolve(makeLoopResult(agent.id, "aborted"));
+          }, 30);
+        });
+      });
+    });
+
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "none", base: TMP_DIR },
+      timeout_minutes: 0.0005, // ~30ms — fires well before the agent-loop would ever resolve on its own
+    });
+
+    await runProject(project, "with_coordinator", false, {});
+
+    expect(order).toEqual(["agent-drained", "coordinator-stopped"]);
+  });
+});

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -207,7 +207,7 @@ describe("runProject — timeout teardown ordering (#112)", () => {
           setTimeout(() => {
             order.push("agent-drained");
             resolve(makeLoopResult(agent.id, "aborted"));
-          }, 30);
+          }, 50);
         });
       });
     });
@@ -217,7 +217,7 @@ describe("runProject — timeout teardown ordering (#112)", () => {
     const project = makeProject({
       agents: [makeAgent({ id: "a1", name: "Agent A" })],
       workspace: { type: "none", base: TMP_DIR },
-      timeout_minutes: 0.0005, // ~30ms — fires well before the agent-loop would ever resolve on its own
+      timeout_minutes: 0.0025, // ~150ms — fires well before the agent-loop would ever resolve on its own; drains ~50ms after abort, well within the grace window
     });
 
     await runProject(project, "with_coordinator", false, {});

--- a/tests/unit/report-counters.test.ts
+++ b/tests/unit/report-counters.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/report-counters.test.ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { countDiffLines, formatCost } from '../../src/orchestrator/reporter.js';
-import { fetchCoordinatorMetrics } from '../../src/orchestrator/metrics.js';
+import { fetchCoordinatorMetrics, fetchLatestEventId } from '../../src/orchestrator/metrics.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -82,5 +82,105 @@ describe('fetchCoordinatorMetrics — authentification (#29)', () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
     const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
     expect(metrics.threads_opened).toBe(0);
+  });
+});
+
+// #108 — fetchCoordinatorMetrics hardcoded `Last-Event-ID: 1`, so a run on a
+// shared, persistent coordinator (where /api/reset is 403-forbidden) always
+// replayed the coordinator's ENTIRE event history, not just this run's.
+describe('fetchCoordinatorMetrics — scoping the SSE cursor to this run (#108)', () => {
+  it('threads the given cursor as Last-Event-ID instead of the hardcoded "1"', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchCoordinatorMetrics('https://coordinator.test', 42);
+
+    const headers = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(headers['Last-Event-ID']).toBe('42');
+  });
+
+  it('defaults to "1" (previous behaviour) when no cursor is given', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchCoordinatorMetrics('https://coordinator.test');
+
+    const headers = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(headers['Last-Event-ID']).toBe('1');
+  });
+
+  it('two sequential runs on a shared coordinator do not see each other\'s events', async () => {
+    // Simulates the real coordinator: a `/api/events` GET only ever returns
+    // events with id > Last-Event-ID. Events accumulate over time — the array
+    // is mutated as each "run" emits its events, mirroring production instead
+    // of pre-seeding the log with events that haven't happened yet. Seeded
+    // with one pre-existing event (id 1) to model the realistic D108 scenario
+    // — a SHARED, persistent coordinator that already has history — rather
+    // than a coordinator that has never seen a single event.
+    const liveEvents: { id: number; type: string; data: Record<string, unknown> }[] = [
+      { id: 1, type: 'thread_opened', data: { thread_id: 'stale-from-earlier-session' } },
+    ];
+    const sseFor = (sinceId: number) =>
+      liveEvents
+        .filter((e) => e.id > sinceId)
+        .map((e) => `id: ${e.id}\nevent: ${e.type}\ndata: ${JSON.stringify(e.data)}`)
+        .join('\n\n');
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const since = parseInt((init!.headers as Record<string, string>)['Last-Event-ID'], 10);
+      return new Response(sseFor(since), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Run 1 captures baseline 1 (the stale event), then emits its 2 threads.
+    const run1Baseline = await fetchLatestEventId('https://coordinator.test');
+    expect(run1Baseline).toBe(1);
+    liveEvents.push(
+      { id: 2, type: 'thread_opened', data: { thread_id: 'run1-t1' } },
+      { id: 3, type: 'thread_opened', data: { thread_id: 'run1-t2' } },
+    );
+    const run1Metrics = await fetchCoordinatorMetrics('https://coordinator.test', run1Baseline);
+    expect(run1Metrics.threads_opened).toBe(2);
+
+    // Run 2's baseline is captured AFTER run 1's events exist (max id 3) — it
+    // must only see its own thread, not the stale event or run 1's leftovers.
+    const run2Baseline = await fetchLatestEventId('https://coordinator.test');
+    expect(run2Baseline).toBe(3);
+    liveEvents.push({ id: 4, type: 'thread_opened', data: { thread_id: 'run2-t1' } });
+    const run2Metrics = await fetchCoordinatorMetrics('https://coordinator.test', run2Baseline);
+    expect(run2Metrics.threads_opened).toBe(1);
+  });
+});
+
+describe('fetchLatestEventId (#108)', () => {
+  it('captures the max event id currently buffered by the coordinator', async () => {
+    const sse = [
+      'id: 5\nevent: thread_opened\ndata: {"thread_id":"t1"}',
+      'id: 9\nevent: message_posted\ndata: {"thread_id":"t1"}',
+      'id: 7\nevent: message_posted\ndata: {"thread_id":"t1"}',
+    ].join('\n\n');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse, { status: 200 })));
+
+    expect(await fetchLatestEventId('https://coordinator.test')).toBe(9);
+  });
+
+  it('returns 0 for a fresh coordinator with no events yet', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })));
+    expect(await fetchLatestEventId('https://coordinator.test')).toBe(0);
+  });
+
+  it('sends Last-Event-ID: 0 to request the buffered-history replay', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchLatestEventId('https://coordinator.test');
+
+    const headers = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(headers['Last-Event-ID']).toBe('0');
+  });
+
+  it('degrades to 0 when the coordinator is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    expect(await fetchLatestEventId('https://coordinator.test')).toBe(0);
   });
 });

--- a/tests/unit/report-counters.test.ts
+++ b/tests/unit/report-counters.test.ts
@@ -114,7 +114,7 @@ describe('fetchCoordinatorMetrics — scoping the SSE cursor to this run (#108)'
     // events with id > Last-Event-ID. Events accumulate over time — the array
     // is mutated as each "run" emits its events, mirroring production instead
     // of pre-seeding the log with events that haven't happened yet. Seeded
-    // with one pre-existing event (id 1) to model the realistic D108 scenario
+    // with one pre-existing event (id 1) to model the realistic #108 scenario
     // — a SHARED, persistent coordinator that already has history — rather
     // than a coordinator that has never seen a single event.
     const liveEvents: { id: number; type: string; data: Record<string, unknown> }[] = [


### PR DESCRIPTION
Four independent hardening fixes in the orchestrator run path (`orchestrator.ts`, `metrics.ts`).

## 1. Skip agents that failed pre-registration
Incomplete pre-registration was logged but never affected control flow, and both launch loops iterated the full `project.agents` — so an agent that failed to register was still launched. Successfully-registered ids are now tracked and both loops skip the rest (`isLaunchable`). The end-of-run result zip previously assumed `processResults[i]` aligned positionally with `project.agents[i]`; since agents can now be skipped, results are keyed by agent id and the array is rebuilt from `project.agents` (skipped agents get a distinct not-run row) so no result is misattributed or dropped.

## 2. Scope coordinator metrics to the current run
`fetchCoordinatorMetrics` hardcoded `Last-Event-ID: "1"`, reading the coordinator's entire event history rather than this run's. A per-run baseline event id is now captured (`fetchLatestEventId`) right after the run id is established and before any agent launches, and threaded through as the replay cursor. **This isolates sequential runs sharing a coordinator; it does not isolate concurrent runs** (their event ids interleave) — full isolation needs coordinator-side run_id filtering, out of scope here (documented at the call site).

## 3. Drain agent-loops before tearing down the coordinator
On timeout, each agent was wrapped in `Promise.race([p, timeout])` and only the race wrappers were awaited — the underlying promises (mid-abort: SIGKILLing children, posting a final coordinator update) were never awaited, and the `finally` stopped the coordinator immediately, cutting them off. The original promises are now awaited with a bounded grace window (`AGENT_DRAIN_GRACE_MS = 5000`, rejections swallowed) before teardown; it's a no-op on normal completion (promises already settled). The grace timer is cancelable and cleared once the race settles, so it never keeps the event loop alive.

## 4. `threads_auto_resolved` can no longer go negative
`resolutionProposed` was a flat filter with no `thread_id` dedup, so a thread that cycled contest→re-propose was counted multiple times and `threadOpened.length - resolutionProposed.length` could go negative. Resolutions are now deduped by `thread_id` (Set) at every count site, and the subtraction is wrapped in `Math.max(0, …)`.

## Tests
New `tests/unit/orchestrator-run.test.ts` (skip/alignment, drain-vs-stop ordering against a real in-process stop spy) plus additions to `tests/unit/metrics.test.ts` and `tests/unit/report-counters.test.ts` (baseline-cursor sequential-isolation with a real `id > Last-Event-ID` server filter; dedup + non-negative metric). All test-first (red→green). `npm run build` clean; suite green apart from one pre-existing Windows-only POSIX-permission test unrelated to this change.

Reviewed for async correctness (drain awaits the real promises, is bounded, swallows rejections, doesn't delay fast completion; `stop()` still runs exactly once).
