### PR TITLE
docs(security): marque les plans et la spec comme livrés, signale le pan périmé

### DIFF
--- a/docs/superpowers/plans/2026-07-22-security-subsystem-plan-1-core-primitives.md
+++ b/docs/superpowers/plans/2026-07-22-security-subsystem-plan-1-core-primitives.md
@@ -1,5 +1,18 @@
 # Security Subsystem — Plan 1: Core Deterministic Primitives — Implementation Plan
 
+> **✅ ÉTAT : EXÉCUTÉ ET LIVRÉ — ne pas ré-implémenter.**
+>
+> Ce plan est un document d'exécution historique, pas du travail en attente. Le
+> sous-système vit sur `main` sous `src/security/`, couvert par 26 fichiers de
+> tests (184 tests). Livré par [#70](https://github.com/swoofer/essaim/pull/70)
+> le 2026-07-23 (`903ecdc`), puis complété par
+> [#76](https://github.com/swoofer/essaim/pull/76) et huit correctifs suivants.
+>
+> Les cases `- [ ]` ci-dessous n'ont pas été cochées pendant l'exécution, et ne
+> l'ont pas été après coup : cocher rétroactivement 146 étapes fabriquerait un
+> journal pas-à-pas que personne ne peut vérifier. **La source de vérité est le
+> code et les tests, pas les cases.**
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build the pure-logic foundation of `src/security/` — the canonical `Finding` schema, fingerprinting, redaction/sanitization, scope resolution/filtering, the baseline suppression store, the config loader, and the fail-closed authorization gate — with zero external I/O (no Docker, no network, no coordinator).

--- a/docs/superpowers/plans/2026-07-22-security-subsystem-plan-2-engine-layer.md
+++ b/docs/superpowers/plans/2026-07-22-security-subsystem-plan-2-engine-layer.md
@@ -1,5 +1,33 @@
 # Security Subsystem — Plan 2: Engine Layer — Implementation Plan
 
+> **✅ ÉTAT : EXÉCUTÉ ET LIVRÉ — ne pas ré-implémenter.**
+>
+> Ce plan est un document d'exécution historique, pas du travail en attente. Le
+> sous-système vit sur `main` sous `src/security/`, couvert par 26 fichiers de
+> tests (184 tests). Livré par [#70](https://github.com/swoofer/essaim/pull/70)
+> le 2026-07-23 (`903ecdc`), puis complété par
+> [#76](https://github.com/swoofer/essaim/pull/76) et huit correctifs suivants.
+>
+> Les cases `- [ ]` ci-dessous n'ont pas été cochées pendant l'exécution, et ne
+> l'ont pas été après coup : cocher rétroactivement 146 étapes fabriquerait un
+> journal pas-à-pas que personne ne peut vérifier. **La source de vérité est le
+> code et les tests, pas les cases.**
+
+> **⚠️ DIVERGENCE ASSUMÉE — la tâche `src/security/docker.ts` est CADUQUE.**
+>
+> Ce plan fait construire des builders d'arguments `docker run` et leur
+> traduction de chemins win32. Ce modèle a été abandonné : essaim ne lance
+> jamais d'image Strix par `docker run` directement, il pilote la CLI hôte
+> `strix` (`pip install strix-agent`), qui gère elle-même son sandbox Docker.
+>
+> Le pivot est fait par [#76](https://github.com/swoofer/essaim/pull/76)
+> (`298552d`) ; `docker.ts` et son test ont été supprimés par `8f14d5c`. Le
+> remplaçant est `src/security/strix-cli.ts`, et le design est décrit dans
+> `docs/superpowers/specs/2026-07-23-strix-adapter-real-invocation-design.md`.
+>
+> Ne pas ressusciter ce fichier — ce serait réintroduire du code retiré
+> volontairement.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build the deterministic engine layer under `src/security/` — Docker invocation helpers, a captured-subprocess runner, the pluggable adapter registry with a **permissive-license gate**, the Strix adapter (exit-code mapping + report parsing + normalization to `Finding`), and the multi-engine scan orchestrator — all unit-tested with mocked subprocesses (no real Docker/Strix/network).

--- a/docs/superpowers/plans/2026-07-22-security-subsystem-plan-3-coordinator-verify-wiring.md
+++ b/docs/superpowers/plans/2026-07-22-security-subsystem-plan-3-coordinator-verify-wiring.md
@@ -1,5 +1,18 @@
 # Security Subsystem — Plan 3: Coordinator Integration, Verification & Orchestrator Wiring — Implementation Plan
 
+> **✅ ÉTAT : EXÉCUTÉ ET LIVRÉ — ne pas ré-implémenter.**
+>
+> Ce plan est un document d'exécution historique, pas du travail en attente. Le
+> sous-système vit sur `main` sous `src/security/`, couvert par 26 fichiers de
+> tests (184 tests). Livré par [#70](https://github.com/swoofer/essaim/pull/70)
+> le 2026-07-23 (`903ecdc`), puis complété par
+> [#76](https://github.com/swoofer/essaim/pull/76) et huit correctifs suivants.
+>
+> Les cases `- [ ]` ci-dessous n'ont pas été cochées pendant l'exécution, et ne
+> l'ont pas été après coup : cocher rétroactivement 146 étapes fabriquerait un
+> journal pas-à-pas que personne ne peut vérifier. **La source de vérité est le
+> code et les tests, pas les cases.**
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Wire the deterministic engine layer into an essaim run: resolve secrets into a container env-file, normalize findings into coordinator threads via the **existing** `/api/announce`, re-scan fixed worktrees to verify closure, add the optional `MiniProject.security` / `RunResult.security` fields, insert the two guarded orchestrator steps (pre-scan + verify), harden child-process env with an **allowlist**, and render the security report section.

--- a/docs/superpowers/plans/2026-07-22-security-subsystem-plan-4-surface.md
+++ b/docs/superpowers/plans/2026-07-22-security-subsystem-plan-4-surface.md
@@ -1,5 +1,18 @@
 # Security Subsystem — Plan 4: Surface (Behaviors, Preset, CLI, Init, Docs) — Implementation Plan
 
+> **✅ ÉTAT : EXÉCUTÉ ET LIVRÉ — ne pas ré-implémenter.**
+>
+> Ce plan est un document d'exécution historique, pas du travail en attente. Le
+> sous-système vit sur `main` sous `src/security/`, couvert par 26 fichiers de
+> tests (184 tests). Livré par [#70](https://github.com/swoofer/essaim/pull/70)
+> le 2026-07-23 (`903ecdc`), puis complété par
+> [#76](https://github.com/swoofer/essaim/pull/76) et huit correctifs suivants.
+>
+> Les cases `- [ ]` ci-dessous n'ont pas été cochées pendant l'exécution, et ne
+> l'ont pas été après coup : cocher rétroactivement 146 étapes fabriquerait un
+> journal pas-à-pas que personne ne peut vérifier. **La source de vérité est le
+> code et les tests, pas les cases.**
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Expose the security subsystem to operators: the `security-fix` + `security-untrusted-findings` behaviors, the `sentinelle` preset, the `essaim security` command (auto-fix-on-branch by default, `--triage-only`, `--secrets-file`, `--authorize`, external-coordinator rejection, Strix-mirrored exit codes), `essaim init --security` scaffolding + `.gitignore` patch, the licensing docs, and the hermeticity + types-integration guard tests.

--- a/docs/superpowers/specs/2026-07-22-essaim-security-subsystem-design.md
+++ b/docs/superpowers/specs/2026-07-22-essaim-security-subsystem-design.md
@@ -1,5 +1,23 @@
 # essaim Security Subsystem — Unified Design Specification (v1)
 
+> **✅ IMPLÉMENTÉ — et un pan de ce document est PÉRIMÉ.**
+>
+> Le sous-système est livré sur `main` sous `src/security/` (26 fichiers de
+> tests, 184 tests), par [#70](https://github.com/swoofer/essaim/pull/70) puis
+> [#76](https://github.com/swoofer/essaim/pull/76).
+>
+> **Tout ce que ce document dit du modèle d'invocation `docker run` est faux
+> aujourd'hui.** Il affirme notamment (§ « Invocation is `docker run` only »)
+> que « essaim never spawns a host `strix` binary » — c'est précisément
+> l'inverse de ce que fait le code. essaim pilote la CLI hôte `strix`
+> (`pip install strix-agent`), qui gère elle-même son sandbox Docker ;
+> `docker.ts` et ses builders d'arguments ont été supprimés par `8f14d5c`.
+>
+> Pour le modèle d'invocation réel, lire
+> `2026-07-23-strix-adapter-real-invocation-design.md`, qui supersede ce
+> document sur ce point précis. Le reste — modèle de findings, empreintes,
+> scope, redaction, baseline, licences, kill-switch — reste valide.
+
 **Status:** implementation-ready design. Lead-architect merge of 9 draft dimensions with all critical/high gaps resolved (69 gaps found by adversarial critics; 15 critical, 19 high — all addressed). Operator decisions in §15 are **confirmed**.
 
 **Scope of this doc:** the whole subsystem, but every "build now" decision is scoped to **v1 = Strix, static diff-scoped scan of a repo you own**. v2/v3 capabilities are designed at the interface level only.


### PR DESCRIPTION
Les 4 plans d'implémentation du sous-système de sécurité gardaient leurs **146 cases non cochées** alors que le travail est livré depuis le 2026-07-23. Quiconque les ouvrait en concluait que le sous-système était en attente — et pouvait le ré-implémenter par-dessus du code existant. C'est exactement ce qui a failli arriver.

## Bandeau plutôt que cases cochées

Cocher rétroactivement 146 étapes fabriquerait un journal pas-à-pas que personne ne peut vérifier — et certaines étapes ont réellement divergé. Chaque plan reçoit donc un bandeau d'état qui dit où est la source de vérité : le code sous `src/security/` et ses 26 fichiers de tests (184 tests).

## Le plan 2 porte un avertissement ciblé

Sa tâche `src/security/docker.ts` est **caduque**. Le modèle `docker run` direct a été abandonné par [#76](https://github.com/swoofer/essaim/pull/76) au profit du pilotage de la CLI hôte `strix`, qui gère son propre sandbox ; le fichier et son test ont été supprimés par `8f14d5c`, dont le message dit explicitement « delete docker.ts and its test ». Le ressusciter réintroduirait du code retiré volontairement.

## La spec du 07-22 est le cas le plus trompeur

Elle contient 21 mentions du modèle abandonné, dont un « **Invocation is `docker run` only** » et un « essaim never spawns a host `strix` binary » — l'exact inverse de ce que fait le code aujourd'hui. Son bandeau renvoie à `2026-07-23-strix-adapter-real-invocation-design.md`, qui la supersede sur ce point, en précisant que le reste du document (findings, empreintes, scope, redaction, baseline, licences, kill-switch) reste valide.

## Portée

Purement additif : 85 insertions, 0 suppression, aucun octet touché hors bandeaux. L'octet NUL du plan 1 — qui le fait passer pour un binaire aux yeux de `grep` et l'avait masqué d'un premier balayage — est le sujet même d'un test sur les caractères de contrôle, et reste tel quel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
