### PR TITLE
feat(coordination): handle ADJUST decisions from the coordination LLM

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -644,9 +644,25 @@ export async function runAgentLoop(
           const resp = await send(
             formatCoordinationContext(action.threadId, action.responses),
           );
-          const decision = resp.content.trim().toUpperCase();
+          const content = resp.content.trim();
+          const decision = content.toUpperCase();
           if (decision.startsWith("YIELD")) {
             protocol.decideYield();
+          } else if (decision.startsWith("ADJUST")) {
+            // The LLM's reply is "ADJUST" followed by its new plan — strip
+            // the leading token (and any separator like ":" or "-") to get
+            // the plan text.
+            const newPlan = content.slice("ADJUST".length).replace(/^[:\s-]+/, "").trim();
+            if (newPlan) {
+              protocol.decideAdjust(newPlan);
+            } else {
+              // Malformed ADJUST (no plan attached) — don't let it wedge the
+              // loop on a plan we don't have. Fall back to the safe default.
+              logger.warn("ADJUST decision had no plan attached — falling back to CONTINUE", {
+                threadId: action.threadId,
+              });
+              protocol.decideContinue();
+            }
           } else {
             protocol.decideContinue();
           }

--- a/src/agent-loop/coordination-protocol.ts
+++ b/src/agent-loop/coordination-protocol.ts
@@ -31,6 +31,7 @@ export interface ThreadState {
   respondedAgents: string[];
   round: number;
   decideRequested: boolean;
+  work: WorkDescription;
 }
 
 // â”€â”€ Protocol actions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -65,6 +66,10 @@ export interface CoordinationProtocol {
   // responds, call one of these to advance the state machine.
   decideContinue(): void;
   decideYield(): void;
+  // The LLM wants to revise its plan instead of continuing or yielding —
+  // updates the thread's plan and re-opens the current round for a fresh
+  // set of responses (same reset as onContestation).
+  decideAdjust(newPlan: string): void;
 
   // After work is done, transition to resolution
   workDone(): void;
@@ -89,6 +94,7 @@ const APPROVAL_TIMEOUT_MS = 20_000;
 export function createCoordinationProtocol(agentId: string): CoordinationProtocol {
   let phase: Phase = "idle";
   let currentThreadId: string | null = null;
+  let pendingWork: WorkDescription | null = null;
 
   const threads = new Map<string, ThreadState>();
   const actionQueue: ProtocolAction[] = [];
@@ -116,6 +122,19 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
     return msgs.map((m) => `[${m.agentId}]: ${m.content}`).join("\n");
   }
 
+  // Shared by onContestation and decideAdjust: reopen the current thread
+  // for a new round of responses (bump round, clear respondents/decision
+  // flag, go back to "waiting").
+  function resetForNewRound(thread: ThreadState): void {
+    thread.round += 1;
+    thread.respondedAgents = [];
+    thread.decideRequested = false;
+    thread.status = "waiting";
+    phase = "waiting";
+    messageBuffer.set(thread.threadId, []);
+    enqueue({ type: "wait_responses", threadId: thread.threadId, timeoutMs: RESPONSE_TIMEOUT_MS });
+  }
+
   return {
     get phase() {
       return phase;
@@ -130,6 +149,7 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
         throw new Error(`Cannot start work while in phase "${phase}"`);
       }
       phase = "announcing";
+      pendingWork = work;
       enqueue({ type: "announce", work });
     },
 
@@ -143,7 +163,9 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
         respondedAgents: [],
         round: 1,
         decideRequested: false,
+        work: pendingWork ?? { subject: "", targetModules: [], targetFiles: [] },
       };
+      pendingWork = null;
       threads.set(result.threadId, thread);
       messageBuffer.set(result.threadId, []);
       currentThreadId = result.threadId;
@@ -227,13 +249,7 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
       }
 
       // Back to waiting for a new round
