### PR TITLE
fix(coordination): une seule décision LLM par round (#53)

### DIFF
--- a/src/agent-loop/coordination-protocol.ts
+++ b/src/agent-loop/coordination-protocol.ts
@@ -257,6 +257,14 @@ export function createCoordinationProtocol(agentId: string): CoordinationProtoco
       if (!thread) return;
 
       if (phase === "waiting") {
+        // Même garde d'idempotence que onThreadMessage, et pour une raison plus
+        // pressante : agent-loop appelle onTimeout sur le chemin NOMINAL
+        // (agent-loop.ts:638-640), pas seulement quand personne n'a répondu.
+        // Après un quorum la phase vaut encore "waiting", donc sa condition
+        // laisse passer — sans ce garde, chaque round payait une seconde
+        // décision LLM sur exactement le même buffer de réponses (#53).
+        if (thread.decideRequested) return;
+        thread.decideRequested = true;
         enqueue({
           type: "ask_llm_decide",
           threadId,

--- a/tests/unit/coordination-protocol.test.ts
+++ b/tests/unit/coordination-protocol.test.ts
@@ -288,6 +288,55 @@ describe("CoordinationProtocol", () => {
     }
   });
 
+  // #53 — le garde d'idempotence n'existait que sur onThreadMessage. Or
+  // agent-loop.ts:638-640 appelle onTimeout sur le chemin NOMINAL : après un
+  // quorum la phase vaut toujours "waiting", donc sa condition laisse passer et
+  // une SECONDE décision LLM était enfilée à chaque round — un appel modèle
+  // payé pour rien, sur exactement le même buffer de réponses.
+  it("ne redemande pas de décision quand le timeout suit un quorum déjà décidé", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-dup",
+      status: "open",
+      expectedRespondents: ["agent-2"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    protocol.onThreadMessage("t-dup", "agent-2", "je touche session.ts aussi");
+    expect(protocol.nextAction()?.type).toBe("ask_llm_decide");
+    expect(protocol.getThreadState("t-dup")?.decideRequested).toBe(true);
+
+    protocol.onTimeout("t-dup");
+
+    expect(protocol.nextAction()).toBeNull();
+  });
+
+  // Contrepartie : sans quorum, le timeout DOIT décider — c'est sa raison
+  // d'être. Un garde trop large gèlerait le round au lieu de le trancher.
+  it("décide bien au timeout quand aucun quorum n'a été atteint", () => {
+    protocol.startWork(WORK);
+    drainActions(protocol);
+
+    protocol.onAnnounceResult({
+      threadId: "t-silence",
+      status: "open",
+      expectedRespondents: ["agent-2", "agent-3"],
+      context: "",
+    });
+    drainActions(protocol);
+
+    // Un seul des deux répond : pas de quorum, donc aucune décision enfilée.
+    protocol.onThreadMessage("t-silence", "agent-2", "je regarde");
+    expect(protocol.nextAction()).toBeNull();
+
+    protocol.onTimeout("t-silence");
+
+    expect(protocol.nextAction()?.type).toBe("ask_llm_decide");
+  });
+
   it("proceeds to work instead of reopening once ADJUST reaches MAX_ROUNDS", () => {
     protocol.startWork(WORK);
     drainActions(protocol);


### PR DESCRIPTION
Corrige la moitié non ambiguë de [#53](https://github.com/swoofer/essaim/issues/53). La seconde moitié est une décision produit, détaillée plus bas — l'issue reste ouverte pour elle.

## Une décision LLM payée deux fois par round

Le garde d'idempotence n'existait que sur `onThreadMessage` ([:200](https://github.com/swoofer/essaim/blob/main/src/agent-loop/coordination-protocol.ts#L200)). Or `agent-loop` appelle `onTimeout` sur le **chemin nominal** ([agent-loop.ts:638-640](https://github.com/swoofer/essaim/blob/main/src/agent-loop/agent-loop.ts#L638-L640)), pas seulement quand personne n'a répondu :

```ts
if (protocol.phase === "waiting" && protocol.currentThreadId) {
  protocol.onTimeout(protocol.currentThreadId);
}
```

Après un quorum, `onThreadMessage` enfile la décision mais ne change pas la phase — elle vaut toujours `"waiting"`. La condition ci-dessus laisse donc passer, et `onTimeout` enfilait une **seconde** `ask_llm_decide` sur exactement le même buffer de réponses. Un appel modèle payé pour rien à chaque round de coordination.

Le garde pose aussi `decideRequested`, sinon deux timeouts successifs rouvriraient la même brèche. `resetForNewRound` le remet à `false`, donc un round rouvert peut toujours décider.

## Le test contrepartie

Un garde trop large gèlerait le round au lieu de le trancher. Un second test fixe la limite : **sans quorum, le timeout doit décider** — c'est sa raison d'être. Il passait déjà avant le correctif et continue de passer, ce qui est exactement son rôle.

## Ce qui n'est PAS corrigé ici

Le plan capté par `decideAdjust` ([:302](https://github.com/swoofer/essaim/blob/main/src/agent-loop/coordination-protocol.ts#L302)) n'est lu nulle part. `resetForNewRound` n'enfile que `wait_responses`, jamais de ré-annonce — le plan révisé ne part donc à personne, et le round rouvert attend des réponses que les pairs n'ont aucune raison d'envoyer.

Corriger ça demande de **choisir un comportement de protocole**, pas d'écrire un correctif :

- soit `decideAdjust` ré-annonce le plan révisé — `announceViaRest` transmet déjà `work.plan` ([agent-loop.ts:268](https://github.com/swoofer/essaim/blob/main/src/agent-loop/agent-loop.ts#L268)), mais réutiliser l'action `announce` rouvre la question de l'identité du thread côté coordinator ;
- soit un ADJUST se limite volontairement à rouvrir le round, et le champ `plan` devrait alors être **supprimé** plutôt que laissé mort de bout en bout.

Aucune action « poster dans le thread » n'existe dans `ProtocolAction`, donc la première option est un ajout au protocole. C'est une décision produit.

Vérifié : RED avant correctif (seconde `ask_llm_decide` enfilée), 27/27 sur le protocole, 666/666 sur la suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
