### PR TITLE
ci: pin third-party actions to commit SHAs and pin the release-please target branch

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -54,15 +54,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # When dispatched / called, check out the requested tag rather than
           # the caller's branch (which is typically refs/heads/main).
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -121,7 +121,7 @@ jobs:
           tar czf "${DIST_NAME}.tar.gz" "${DIST_NAME}"
 
       - name: Publish tarball to GH Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           # tag_name is required on workflow_call / workflow_dispatch because
           # github.ref is the caller branch (not the tag). On a direct

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,21 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         if: ${{ github.event_name == 'push' || inputs.publish_only != 'true' }}
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Pinned explicitly so the release target always matches this
+          # workflow's `push: branches: [main]` trigger, instead of relying
+          # implicitly on the repository's default-branch setting.
+          target-branch: main
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ steps.release.outputs.release_created || inputs.publish_only == 'true' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: ${{ steps.release.outputs.release_created || inputs.publish_only == 'true' }}
         with:
           node-version: "22"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
Supply-chain + release-config hardening for the CI workflows.

- **Pin third-party actions to commit SHAs**: `actions/checkout`, `actions/setup-node`, `googleapis/release-please-action`, `oven-sh/setup-bun`, and `softprops/action-gh-release` were referenced by mutable tags (`@v4` etc.). Each is now pinned to a full commit SHA with a `# vX.Y.Z` comment (annotated tags dereferenced to their commit). Closes the mutable-tag supply-chain gap. (SHA pins will want periodic bumping — e.g. a Dependabot `github-actions` entry — not set up here.)
- **Pin the release-please target branch**: added an explicit `target-branch: main` to the release-please step, so the release target always matches this workflow's `push: branches: [main]` trigger instead of relying implicitly on the repository's default-branch setting. This is defensive hardening — with `main` as the default branch it's a no-op — not a fix for an observed failure.

All three edited workflow files parse as valid YAML; no floating third-party tags remain.
