### PR TITLE
fix(orchestrator): cap concurrent agent launches and refuse resetBase's implicit-cwd clean

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -66,6 +66,37 @@ async function postJson(url: string, body: unknown, timeoutMs = 5000): Promise<b
 
 const COORDINATOR_URL = process.env.COORDINATOR_URL || "http://localhost:3100";
 const DEFAULT_BASE = process.cwd(); // default to current working directory
+const DEFAULT_MAX_CONCURRENCY = 8;
+
+/**
+ * Minimal counting semaphore. Caps how many launches are in flight at once,
+ * independent of stagger config — stagger.mode "fixed"/"random" with `delay`
+ * omitted otherwise spawns every agent in project.agents back-to-back in the
+ * same tick with no throttling at all. `acquire()` resolves once a slot is
+ * free; the caller must invoke the returned release function when its unit
+ * of work finishes so the next queued caller can proceed.
+ */
+function createConcurrencyLimiter(max: number): () => Promise<() => void> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const grantNext = () => {
+    if (active >= max || queue.length === 0) return;
+    active++;
+    queue.shift()!();
+  };
+  return function acquire(): Promise<() => void> {
+    return new Promise<() => void>((resolve) => {
+      let released = false;
+      queue.push(() => resolve(() => {
+        if (released) return;
+        released = true;
+        active--;
+        grantNext();
+      }));
+      grantNext();
+    });
+  };
+}
 
 // On a run-level timeout, agent-loop promises are raced against the deadline
 // (see the "Wait for all agents" section) — the race settles the instant the
@@ -354,6 +385,37 @@ async function _runProjectBody(
     return proc;
   }
 
