### PR TITLE
fix(catalog): interpole ou retire les params que l'assemblage jetait (#79)

### DIFF
--- a/behaviors/announce-before-write.yaml
+++ b/behaviors/announce-before-write.yaml
@@ -16,13 +16,6 @@ requires:
 conflicts_with: [silent-mode]
 suggests: [conflict-resolution]
 
-params:
-  announce_threshold:
-    type: number
-    default: 1
-    required: false
-    description: "Minimum files before announcing"
-
 sections:
   "015-wait-for-peers":
     prompt: |

--- a/behaviors/audit-reconciliator.yaml
+++ b/behaviors/audit-reconciliator.yaml
@@ -30,10 +30,6 @@ params:
       - "Risques de migration (séparés des complexités)"
       - "Estimation effort (S/M/L/XL) + range jours-dev (best/likely/worst)"
       - "Notes migration React (court, factuel)"
-  effort:
-    type: string
-    default: high
-    description: "Effort profile — high (Opus) recommended for synthesis judgment"
 
 sections:
   "030-mission":

--- a/behaviors/audit-specialist.yaml
+++ b/behaviors/audit-specialist.yaml
@@ -23,10 +23,6 @@ params:
     type: string
     required: true
     description: "YAML schema the agent must produce. Reconciliator depends on this contract."
-  effort:
-    type: string
-    default: mid
-    description: "Effort profile (low/mid/high/max). Defaults to mid (Sonnet)."
 
 sections:
   "030-mission":

--- a/behaviors/bug-hunting.yaml
+++ b/behaviors/bug-hunting.yaml
@@ -30,9 +30,15 @@ sections:
          d. Poste les détails (post_to_thread type: "warning") avec fichier et ligne
          e. Appelle log_action_summary
       4. Catégories de bugs à chercher:
