### PR TITLE
fix(metrics): le budget de temps doit couvrir la lecture du corps (#58)

### DIFF
--- a/src/orchestrator/metrics.ts
+++ b/src/orchestrator/metrics.ts
@@ -86,15 +86,93 @@ export function computeMetrics(events: SseEvent[]): CoordinatorMetrics {
  * run full of real threads (#29). Metrics that silently read as zero are worse
  * than metrics that fail loudly.
  */
-async function getWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+interface BudgetedResponse {
+  ok: boolean;
+  status: number;
+  body: string;
+}
+
+/**
+ * GET/POST and read the body, the whole thing under ONE time budget.
+ *
+ * `/api/events` is an SSE stream the coordinator NEVER closes: `handleSse`
+ * writes the replay, registers a listener, then starts a keep-alive heartbeat
+ * and returns (mcp-coordinator `serve-http.ts`). Its body has no end, so
+ * `resp.text()` — which waits for exactly that — can never resolve.
+ *
+ * Two failure modes, both real, and a fix has to dodge both:
+ *
+ *   1. Releasing the abort timer once the HEADERS land leaves the body read
+ *      with no deadline at all. That was the bug (#58): `fetchLatestEventId`
+ *      runs BEFORE `/api/reset`, before workspaces, before any agent spawns,
+ *      so the whole run hung at startup against a real coordinator.
+ *   2. Letting the budget abort mid-body throws away everything buffered —
+ *      which IS the replay we came for. The call returns fast and empty, and
+ *      the report prints zeros, the exact symptom #29 was about.
+ *
+ * So the body is read INCREMENTALLY and whatever arrived is kept. The replay
+ * lands in one burst right after the headers; a short silence after it means
+ * "that's all there is" — that is what `idleMs` detects, and it is why this
+ * returns in milliseconds rather than sitting out the full budget. The budget
+ * remains as a hard backstop for a server that dribbles forever.
+ *
+ * `idleMs` is opt-in: endpoints whose response actually ENDS (hot-files) pass
+ * nothing and are read to completion, so a slow transfer is never truncated.
+ */
+async function getWithBudget(
+  url: string,
+  init: RequestInit,
+  budgetMs: number,
+  idleMs?: number,
+): Promise<BudgetedResponse> {
   const abort = new AbortController();
-  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  const timer = setTimeout(() => abort.abort(), budgetMs);
   try {
-    return await fetch(url, { ...init, signal: abort.signal });
+    const resp = await fetch(url, { ...init, signal: abort.signal });
+    if (!resp.ok || !resp.body) return { ok: resp.ok, status: resp.status, body: "" };
+    return { ok: true, status: resp.status, body: await readBody(resp.body, idleMs) };
   } finally {
     clearTimeout(timer);
   }
 }
+
+/** Accumulate a stream until it ends, goes quiet for `idleMs`, or is aborted. */
+async function readBody(stream: ReadableStream<Uint8Array>, idleMs?: number): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  try {
+    for (;;) {
+      // Swallow the read's rejection here rather than letting it dangle: when
+      // the idle race wins, this promise is still in flight and the cancel()
+      // below settles it — an unhandled rejection would crash the process.
+      const read = reader.read().catch(() => ({ done: true, value: undefined }) as ReadableStreamReadResult<Uint8Array>);
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      const chunk =
+        idleMs === undefined
+          ? await read
+          : await Promise.race([
+              read,
+              new Promise<"idle">((r) => {
+                idleTimer = setTimeout(() => r("idle"), idleMs);
+              }),
+            ]).finally(() => clearTimeout(idleTimer));
+
+      if (chunk === "idle" || chunk.done) break;
+      out += decoder.decode(chunk.value, { stream: true });
+    }
+    out += decoder.decode();
+  } catch {
+    // Budget abort, or a torn socket. Keep whatever arrived — partial metrics
+    // beat none, and an SSE replay is complete long before the budget expires.
+  } finally {
+    void reader.cancel().catch(() => {});
+  }
+  return out;
+}
+
+/** Silence after the SSE replay burst that means "the replay is complete". */
+const SSE_REPLAY_IDLE_MS = 250;
 
 /**
  * Capture the coordinator's current max event id, to be used as the
@@ -107,13 +185,14 @@ async function getWithTimeout(url: string, init: RequestInit, timeoutMs: number)
  */
 export async function fetchLatestEventId(coordinatorUrl: string): Promise<number> {
   try {
-    const resp = await getWithTimeout(
+    const resp = await getWithBudget(
       `${coordinatorUrl}/api/events`,
       { headers: { "Last-Event-ID": "0", ...authHeaders() } },
       3000,
+      SSE_REPLAY_IDLE_MS,
     );
     if (!resp.ok) return 0;
-    const events = parseSseEvents(await resp.text());
+    const events = parseSseEvents(resp.body);
     return events.reduce((max, e) => Math.max(max, e.id), 0);
   } catch {
     // Coordinator unreachable — degrade to "no baseline" (0), matching the
@@ -140,13 +219,14 @@ export async function fetchCoordinatorMetrics(coordinatorUrl: string, sinceEvent
     // (the previous hardcoded value) so a fresh coordinator with no prior
     // events still gets the full replay instead of the last-50 fallback.
     const cursor = Math.max(sinceEventId, 1);
-    const resp = await getWithTimeout(
+    const resp = await getWithBudget(
       `${coordinatorUrl}/api/events`,
       { headers: { "Last-Event-ID": String(cursor), ...authHeaders() } },
       3000,
+      SSE_REPLAY_IDLE_MS,
     );
     if (resp.ok) {
-      sseRaw = await resp.text();
+      sseRaw = resp.body;
     } else {
       console.warn(`[metrics] /api/events → ${resp.status} — counters will read 0`);
     }
@@ -158,7 +238,9 @@ export async function fetchCoordinatorMetrics(coordinatorUrl: string, sinceEvent
   const metrics = computeMetrics(parseSseEvents(sseRaw));
 
   try {
-    const resp = await getWithTimeout(
+    // No idle cutoff: unlike /api/events this response actually ends, so it is
+    // read to completion and a slow transfer can never be truncated mid-JSON.
+    const resp = await getWithBudget(
       `${coordinatorUrl}/api/hot-files`,
       {
         method: "POST",
@@ -168,7 +250,7 @@ export async function fetchCoordinatorMetrics(coordinatorUrl: string, sinceEvent
       2000,
     );
     if (resp.ok) {
-      const hotFiles = (await resp.json()) as { file_path: string }[];
+      const hotFiles = JSON.parse(resp.body) as { file_path: string }[];
       metrics.hot_files = hotFiles.map((f) => f.file_path);
     }
   } catch {}

--- a/tests/unit/metrics-sse-budget.test.ts
+++ b/tests/unit/metrics-sse-budget.test.ts
@@ -1,0 +1,114 @@
+// tests/unit/metrics-sse-budget.test.ts
+//
+// #58 — la lecture des métriques doit tenir son budget de temps ET rapporter ce
+// qu'elle a lu, contre un endpoint SSE que le coordinator NE FERME JAMAIS.
+//
+// `handleSse` (mcp-coordinator serve-http.ts) écrit ses en-têtes, pousse le
+// replay, puis garde la connexion ouverte avec un heartbeat. Le corps de la
+// réponse n'atteint donc jamais son terme.
+//
+// Ces tests utilisent un vrai serveur HTTP qui reproduit ce comportement. Les
+// tests de métriques préexistants ne couvraient que des fonctions pures, et un
+// stub `new Response("")` a un corps déjà bufferisé — aveugle par construction à
+// tout ce qui concerne le streaming.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { fetchLatestEventId, fetchCoordinatorMetrics } from "../../src/orchestrator/metrics.js";
+
+/** Le budget documenté des appels /api/events, dans metrics.ts. */
+const BUDGET_MS = 3000;
+/** Marge au-delà de laquelle on considère que l'appel ne rend jamais la main. */
+const VERDICT_MS = 8000;
+
+const REPLAY = [
+  'id: 41\nevent: thread_opened\ndata: {"thread_id":"t1","agent_id":"a1"}\n\n',
+  'id: 42\nevent: message_posted\ndata: {"thread_id":"t1","agent_id":"a2"}\n\n',
+  'id: 43\nevent: thread_opened\ndata: {"thread_id":"t2","agent_id":"a3"}\n\n',
+].join("");
+
+let server: Server;
+let baseUrl: string;
+const openSockets: import("node:net").Socket[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    if (req.url?.startsWith("/api/events")) {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.flushHeaders();
+      res.write(REPLAY);
+      // Et on ne ferme JAMAIS — c'est tout l'enjeu. Pas de res.end().
+      return;
+    }
+    if (req.url?.startsWith("/api/hot-files")) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([{ file_path: "src/a.ts" }]));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.on("connection", (s) => openSockets.push(s));
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  for (const s of openSockets) s.destroy();
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+/** Résout en "PENDING" si la promesse n'a pas rendu la main dans les temps. */
+async function within<T>(p: Promise<T>, ms: number): Promise<T | "PENDING"> {
+  let timer: NodeJS.Timeout;
+  const guard = new Promise<"PENDING">((r) => {
+    timer = setTimeout(() => r("PENDING"), ms);
+  });
+  return Promise.race([p, guard]).finally(() => clearTimeout(timer));
+}
+
+describe("#58 — /api/events ne se ferme jamais", () => {
+  it("fetchLatestEventId rend la main au lieu d'attendre indéfiniment", async () => {
+    const started = Date.now();
+    const result = await within(fetchLatestEventId(baseUrl), VERDICT_MS);
+
+    expect(result, "l'appel n'a jamais rendu la main — le budget ne couvre pas la lecture du corps").not.toBe("PENDING");
+    expect(Date.now() - started).toBeLessThan(VERDICT_MS);
+  }, 20000);
+
+  it("fetchLatestEventId rapporte le replay reçu, il ne le jette pas", async () => {
+    // Le piège du correctif naïf : lire le corps sous le même AbortController
+    // fait rejeter resp.text() au timeout, donc renvoie 0 — l'appel rend bien la
+    // main, mais on a perdu exactement ce qu'on venait chercher.
+    const result = await within(fetchLatestEventId(baseUrl), VERDICT_MS);
+
+    expect(result).toBe(43);
+  }, 20000);
+
+  it("fetchCoordinatorMetrics compte les événements du replay", async () => {
+    const result = await within(fetchCoordinatorMetrics(baseUrl, 1), VERDICT_MS);
+
+    expect(result, "l'appel n'a jamais rendu la main").not.toBe("PENDING");
+    const metrics = result as Awaited<ReturnType<typeof fetchCoordinatorMetrics>>;
+    expect(metrics.threads_opened).toBe(2);
+    expect(metrics.messages_exchanged).toBe(1);
+  }, 20000);
+
+  it("tient nettement sous le budget documenté quand le replay arrive vite", async () => {
+    // Sans ça, une implémentation qui attend bêtement l'expiration du budget
+    // passerait les tests ci-dessus tout en ajoutant 3 s au démarrage ET à la
+    // fin de chaque run.
+    const started = Date.now();
+    const result = await within(fetchLatestEventId(baseUrl), VERDICT_MS);
+
+    // Le résultat est réassert ici EN PLUS du chrono : sans lui, un appel qui
+    // échoue vite (socket réutilisé et cassé, par exemple) renvoie 0 en quelques
+    // millisecondes et ferait passer ce test sans rien garantir.
+    expect(result).toBe(43);
+    expect(Date.now() - started).toBeLessThan(BUDGET_MS);
+  }, 20000);
+});


### PR DESCRIPTION
Corrige [#58](https://github.com/swoofer/essaim/issues/58) — la moitié qui restait, et qui s'est révélée pire que le défaut d'origine.

Les deux défauts rapportés dans l'issue (curseur non scopé, compteur négatif) étaient bien corrigés par `15e462e`. Mais ce même commit a introduit un appel réseau **bloquant en amont du run**.

## Le défaut

`getWithTimeout` libérait son timer dans un `finally` déclenché dès l'arrivée des en-têtes, alors que ses trois appelants lisaient le corps **après** son retour. Le corps était donc lu sans deadline ni `AbortController` vivant.

Sur `/api/events` c'est fatal : `handleSse` écrit le replay, s'abonne, lance un heartbeat et **ne ferme jamais** la connexion ([mcp-coordinator `serve-http.ts:384`](https://github.com/swoofer/mcp-coordinator)). `resp.text()` attend exactement cette fin. Et `fetchLatestEventId` tourne à [orchestrator.ts:214](https://github.com/swoofer/essaim/blob/main/src/orchestrator/orchestrator.ts#L214), avant `/api/reset`, avant les workspaces, avant tout spawn d'agent — un run avec coordinator se bloquait au démarrage.

Le commentaire « or the SSE stream never closes and we abort » supposait un abort devenu impossible.

## Pourquoi le correctif évident ne marche pas

Lire le corps sous le même `AbortController` échoue autrement : l'abort au budget rejette la lecture et **jette le replay qu'on venait chercher**. L'appel rend la main vite et vide, et le rapport réimprime des zéros — exactement le symptôme de #29.

Le corps est donc lu par morceaux, et ce qui est arrivé est conservé. Le replay arrivant en une rafale juste après les en-têtes, un court silence signale qu'il est complet : c'est ce que détecte `idleMs`, et c'est pourquoi l'appel rend la main en **~270 ms** au lieu de consommer ses 3 s. Le budget reste en filet.

La coupure sur silence est opt-in : `/api/hot-files`, dont la réponse se termine vraiment, est lu jusqu'au bout et ne peut pas être tronqué.

## Tests

Les tests préexistants étaient aveugles **par construction** — ils stubaient `new Response("")`, un corps déjà bufferisé, donc incapable d'exhiber quoi que ce soit sur le streaming.

Les nouveaux montent un vrai serveur HTTP qui ne ferme jamais sa réponse, et vérifient les deux moitiés : l'appel rend la main, **et** il rapporte le replay. Le cas « sous le budget » réassert aussi le résultat — sans ça, un échec rapide le ferait passer sans rien garantir.

Vérifié : RED sur les 4 avant correctif (l'appel restait pendant à 8 s), vert après, stable sur 3 passes consécutives, 668 tests verts au total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
