### PR TITLE
ci: passe le runtime des actions et le node des jobs sur Node 24

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # When dispatched / called, check out the requested tag rather than
           # the caller's branch (which is typically refs/heads/main).
@@ -62,9 +62,9 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci
@@ -121,7 +121,7 @@ jobs:
           tar czf "${DIST_NAME}.tar.gz" "${DIST_NAME}"
 
       - name: Publish tarball to GH Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           # tag_name is required on workflow_call / workflow_dispatch because
           # github.ref is the caller branch (not the tag). On a direct

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         if: ${{ github.event_name == 'push' || inputs.publish_only != 'true' }}
         with:
@@ -40,13 +40,13 @@ jobs:
           # implicitly on the repository's default-branch setting.
           target-branch: main
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ steps.release.outputs.release_created || inputs.publish_only == 'true' }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: ${{ steps.release.outputs.release_created || inputs.publish_only == 'true' }}
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   no-domain-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Refuser les fichiers mekova
         run: |
           hits=$(git ls-files 'templates/mekova-*' 'presets/mekova-*' 'behaviors/mekova-*' 'compositions/mekova-*')
@@ -30,11 +30,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - run: npm install


### PR DESCRIPTION
Chaque run signalait la dépréciation de Node 20 : les runners forçaient déjà sur Node 24 les actions qui le ciblent.

## Actions

| action | avant | après |
|---|---|---|
| `actions/checkout` | v4.4.0 (node20) | v7.0.1 (node24) |
| `actions/setup-node` | v4.4.0 (node20) | v7.0.0 (node24) |
| `softprops/action-gh-release` | v2.6.2 (node20) | v3.0.2 (node24) |
| `googleapis/release-please-action` | v4.4.1 (node20) | v5.0.0 (node24) |

`oven-sh/setup-bun` v2.2.0 était déjà en node24 et ne bouge pas.

Les deux bumps majeurs sont purement runtime : release-please 5.0.0 ne déclare comme breaking change que le passage à node24, sans rupture d'API ni de config — `config-file`, `manifest-file` et `target-branch` sont inchangés. action-gh-release 3.0.0 ne change que la cible du bundle.

Les SHAs sont résolus depuis les tags via l'API GitHub, pas recopiés à la main.

## Node des jobs

`node-version` passe de 22 à 24 dans les trois workflows : Node 24 est l'Active LTS courante, Node 22 est en maintenance, et le paquet déclare `engines: node >=20`.

## Vérification

Le vrai test est ce run de CI : il doit passer sans l'annotation de dépréciation. La compilation des binaires par `release-binaries.yml` ne s'exécute que sur une release — à surveiller au prochain cut, `action-gh-release` y ayant changé de majeure.

Le même changement part en parallèle sur [swoofer/promptweave#19](https://github.com/swoofer/promptweave/pull/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