+      {{#if params.bug_categories}}
+      {{#each params.bug_categories}}
+         - {{this}}
+      {{/each}}
+      {{else}}
          - Valeurs nulles / undefined non gérées
          - Edge cases manquants (tableau vide, chaîne vide, nombres négatifs)
          - Erreurs de gestion d'exceptions
          - Conditions limites dans les boucles
          - Problèmes de concurrence ou d'état
+      {{/if}}
       5. Lance les tests régulièrement

--- a/behaviors/discovery-synth.yaml
+++ b/behaviors/discovery-synth.yaml
@@ -16,6 +16,9 @@ sections:
   "030-mission":
     prompt: |
       ## Ta mission — Synthèse de découverte
+      Prototype : `{{params.projet}}` — c'est le nom kebab-case à reprendre tel
+      quel dans le frontmatter `titre` du `spec_draft`, sans le reformuler.
+
       Les 4 angles ont posé leurs résultats dans `tmp/decouverte/*.yaml`
       (features, risques, roi, questions). Lis-les tous, arbitre les
       recoupements/contradictions en retournant au transcript

--- a/behaviors/quality-audit.yaml
+++ b/behaviors/quality-audit.yaml
@@ -14,12 +14,18 @@ sections:
       ## Ta mission — Audit qualité
       Analyse le projet selon ces catégories:
 
+      {{#if params.categories}}
+      {{#each params.categories}}
+      - {{this}}
+      {{/each}}
+      {{else}}
       1. **Structure** — Organisation des fichiers, séparation des responsabilités, profondeur des répertoires
       2. **Conventions** — Naming (fichiers, variables, fonctions), cohérence du style
       3. **Complexité** — Fichiers trop longs (>300 lignes), fonctions complexes, nesting profond
       4. **Dette technique** — TODO/FIXME/HACK dans le code, code commenté, imports inutilisés
       5. **Tests** — Couverture apparente (ratio fichiers test / fichiers source), fichiers sans tests
       6. **Documentation** — Présence de README, commentaires sur les modules publics
+      {{/if}}
 
       Pour chaque catégorie:
       - Annonce via announce_work (subject: "Analyse: [catégorie]")

--- a/behaviors/test-writing.yaml
+++ b/behaviors/test-writing.yaml
@@ -23,7 +23,10 @@ sections:
          - depends_on_files: les fichiers source que tu testes
       2. Si le coordinator détecte un conflit, participe à la consultation
       3. SEULEMENT après résolution, écris tes tests
-      4. Utilise le framework de test existant du projet
+      {{#if params.test_dir}}
+         Écris-les sous `{{params.test_dir}}`.
+      {{/if}}
+      4. Utilise {{#if params.test_framework}}`{{params.test_framework}}`{{else}}le framework de test existant du projet{{/if}}
       5. Vérifie que tes tests passent
       6. Appelle log_action_summary après chaque fichier
       Coordonne-toi avec les autres agents pour éviter les doublons.

--- a/tests/unit/catalog-params.test.ts
+++ b/tests/unit/catalog-params.test.ts
@@ -1,0 +1,110 @@
+// tests/unit/catalog-params.test.ts
+//
+// essaim#79 — `quality-audit` déclarait un param `categories` qu'aucune section
+// n'interpolait. La valeur passait la validation de schéma puis disparaissait à
+// l'assemblage : un preset qui surchargeait les catégories produisait un prompt
+// byte-identical au preset générique, et le `--dry-run` ne montrait rien.
+//
+// Ces tests exercent le catalogue bundlé par le vrai assembleur : ils échouent
+// si quelqu'un retire une interpolation, et ils échoueraient aussi si on
+// « corrigeait » le bug en supprimant simplement le param.
+import { describe, it, expect } from "vitest";
+import { runPipeline } from "@swoofer/promptweave";
+import { getBundledRoot } from "../../cli/bce-resolver.js";
+
+function promptFor(
+  behavior: string,
+  params: Record<string, unknown> = {},
+): string {
+  const result = runPipeline(
+    { name: "test", behaviors: [behavior], add: [], remove: [], params: {} },
+    getBundledRoot(),
+    { [behavior]: params },
+  );
+  return result.output.prompt;
+}
+
+describe("quality-audit — categories (#79)", () => {
+  it("une valeur fournie atteint le prompt", () => {
+    const prompt = promptFor("quality-audit", {
+      categories: ["Ergonomie du CLI", "Budget de tours"],
+    });
+
+    expect(prompt).toContain("Ergonomie du CLI");
+    expect(prompt).toContain("Budget de tours");
+  });
+
+  it("sans valeur, les six catégories par défaut restent en place", () => {
+    const prompt = promptFor("quality-audit");
+
+    for (const defaut of [
+      "Structure",
+      "Conventions",
+      "Complexité",
+      "Dette technique",
+      "Tests",
+      "Documentation",
+    ]) {
+      expect(prompt).toContain(defaut);
+    }
+  });
+
+  it("une valeur fournie remplace les défauts au lieu de s'y ajouter", () => {
+    // Sinon l'agent auditerait huit catégories dont six qu'on ne lui a pas demandées.
+    const prompt = promptFor("quality-audit", { categories: ["Ergonomie du CLI"] });
+
+    expect(prompt).not.toContain("Dette technique");
+  });
+
+  it("le prompt diffère de celui par défaut — le repro exact de l'issue", () => {
+    // L'issue se manifestait comme deux prompts rigoureusement identiques.
+    expect(promptFor("quality-audit", { categories: ["Ergonomie du CLI"] })).not.toBe(
+      promptFor("quality-audit"),
+    );
+  });
+});
+
+describe("bug-hunting — bug_categories", () => {
+  it("une valeur fournie atteint le prompt", () => {
+    const prompt = promptFor("bug-hunting", {
+      bug_categories: ["Fuites de descripteurs de fichiers"],
+    });
+
+    expect(prompt).toContain("Fuites de descripteurs de fichiers");
+  });
+
+  it("sans valeur, les catégories par défaut restent en place", () => {
+    const prompt = promptFor("bug-hunting");
+
+    expect(prompt).toContain("Edge cases manquants");
+    expect(prompt).toContain("Problèmes de concurrence");
+  });
+});
+
+describe("test-writing — test_framework et test_dir", () => {
+  it("le framework fourni atteint le prompt", () => {
+    expect(promptFor("test-writing", { test_framework: "vitest" })).toContain("vitest");
+  });
+
+  it("le répertoire fourni atteint le prompt", () => {
+    expect(promptFor("test-writing", { test_dir: "tests/unit" })).toContain("tests/unit");
+  });
+
+  it("sans valeur, la consigne générique reste — aucun placeholder vide", () => {
+    const prompt = promptFor("test-writing");
+
+    expect(prompt).toContain("framework de test existant");
+    expect(prompt).not.toMatch(/\{\{|\}\}/);
+  });
+});
+
+describe("discovery-synth — projet", () => {
+  it("le nom du prototype fourni atteint le prompt", () => {
+    const prompt = promptFor("discovery-synth", {
+      transcript: "tmp/transcript.md",
+      projet: "commandes-boulangerie",
+    });
+
+    expect(prompt).toContain("commandes-boulangerie");
+  });
+});


### PR DESCRIPTION
Corrige [#79](https://github.com/swoofer/essaim/issues/79).

`quality-audit` déclarait un param `categories` qu'aucune section n'interpolait. La valeur passait la validation de schéma puis disparaissait à l'assemblage : silencieux par construction, le `--dry-run` ne montrait rien à moins de comparer les tailles de prompt.

Le symptôme décrit dans l'issue n'est plus reproductible ici — le preset `mekova-review` a quitté le repo public en `5dcd52a`. La cause racine, elle, était toujours vivante sur `main`, et le repro de l'issue au `--set` le montrait bien : le prompt restait à 4608 chars quoi qu'on fournisse. Il passe maintenant à 4152.

## Sept params, deux traitements

Quatre étaient des trous d'interpolation à combler, en `{{#if}}`/`{{#each}}`/`{{else}}` : `quality-audit.categories`, `bug-hunting.bug_categories`, `test-writing.{test_framework,test_dir}` et `discovery-synth.projet` — ce dernier `required: true`, donc l'appelant était forcé de fournir une valeur qui partait à la poubelle. Une valeur fournie **remplace** les défauts au lieu de s'y ajouter, sinon l'agent auditerait des catégories que personne ne lui a demandées.

Trois autres n'étaient pas des trous et sont retirés. `announce-before-write.announce_threshold` décrivait déjà le comportement en dur ; l'honorer voudrait dire demander à l'agent de compter ses fichiers avant d'annoncer, ce qui est fragile en prompt, et aucun preset ne l'a jamais réglé. `audit-specialist.effort` et `audit-reconciliator.effort` ne peuvent structurellement pas fonctionner : `assemblePhases` ne lit les knobs `effort`/`model`/`thinking`/`maxTurns` que sur un behavior déclarant une phase nommée, et ces deux-là n'en ont pas — les presets `phare-*` qui les utilisent n'incluent aucun behavior `phase-*`, donc l'assemblage part en mode one-shot. Leur `default` annonçait un réglage qui n'existait pas.

## Ce que l'analyse manuelle avait raté

`audit-reconciliator.effort` avait d'abord été blanchi à tort : chercher `params.effort` par sous-chaîne matche `params.effort_scale`, qui lui est bien interpolé. Et une première passe avait aussi compté à tort comme morts les 13 params des behaviors `phase-*` et de `security-fix`, plus `coordinator-rules.solo_mode` — les premiers sont lus comme knobs de phase, le dernier par `params_match` dans [compositions/solo-mode.yaml](compositions/solo-mode.yaml).

C'est ce qui a motivé de mettre la règle dans l'assembleur plutôt que dans un script maison : [swoofer/promptweave#16](https://github.com/swoofer/promptweave/pull/16) ajoute `findUnusedParams`, qui relève les références via le parseur Handlebars et connaît les cinq canaux réels. Le garde-fou de catalogue qui s'en sert arrive en PR de suivi, une fois promptweave 0.4.0 publié.

## Tests

10 tests de non-régression passant par le vrai assembleur sur le catalogue bundlé. Ils couvrent les deux sens — la valeur fournie atteint le prompt, et les défauts survivent quand rien n'est fourni — de sorte qu'ils échoueraient aussi si on « corrigeait » le bug en supprimant simplement le param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
