### PR TITLE
fix(test): n'exige les bits POSIX que là où ils existent

### DIFF
--- a/tests/unit/orchestrator-write.test.ts
+++ b/tests/unit/orchestrator-write.test.ts
@@ -89,7 +89,13 @@ describe("writeClaudeHooksDir", () => {
     expect(hookScript).toMatch(/[/\\]scripts[/\\]test_script\.sh/);
   });
 
-  it("writes hook scripts with 0o755 permissions", () => {
+  // POSIX seulement : Windows n'implémente pas les bits de permission POSIX.
+  // fs.chmod n'y pilote que l'attribut lecture-seule, si bien qu'un fichier écrit
+  // avec `{ mode: 0o755 }` ressort en 0o666 et que le bit d'exécution vaut 0 —
+  // l'assertion ne peut jamais tenir. Ce n'est pas un défaut du produit : le mode
+  // compte sur les plateformes où les hooks s'exécutent réellement, et il y est
+  // toujours vérifié.
+  it.skipIf(process.platform === "win32")("writes hook scripts with 0o755 permissions", () => {
     const claudeDir = path.join(TMP_ROOT, "perms", ".claude");
     writeClaudeHooksDir({ claudeDir, hooks: BCE_HOOKS, envVars: BCE_ENV_VARS });
 


### PR DESCRIPTION
La suite d'essaim ne passait pas sous Windows : `writeClaudeHooksDir writes hook scripts with 0o755 permissions` échouait sur `expected +0 to be 64`.

## Cause racine

Le test lit le bit d'exécution du propriétaire d'un hook écrit avec `{ mode: 0o755 }`. Windows n'implémente pas les permissions POSIX — `fs.chmod` n'y pilote que l'attribut lecture-seule. Vérifié en écrivant un fichier avec ce mode puis en relisant son `stat` :

```
mode après chmod 0o755 : 0o666
bit execute propriétaire (m & 0o100) : 0
```

L'assertion ne peut donc jamais tenir sur win32.

## Ce que ce n'est pas

Un défaut du produit. [orchestrator.ts:712](src/orchestrator/orchestrator.ts:712) passe bien `{ mode: 0o755 }`, et ce mode compte sur les plateformes où les hooks s'exécutent réellement. C'est le test qui affirmait une propriété POSIX sans condition.

## Le correctif

`it.skipIf(process.platform === 'win32')`. Le cas reste enregistré et s'exécute inchangé sur POSIX, donc en CI — c'est un skip conditionnel, pas une suppression. Vérifié via le rapport JSON : 10 tests au total, 9 passés, 1 skippé, 0 échec, le cas n'ayant pas disparu de la collecte.

## Pourquoi ça compte

La suite passe désormais entièrement sous Windows (664 tests). Un échec local redevient un signal, au lieu d'un bruit de fond qu'on apprend à ignorer — et qui masque les vrais.

Le même travail part sur [swoofer/promptweave#20](https://github.com/swoofer/promptweave/pull/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
