### PR TITLE
test(catalog): garde-fou contre les params qu'aucun canal ne peut lire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.0",
-        "@swoofer/promptweave": "^0.3.0",
+        "@swoofer/promptweave": "^0.4.0",
         "commander": "^14.0.3",
         "handlebars": "^4.7.0",
         "mcp-coordinator": "^0.13.0",
@@ -937,9 +937,9 @@
       "license": "MIT"
     },
     "node_modules/@swoofer/promptweave": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@swoofer/promptweave/-/promptweave-0.3.0.tgz",
-      "integrity": "sha512-dViqf6Qw3yssegnKCRyfvIS9TsyKH9x3XITZNGB9UfRB7z3SxBEDTJXqM6SKmfTiUI4qJGrry4DGvV6IaXyXYg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@swoofer/promptweave/-/promptweave-0.4.0.tgz",
+      "integrity": "sha512-sP3TGehiLlorgCwapVfJGkET1x8F769/6Dh4Q2/eQN2HCXqZNVbO4MIBMiwjp/Fzd53QFiYpa5uIqqSF655TYg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",
-    "@swoofer/promptweave": "^0.3.0",
+    "@swoofer/promptweave": "^0.4.0",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
     "mcp-coordinator": "^0.13.0",

--- a/tests/unit/catalog-lint.test.ts
+++ b/tests/unit/catalog-lint.test.ts
@@ -1,0 +1,72 @@
+// tests/unit/catalog-lint.test.ts
+//
+// Garde-fou de catalogue : un behavior ne doit pas déclarer un param qu'aucun
+// canal d'assemblage ne peut lire.
+//
+// Complémentaire du warning runtime de promptweave, qui ne parle que si un
+// appelant pose effectivement une valeur. Un param que personne ne règle reste
+// mort en silence pour toujours — c'est exactement comme ça que
+// `quality-audit.categories` a pourri jusqu'à #79.
+//
+// La règle vient de findUnusedParams plutôt que d'être réécrite ici : les canaux
+// (sections, args de hooks, side_car_files, knobs de phase, compositions) sont
+// une propriété de l'assembleur, et les dupliquer, c'est les voir diverger.
+import { describe, it, expect } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Registry, findUnusedParams } from "@swoofer/promptweave";
+import { getBundledRoot } from "../../cli/bce-resolver.js";
+
+describe("catalogue bundlé — params orphelins", () => {
+  const registry = Registry.load(getBundledRoot());
+
+  it("charge réellement le catalogue", () => {
+    // Sans ça, l'assertion suivante passerait à vide si la résolution de racine
+    // cassait : un garde-fou qui ne regarde rien est pire que pas de garde-fou.
+    expect(registry.behaviors.size).toBeGreaterThan(20);
+  });
+
+  it("aucun behavior ne déclare un param que rien ne peut lire", () => {
+    const orphelins = findUnusedParams(registry.behaviors, registry.compositions.values());
+
+    expect(
+      orphelins.map((o) => `${o.behavior}.${o.param}`),
+      "Interpole ce param, ou retire sa déclaration. Une valeur fournie pour un " +
+        "param qu'aucune section, hook, side_car_file, knob de phase ou composition " +
+        "ne lit est validée par le schéma puis jetée sans un mot.",
+    ).toEqual([]);
+  });
+});
+
+describe("le lint détecte vraiment un orphelin", () => {
+  it("signale un param déclaré et jamais interpolé", () => {
+    // Preuve que le test ci-dessus est vert parce que le catalogue est sain, et
+    // non parce que le lint ne trouve jamais rien.
+    const root = join(tmpdir(), `essaim-lint-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(root, "behaviors"), { recursive: true });
+    writeFileSync(
+      join(root, "behaviors", "temoin.yaml"),
+      [
+        "name: temoin",
+        'description: "déclare un param que sa section ignore"',
+        "params:",
+        "  jete:",
+        '    type: string',
+        "    required: false",
+        "sections:",
+        '  "030-mission":',
+        '    prompt: "texte statique"',
+      ].join("\n"),
+    );
+
+    try {
+      const temoin = Registry.load(root);
+      expect(findUnusedParams(temoin.behaviors, temoin.compositions.values())).toEqual([
+        { behavior: "temoin", param: "jete" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Suite de #87, qui corrigeait les sept params morts trouvés à l'occasion de [#79](https://github.com/swoofer/essaim/issues/79). Ce PR empêche la classe entière de revenir.

## Pourquoi un test en plus du warning runtime

promptweave 0.4.0 ([swoofer/promptweave#16](https://github.com/swoofer/promptweave/pull/16)) avertit désormais quand un appelant fournit une valeur qu'aucun canal ne peut lire. Mais il ne parle que dans ce cas : un param que *personne* ne règle reste mort en silence pour toujours.

C'est exactement comme ça que `quality-audit.categories` a pourri jusqu'à #79 — aucun preset du catalogue public ne surchargeait les catégories, donc rien ne se plaignait jamais. Le warning attrape l'utilisateur ignoré, ce test attrape la déclaration morte.

## La règle n'est pas réécrite ici

Le test appelle `findUnusedParams`, importé de promptweave. Les cinq canaux — sections, args de hooks, `side_car_files`, knobs de phase, compositions — sont une propriété de l'assembleur ; les dupliquer côté catalogue, c'est les voir diverger.

Ce n'est pas théorique : en analysant #79 à la main, la règle a été reconstituée faussement deux fois. Une recherche par sous-chaîne de `params.effort` matche `params.effort_scale`, ce qui a blanchi à tort `audit-reconciliator.effort` ; et 14 params ont d'abord été comptés morts alors qu'ils sont lus comme knobs de phase ou via `params_match`. Le parseur Handlebars de `findUnusedParams` ne se trompe sur ni l'un ni l'autre.

## Deux gardes contre le faux vert

Un test « zéro orphelin » est vide de sens s'il ne regarde rien. Le catalogue doit donc se charger non vide — sinon l'assertion passerait si la résolution de racine cassait — et un catalogue témoin en `tmp` doit produire une détection positive, sinon un lint qui ne trouve jamais rien passerait pour un catalogue sain.

Vérifié en réinjectant temporairement un param mort dans `behaviors/quality-audit.yaml` : le test échoue en nommant `quality-audit.fantome`, avec un message qui dit quoi faire — interpoler, ou retirer la déclaration.

## Note

Le bump vers `^0.4.0` est nécessaire : `findUnusedParams` n'existe pas en 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