+  // Bound fan-out independent of stagger. Both launch loops below spawn
+  // agents without awaiting their completion (sequential/delayed stagger is a
+  // best-effort throttle, not a cap) — a config with stagger.mode "fixed"/
+  // "random" and delay omitted otherwise launches every agent in the same
+  // tick. acquireLaunchSlot() blocks the loop from spawning the next agent
+  // once max_concurrency agents are in flight, and is released once that
+  // agent's underlying work (child process exit, or agent-loop settlement)
+  // completes — independent of when the caller stops waiting on it (e.g. the
+  // run-level timeout race in the "Wait for all agents" section below).
+  const maxConcurrency = project.max_concurrency ?? DEFAULT_MAX_CONCURRENCY;
+  const acquireLaunchSlot = createConcurrencyLimiter(maxConcurrency);
+
+  async function launchWithLimit(agent: typeof project.agents[0]): Promise<ChildProcess | null> {
+    const release = await acquireLaunchSlot();
+    const proc = setupAndLaunch(agent);
+    if (useAgentLoop) {
+      const loopPromise = agentLoopPromises.get(agent.id);
+      if (loopPromise) {
+        loopPromise.finally(release);
+      } else {
+        release();
+      }
+    } else if (proc) {
+      proc.once("exit", release);
+      proc.once("error", release);
+    } else {
+      release();
+    }
+    return proc;
+  }
+
   if (hasLaunchDelays) {
     // Group-based launching: group agents by launch_delay, launch each group together
     const groups = new Map<number, typeof project.agents>();
@@ -373,7 +435,7 @@ async function _runProjectBody(
       elapsed = delayTarget;
       for (const agent of groups.get(delayTarget)!) {
         if (!isLaunchable(agent)) continue;
-        setupAndLaunch(agent);
+        await launchWithLimit(agent);
       }
     }
   } else {
@@ -381,7 +443,7 @@ async function _runProjectBody(
     for (let i = 0; i < project.agents.length; i++) {
       const agent = project.agents[i];
       if (!isLaunchable(agent)) continue;
-      const proc = setupAndLaunch(agent);
+      const proc = await launchWithLimit(agent);
 
       // Stagger
       if (i < project.agents.length - 1) {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -211,6 +211,16 @@ async function _runProjectBody(
   // 2. Create workspaces (resetBase FIRST, then setup, then worktrees)
   const basePath = project.workspace.base || DEFAULT_BASE;
   if (project.workspace.type === "worktree") {
+    // resetBase runs `git checkout -- .` + `git clean -fd` — refuse to let it
+    // silently target process.cwd() when the destructive opt-in is set but
+    // the config never named an explicit base. Falling back to cwd here has
+    // no safe reading: whatever directory the operator happened to invoke
+    // essaim from would get wiped.
+    if (process.env.ESSAIM_RESET_BASE === "1" && !project.workspace.base) {
+      throw new Error(
+        "resetBase refused: set workspace.base explicitly before ESSAIM_RESET_BASE=1",
+      );
+    }
     resetBase(basePath);
   }
 

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -44,6 +44,13 @@ export interface MiniProject {
   };
   timeout_minutes?: number;
   use_legacy_mode?: boolean; // Opt-out: fall back to claude -p one-shot instead of agent-loop
+  // Caps how many agents are launched (and running) at once during fan-out,
+  // independent of stagger config. Defaults to 8. Composes with stagger: a
+  // sequential/staggered project already launches at most one (or a delayed
+  // trickle of) agents at a time and never hits this ceiling; it only bounds
+  // configs where stagger.mode is "fixed"/"random" with delay omitted, which
+  // otherwise launches every agent in project.agents back-to-back with no wait.
+  max_concurrency?: number;
   setup?: string;
   during_run?: string;
   teardown?: string;

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -225,3 +225,66 @@ describe("runProject — timeout teardown ordering (#112)", () => {
     expect(order).toEqual(["agent-drained", "coordinator-stopped"]);
   });
 });
+
+// ── resetBase refuses an implicit cwd fallback ──────────────────────────────
+
+describe("runProject — resetBase refuses implicit cwd fallback", () => {
+  const ORIGINAL_ENV = process.env.ESSAIM_RESET_BASE;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.ESSAIM_RESET_BASE;
+    else process.env.ESSAIM_RESET_BASE = ORIGINAL_ENV;
+  });
+
+  it("refuses to run (and never touches cwd) when ESSAIM_RESET_BASE=1 and workspace.base is unset", async () => {
+    process.env.ESSAIM_RESET_BASE = "1";
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "worktree" }, // base intentionally omitted
+    });
+
+    await expect(
+      runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" })
+    ).rejects.toThrow(/resetBase refused/);
+
+    // The agent must never have been launched — the refusal happens before
+    // any workspace/agent setup.
+    expect(launchAgentLoop).not.toHaveBeenCalled();
+  });
+
+  it("proceeds normally when ESSAIM_RESET_BASE=1 and workspace.base IS set", async () => {
+    process.env.ESSAIM_RESET_BASE = "1";
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "worktree", base: TMP_DIR },
+    });
+
+    const result = await runProject(project, "with_coordinator", false, {
+      coordinatorUrl: "http://coordinator.test",
+    });
+
+    expect(launchAgentLoop).toHaveBeenCalledTimes(1);
+    expect(result.agent_results).toHaveLength(1);
+  });
+
+  it("does not throw when ESSAIM_RESET_BASE is unset, even with workspace.base omitted (no regression)", async () => {
+    delete process.env.ESSAIM_RESET_BASE;
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "worktree" }, // base omitted, but no destructive opt-in
+    });
+
+    await expect(
+      runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" })
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -226,6 +226,112 @@ describe("runProject — timeout teardown ordering (#112)", () => {
   });
 });
 