-      thread.round += 1;
-      thread.respondedAgents = [];
-      thread.decideRequested = false;
-      thread.status = "waiting";
-      phase = "waiting";
-      messageBuffer.set(threadId, []);
-      enqueue({ type: "wait_responses", threadId, timeoutMs: RESPONSE_TIMEOUT_MS });
+      resetForNewRound(thread);
     },
 
     onTimeout(threadId: string): void {
@@ -276,6 +292,15 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
       phase = "idle";
       currentThreadId = null;
       enqueue({ type: "done", summary: `Yielded on thread ${thread.threadId}` });
+    },
+
+    decideAdjust(newPlan: string): void {
+      if (phase !== "waiting" || !currentThreadId) return;
+      const thread = getThread(currentThreadId);
+      if (!thread) return;
+
+      thread.work.plan = newPlan;
+      resetForNewRound(thread);
     },
 
     workDone(): void {

--- a/src/agent-loop/coordination-protocol.ts
+++ b/src/agent-loop/coordination-protocol.ts
@@ -300,6 +300,18 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
       if (!thread) return;
 
       thread.work.plan = newPlan;
+
+      // Bound re-planning the same way onContestation bounds re-rounds: an LLM
+      // that keeps replying ADJUST would otherwise reopen rounds indefinitely.
+      // At the cap, adopt the latest plan and proceed to work instead of
+      // reopening another announce round.
+      if (thread.round >= MAX_ROUNDS) {
+        thread.status = "working";
+        phase = "working";
+        enqueue({ type: "work" });
+        return;
+      }
+
       resetForNewRound(thread);
     },
 

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -43,6 +43,7 @@ const mockNextAction = vi.fn(() => null);
 const mockOnAnnounceResult = vi.fn();
 const mockDecideContinue = vi.fn();
 const mockDecideYield = vi.fn();
+const mockDecideAdjust = vi.fn();
 const mockWorkDone = vi.fn();
 const mockOnTimeout = vi.fn();
 const mockOnThreadMessage = vi.fn();
