### PR TITLE
fix(hooks): report workspace-relative paths from submodule checkouts

### DIFF
--- a/scripts/pre_track_activity.sh
+++ b/scripts/pre_track_activity.sh
@@ -27,7 +27,12 @@ fi
 # In team-mode the coordinator is on a different machine and cannot
 # resolve the agent's local repo root; only this client can.
 if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
-  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+  # Prefer the SUPERPROJECT root when this file lives inside a submodule, so
+  # paths reported to the coordinator are workspace-relative (relative to the
+  # outer working tree, e.g. a nested multi-repo workspace) rather than
+  # submodule-relative. Falls back to the repo toplevel in a normal checkout.
+  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-superproject-working-tree 2>/dev/null)
+  [ -z "$REPO_ROOT" ] && REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
   if [ -n "$REPO_ROOT" ] && [[ "$FILE_PATH" == "$REPO_ROOT"/* ]]; then
     FILE_PATH="${FILE_PATH#$REPO_ROOT/}"
   fi

--- a/scripts/track_activity.sh
+++ b/scripts/track_activity.sh
@@ -64,7 +64,12 @@ fi
 # In team-mode the coordinator is on a different machine and cannot
 # resolve the agent's local repo root; only this client can.
 if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
-  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+  # Prefer the SUPERPROJECT root when this file lives inside a submodule, so
+  # paths reported to the coordinator are workspace-relative (relative to the
+  # outer working tree, e.g. a nested multi-repo workspace) rather than
+  # submodule-relative. Falls back to the repo toplevel in a normal checkout.
+  REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-superproject-working-tree 2>/dev/null)
+  [ -z "$REPO_ROOT" ] && REPO_ROOT=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
   if [ -n "$REPO_ROOT" ] && [[ "$FILE_PATH" == "$REPO_ROOT"/* ]]; then
     FILE_PATH="${FILE_PATH#$REPO_ROOT/}"
   fi


### PR DESCRIPTION
Makes the activity-tracking hooks report **workspace-relative** paths when the edited file lives inside a submodule.

`track_activity.sh` / `pre_track_activity.sh` stripped `FILE_PATH` against `git rev-parse --show-toplevel`, which — inside a submodule — resolves to the *submodule* root, so the path POSTed to the coordinator was submodule-relative rather than relative to the outer working tree. Now they prefer `git rev-parse --show-superproject-working-tree` (the superproject root when in a submodule) and fall back to `--show-toplevel` otherwise.

This is a **no-op in a normal flat checkout** (no superproject → falls back to today's behavior) and fixes path reporting for nested multi-repo workspaces where the runner is checked out as a submodule. `bash -n` clean.