+// ── Concurrency cap on agent fan-out ────────────────────────────────────────
+
+describe("runProject — concurrency cap on agent fan-out", () => {
+  /**
+   * Wires launchAgentLoop to track how many launches are simultaneously
+   * in-flight and hand back per-agent resolvers so the test can release them
+   * in a controlled order.
+   */
+  function makeTrackedLaunch() {
+    let active = 0;
+    let maxActive = 0;
+    const pending: Array<() => void> = [];
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => pending.push(resolve));
+      active--;
+      return makeLoopResult(agent.id);
+    });
+    return {
+      get maxActive() { return maxActive; },
+      get pendingCount() { return pending.length; },
+      releaseOne() { pending.shift()?.(); },
+      releaseAll() { while (pending.length) pending.shift()!(); },
+    };
+  }
+
+  function makeFanoutProject(agentCount: number, extra: Partial<MiniProject> = {}): MiniProject {
+    const agents = Array.from({ length: agentCount }, (_, i) =>
+      makeAgent({ id: `a${i}`, name: `Agent ${i}` })
+    );
+    const registerOk: Record<string, boolean> = Object.fromEntries(agents.map((a) => [a.id, true]));
+    vi.stubGlobal("fetch", makeFetchMock(registerOk));
+    return makeProject({
+      agents,
+      workspace: { type: "none", base: TMP_DIR },
+      // mode "fixed" with no delay: the no-throttle path — every agent would
+      // otherwise launch back-to-back in the same tick.
+      stagger: { mode: "fixed" },
+      ...extra,
+    });
+  }
+
+  it("never runs more than max_concurrency agent-loops in flight at once", async () => {
+    const tracked = makeTrackedLaunch();
+    const project = makeFanoutProject(5, { max_concurrency: 2 });
+
+    const runPromise = runProject(project, "with_coordinator", false, {
+      coordinatorUrl: "http://coordinator.test",
+    });
+
+    // Only 2 of the 5 agents should have been allowed to start.
+    await vi.waitFor(() => expect(tracked.pendingCount).toBe(2));
+    expect(tracked.maxActive).toBeLessThanOrEqual(2);
+
+    // Releasing one in-flight agent should let exactly one more through —
+    // still never exceeding the cap.
+    tracked.releaseOne();
+    await vi.waitFor(() => expect(tracked.pendingCount).toBe(2));
+    expect(tracked.maxActive).toBeLessThanOrEqual(2);
+
+    tracked.releaseAll();
+    await vi.waitFor(() => expect(tracked.pendingCount).toBeGreaterThan(0));
+    tracked.releaseAll();
+    await runPromise;
+
+    expect(tracked.maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it("defaults max_concurrency to 8 when unset", async () => {
+    const tracked = makeTrackedLaunch();
+    const project = makeFanoutProject(10); // no max_concurrency override
+
+    const runPromise = runProject(project, "with_coordinator", false, {
+      coordinatorUrl: "http://coordinator.test",
+    });
+
+    await vi.waitFor(() => expect(tracked.pendingCount).toBe(8));
+    expect(tracked.maxActive).toBeLessThanOrEqual(8);
+
+    tracked.releaseAll();
+    await vi.waitFor(() => expect(tracked.pendingCount).toBeGreaterThan(0));
+    tracked.releaseAll();
+    await runPromise;
+
+    expect(tracked.maxActive).toBeLessThanOrEqual(8);
+  });
+
+  it("does not cap below the configured max_concurrency (no false throttling)", async () => {
+    const tracked = makeTrackedLaunch();
+    const project = makeFanoutProject(3, { max_concurrency: 8 });
+
+    const runPromise = runProject(project, "with_coordinator", false, {
+      coordinatorUrl: "http://coordinator.test",
+    });
+
+    // All 3 agents (well under the cap) should launch immediately.
+    await vi.waitFor(() => expect(tracked.pendingCount).toBe(3));
+
+    tracked.releaseAll();
+    await runPromise;
+
+    expect(tracked.maxActive).toBe(3);
+  });
+});
+
 // ── resetBase refuses an implicit cwd fallback ──────────────────────────────
 
 describe("runProject — resetBase refuses implicit cwd fallback", () => {


### PR DESCRIPTION
Two independent orchestrator hardening fixes.

## resetBase refuses the implicit-cwd destructive clean (D116)
`resetBase` runs `git checkout -- .` + `git clean -fd`, and the base path defaulted to `process.cwd()` when `project.workspace.base` was unset — so a misconfigured run under `ESSAIM_RESET_BASE=1` could destructively clean the current working directory. Now, when `ESSAIM_RESET_BASE=1` and `workspace.base` is not set, the run refuses with a clear error (`resetBase refused: set workspace.base explicitly before ESSAIM_RESET_BASE=1`) instead of falling back to cwd. Behavior is unchanged when the reset flag is off, or when `workspace.base` is set.

## Cap concurrent agent launches (D115)
With `stagger.mode` "fixed"/"random" and `delay` omitted, every agent in `project.agents` launched back-to-back in the same tick with no throttle. Added an optional `max_concurrency` (default **8**) to the project config and a small inline counting semaphore that gates launches in both loops, so at most `max_concurrency` agent-loops run at once. Non-breaking: sequential/staggered configs are unaffected — the cap composes with them; it only bounds an otherwise-unlimited parallel fan-out. Applied to both the agent-loop and legacy child-process launch paths (the unbounded-fan-out gap is identical in both).

## Tests
`tests/unit/orchestrator-run.test.ts`: concurrency never exceeds the cap (with `max_concurrency=2` over 5 agents, and the default 8 over 10) — verified red→green by reverting the limiter; and the resetBase refusal path (verified by inspection, since exercising it live would run a real `git clean`). `npm run build` clean; suite green apart from the pre-existing Windows-only POSIX-permission test.