@@ -62,6 +63,7 @@ vi.mock("../../src/agent-loop/coordination-protocol.js", () => ({
     onTimeout: mockOnTimeout,
     decideContinue: mockDecideContinue,
     decideYield: mockDecideYield,
+    decideAdjust: mockDecideAdjust,
     workDone: mockWorkDone,
     getThreadState: vi.fn(() => null),
     get phase() { return mockPhase; },
@@ -366,6 +368,92 @@ describe("runAgentLoop", () => {
     // The second call is interruptClaude — should use haiku
     const interruptOpts = calls[1][0] as { model?: string };
     expect(interruptOpts.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  // ── Coordination decision: ADJUST ────────────────────────────────────
+
+  it("routes an ADJUST reply to protocol.decideAdjust with the parsed plan", async () => {
+    let nextActionCall = 0;
+    mockNextAction.mockImplementation((): any => {
+      nextActionCall++;
+      if (nextActionCall === 1) {
+        return { type: "ask_llm_decide", threadId: "t-1", responses: "[agent-2]: I'm on file X too" };
+      }
+      mockPhase = "working";
+      return { type: "work" };
+    });
+
+    let sendCall = 0;
+    mockSend.mockImplementation(async () => {
+      sendCall++;
+      if (sendCall === 1) {
+        return {
+          content: "ADJUST: je vais éviter le fichier X et me concentrer sur Y à la place",
+          toolCalls: [],
+          costUsd: 0.01,
+          durationMs: 100,
+          sessionId: "s1",
+        };
+      }
+      return {
+        content: "DONE: finished",
+        toolCalls: [],
+        costUsd: 0.01,
+        durationMs: 100,
+        sessionId: "s1",
+      };
+    });
+
+    await runAgentLoop(makeConfig(), silentLogger);
+
+    expect(mockDecideAdjust).toHaveBeenCalledWith("je vais éviter le fichier X et me concentrer sur Y à la place");
+    expect(mockDecideContinue).not.toHaveBeenCalled();
+    expect(mockDecideYield).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CONTINUE and logs a warning when ADJUST has no plan attached", async () => {
+    let nextActionCall = 0;
+    mockNextAction.mockImplementation((): any => {
+      nextActionCall++;
+      if (nextActionCall === 1) {
+        return { type: "ask_llm_decide", threadId: "t-2", responses: "[agent-2]: hello" };
+      }
+      mockPhase = "working";
+      return { type: "work" };
+    });
+
+    let sendCall = 0;
+    mockSend.mockImplementation(async () => {
+      sendCall++;
+      if (sendCall === 1) {
+        return {
+          content: "ADJUST",
+          toolCalls: [],
+          costUsd: 0.01,
+          durationMs: 100,
+          sessionId: "s1",
+        };
+      }
+      return {
+        content: "DONE: finished",
+        toolCalls: [],
+        costUsd: 0.01,
+        durationMs: 100,
+        sessionId: "s1",
+      };
+    });
+
+    const warnSpy = vi.fn();
+    const loggerWithSpy: AgentLoopLogger = { ...silentLogger, warn: warnSpy };
+
+    await runAgentLoop(makeConfig(), loggerWithSpy);
+
+    expect(mockDecideAdjust).not.toHaveBeenCalled();
+    expect(mockDecideContinue).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ADJUST"),
+      expect.anything(),
+    );
   });
 });
 

--- a/tests/unit/coordination-protocol.test.ts
+++ b/tests/unit/coordination-protocol.test.ts
@@ -288,6 +288,41 @@ describe("CoordinationProtocol", () => {
     }
   });
 
+  it("proceeds to work instead of reopening once ADJUST reaches MAX_ROUNDS", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-adjcap",
+      status: "open",
+      expectedRespondents: ["agent-2"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    protocol.onThreadMessage("t-adjcap", "agent-2", "conflict");
+    expect(protocol.nextAction()?.type).toBe("ask_llm_decide"); // round 1, waiting
+
+    // round 1 -> adjust -> round 2
+    protocol.decideAdjust("plan v2");
+    expect(protocol.getThreadState("t-adjcap")?.round).toBe(2);
+    drainActions(protocol);
+
+    // round 2 -> adjust -> round 3 (== MAX_ROUNDS)
+    protocol.decideAdjust("plan v3");
+    expect(protocol.getThreadState("t-adjcap")?.round).toBe(3);
+    drainActions(protocol);
+
+    // round 3 -> adjust at the cap: adopt the plan and work, do NOT reopen
+    protocol.decideAdjust("plan v4");
+    const thread = protocol.getThreadState("t-adjcap");
+    expect(thread?.work.plan).toBe("plan v4");
+    expect(thread?.round).toBe(3); // not bumped past the cap
+    expect(thread?.status).toBe("working");
+    expect(protocol.phase).toBe("working");
+    expect(protocol.nextAction()?.type).toBe("work");
+  });
+
   it("allows a fresh ask_llm_decide after decideAdjust opens a new round", () => {
     protocol.startWork(WORK);
     drainActions(protocol);

--- a/tests/unit/coordination-protocol.test.ts
+++ b/tests/unit/coordination-protocol.test.ts
@@ -250,6 +250,74 @@ describe("CoordinationProtocol", () => {
     expect(thread?.respondedAgents).toEqual([]);
   });
 
+  // ── Adjust: waiting → waiting (new round, updated plan) ────────────
+
+  it("updates the plan, bumps the round, and re-enters waiting on decideAdjust", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-adjust",
+      status: "open",
+      expectedRespondents: ["agent-2"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    // Respondent replies, LLM is asked to decide
+    protocol.onThreadMessage("t-adjust", "agent-2", "I'm touching session.ts too");
+    const decideAction = protocol.nextAction();
+    expect(decideAction?.type).toBe("ask_llm_decide");
+
+    expect(protocol.getThreadState("t-adjust")?.round).toBe(1);
+
+    protocol.decideAdjust("Avoid session.ts, focus on login.ts instead");
+
+    expect(protocol.phase).toBe("waiting");
+    const thread = protocol.getThreadState("t-adjust");
+    expect(thread?.work.plan).toBe("Avoid session.ts, focus on login.ts instead");
+    expect(thread?.round).toBe(2);
+    expect(thread?.respondedAgents).toEqual([]);
+    expect(thread?.decideRequested).toBe(false);
+    expect(thread?.status).toBe("waiting");
+
+    const action = protocol.nextAction();
+    expect(action?.type).toBe("wait_responses");
+    if (action?.type === "wait_responses") {
+      expect(action.threadId).toBe("t-adjust");
+    }
+  });
+
+  it("allows a fresh ask_llm_decide after decideAdjust opens a new round", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-adjust-2",
+      status: "open",
+      expectedRespondents: ["agent-2"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    protocol.onThreadMessage("t-adjust-2", "agent-2", "conflict on file X");
+    drainActions(protocol); // ask_llm_decide
+
+    protocol.decideAdjust("New plan avoiding file X");
+    drainActions(protocol); // wait_responses
+
+    // Round 2: quorum should trigger a fresh ask_llm_decide
+    protocol.onThreadMessage("t-adjust-2", "agent-2", "looks fine now");
+    const action = protocol.nextAction();
+    expect(action?.type).toBe("ask_llm_decide");
+  });
+
+  it("ignores decideAdjust when not waiting", () => {
+    protocol.decideAdjust("some plan");
+    expect(protocol.phase).toBe("idle");
+    expect(protocol.nextAction()).toBeNull();
+  });
+
   // ── Max rounds: 3 contestations → auto-resolve ────────────────────
 
   it("auto-resolves after max rounds", () => {


### PR DESCRIPTION
Handles the coordination LLM's `ADJUST` decision instead of silently treating it as `CONTINUE`.

## The gap

`formatCoordinationContext` offers the coordination LLM three replies — `CONTINUE`, `YIELD`, `ADJUST <new plan>` — but only `YIELD` and `CONTINUE` were handled. An `ADJUST` reply fell into the `else` branch and was treated as `CONTINUE`, so the agent never actually revised its plan.

## Change

- **Protocol**: added `decideAdjust(newPlan)` to `CoordinationProtocol`. It updates the thread's `WorkDescription.plan` and reopens the round via a shared `resetForNewRound()` helper (round bump, reset respondents, clear the per-round decide flag, back to `waiting`, re-enqueue `wait_responses`) — factored out of `onContestation` rather than duplicated. `ThreadState` now carries its `WorkDescription` so the plan can be updated in place.
- **Handler** (`agent-loop.ts`): branches explicitly on an `ADJUST` decision, parsing the new plan from the reply. A malformed `ADJUST` (empty/missing plan) logs a warning and falls back to `CONTINUE`, so it can't wedge the loop.
- **Bounded**: `decideAdjust` respects the same `MAX_ROUNDS` cap as `onContestation` — at the cap it adopts the latest plan and proceeds to work instead of reopening yet another round, so a persistently-`ADJUST`ing LLM can't loop indefinitely.

## Tests

`tests/unit/coordination-protocol.test.ts` + `tests/unit/agent-loop.test.ts` (test-first, red→green): `decideAdjust` updates the plan / bumps the round / re-enters waiting; the handler routes `ADJUST <plan>` to `decideAdjust`; a plan-less `ADJUST` falls back to `CONTINUE` without bumping the round; and `ADJUST` at `MAX_ROUNDS` proceeds to work without reopening. `npm run build` clean; suite green apart from the pre-existing Windows-only POSIX-permission test.

## Known limitation (v1)

`decideAdjust` reuses `onContestation`'s local reset — it does not proactively re-announce the new plan text to peers over REST; the round simply reopens and re-coordinates through the normal thread-message flow. A proactive re-announce could be a follow-up if peers should see the revised plan immediately.
