### PR TITLE
fix(workspace)!: ESSAIM_RESET_BASE nomme le répertoire à détruire (#56)

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -243,16 +243,12 @@ async function _runProjectBody(
   // 2. Create workspaces (resetBase FIRST, then setup, then worktrees)
   const basePath = project.workspace.base || DEFAULT_BASE;
   if (project.workspace.type === "worktree") {
-    // resetBase runs `git checkout -- .` + `git clean -fd` — refuse to let it
-    // silently target process.cwd() when the destructive opt-in is set but
-    // the config never named an explicit base. Falling back to cwd here has
-    // no safe reading: whatever directory the operator happened to invoke
-    // essaim from would get wiped.
-    if (process.env.ESSAIM_RESET_BASE === "1" && !project.workspace.base) {
-      throw new Error(
-        "resetBase refused: set workspace.base explicitly before ESSAIM_RESET_BASE=1",
-      );
-    }
+    // The authorization check lives in resetBase itself, which throws unless
+    // ESSAIM_RESET_BASE names this exact directory (#56). The guard that used
+    // to sit here only covered an UNSET workspace.base — a case no CLI path
+    // produces, since cli/run.ts defaults -p to "." and bridge.ts types
+    // workspace.base as a required string. It protected the library API while
+    // leaving the CLI wide open; naming the target covers both.
     resetBase(basePath);
   }
 

--- a/src/orchestrator/workspace.ts
+++ b/src/orchestrator/workspace.ts
@@ -74,14 +74,31 @@ export function cleanupWorkspaces(workspace: WorkspaceResult): void {
  * any local config, any in-progress edits.
  *
  * Worktrees do NOT need a clean source: `git worktree add` snapshots from a
- * ref, independent of the source tree's working state. So this is opt-in
- * only: set ESSAIM_RESET_BASE=1 if you really want it (typical use: a
- * dedicated sandbox dir under `/tmp/essaim-sandbox/`, never your real
- * project). Without the opt-in, we just log a warning if there's dirt and
- * return — let `git worktree add` do its thing from the committed state.
+ * ref, independent of the source tree's working state. So this is opt-in only,
+ * and the opt-in NAMES its target: set `ESSAIM_RESET_BASE=/path/to/sandbox`,
+ * which must resolve to this run's base or the call throws. A boolean `=1`
+ * used to authorize the operation without saying on what — see the refusal
+ * below for why that was replaced (#56). Typical use remains a dedicated
+ * sandbox dir under `/tmp/essaim-sandbox/`, never your real project.
+ *
+ * Without the opt-in, we just log a warning if there's dirt and return — let
+ * `git worktree add` do its thing from the committed state.
  */
+/**
+ * Same directory? Compared on resolved form, case-insensitively on win32 where
+ * the filesystem is.
+ */
+function samePath(a: string, b: string): boolean {
+  const ra = path.resolve(a);
+  const rb = path.resolve(b);
+  return process.platform === "win32" ? ra.toLowerCase() === rb.toLowerCase() : ra === rb;
+}
+
 export function resetBase(basePath: string): void {
-  if (process.env.ESSAIM_RESET_BASE !== "1") {
+  const authorized = process.env.ESSAIM_RESET_BASE;
+  const target = path.resolve(basePath);
+
+  if (!authorized) {
     let dirty = "";
     try {
       dirty = execSync("git status --porcelain", { cwd: basePath, encoding: "utf8" }).trim();
@@ -89,13 +106,35 @@ export function resetBase(basePath: string): void {
     if (dirty) {
       const lines = dirty.split("\n");
       console.warn(
-        `[workspace] base has ${lines.length} dirty/untracked entr${lines.length === 1 ? "y" : "ies"} — leaving them alone (set ESSAIM_RESET_BASE=1 to git clean -fd + git checkout -- .).\n` +
+        `[workspace] base has ${lines.length} dirty/untracked entr${lines.length === 1 ? "y" : "ies"} — leaving them alone (set ESSAIM_RESET_BASE=${target} to git clean -fd + git checkout -- .).\n` +
         `            worktrees snapshot from a git ref so this is fine; your local files stay safe.`,
       );
     }
     return;
   }
-  console.warn("[workspace] ESSAIM_RESET_BASE=1 — running destructive git checkout -- . + git clean -fd on " + basePath);
+
+  // The variable NAMES the directory to destroy; it is not a boolean.
+  //
+  // `=1` authorized the operation without saying on what: the target came from
+  // elsewhere (workspace.base, defaulting to cwd), so a stray `-p` was enough
+  // to lose uncommitted work with nothing but a console.warn (#56).
+  //
+  // No heuristic fixes that. Refusing when the base equals the cwd — the
+  // obvious guard — breaks the very usage this doc recommends
+  // (`cd /tmp/sandbox && essaim run -p .`); it was implemented, and an existing
+  // test proved it wrong. Naming the path is the only authorization with
+  // neither false positives nor false negatives: you cannot destroy what you
+  // did not name.
+  if (!samePath(authorized, target)) {
+    throw new Error(
+      `resetBase refused: ESSAIM_RESET_BASE must name the directory to reset, not enable a mode. ` +
+        `It is set to ${JSON.stringify(authorized)}, but this run's base is ${target}. ` +
+        `This would run "git checkout -- ." + "git clean -fd" there, discarding uncommitted work. ` +
+        `If that is really what you want: ESSAIM_RESET_BASE=${target}`,
+    );
+  }
+
+  console.warn(`[workspace] ESSAIM_RESET_BASE names ${target} — running destructive git checkout -- . + git clean -fd`);
   execSync("git checkout -- .", { cwd: basePath, stdio: "pipe" });
   execSync("git clean -fd", { cwd: basePath, stdio: "pipe" });
 }

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -332,9 +332,9 @@ describe("runProject — concurrency cap on agent fan-out", () => {
   });
 });
 
-// ── resetBase refuses an implicit cwd fallback ──────────────────────────────
+// ── #56 — ESSAIM_RESET_BASE names the directory it is allowed to destroy ────
 
-describe("runProject — resetBase refuses implicit cwd fallback", () => {
+describe("runProject — resetBase authorization", () => {
   const ORIGINAL_ENV = process.env.ESSAIM_RESET_BASE;
 
   afterEach(() => {
@@ -342,27 +342,44 @@ describe("runProject — resetBase refuses implicit cwd fallback", () => {
     else process.env.ESSAIM_RESET_BASE = ORIGINAL_ENV;
   });
 
-  it("refuses to run (and never touches cwd) when ESSAIM_RESET_BASE=1 and workspace.base is unset", async () => {
+  it("refuses the legacy boolean, and never launches an agent when it does", async () => {
+    // `=1` authorized the destruction without naming its target, so whatever
+    // workspace.base happened to be — cwd by default — got wiped.
     process.env.ESSAIM_RESET_BASE = "1";
     vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
     vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
 
     const project = makeProject({
       agents: [makeAgent({ id: "a1", name: "Agent A" })],
-      workspace: { type: "worktree" }, // base intentionally omitted
+      workspace: { type: "worktree" }, // base omitted → would have fallen back to cwd
     });
 
     await expect(
       runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" })
     ).rejects.toThrow(/resetBase refused/);
 
-    // The agent must never have been launched — the refusal happens before
-    // any workspace/agent setup.
+    // The refusal must happen before any workspace or agent setup.
     expect(launchAgentLoop).not.toHaveBeenCalled();
   });
 
-  it("proceeds normally when ESSAIM_RESET_BASE=1 and workspace.base IS set", async () => {
-    process.env.ESSAIM_RESET_BASE = "1";
+  it("refuses when the variable names a different directory than the run's base", async () => {
+    process.env.ESSAIM_RESET_BASE = path.join(TMP_DIR, "some-other-dir");
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "worktree", base: TMP_DIR },
+    });
+
+    await expect(
+      runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" })
+    ).rejects.toThrow(/resetBase refused/);
+    expect(launchAgentLoop).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when the variable names exactly the run's base", async () => {
+    process.env.ESSAIM_RESET_BASE = TMP_DIR;
     vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
     vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
 

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { createWorkspaces, cleanupWorkspaces } from "../../src/orchestrator/workspace.js";
+import { createWorkspaces, cleanupWorkspaces, resetBase } from "../../src/orchestrator/workspace.js";
 import type { AgentConfig, WorkspaceResult } from "../../src/orchestrator/types.js";
 
 function testAgent(partial: Partial<AgentConfig> & Pick<AgentConfig, "id" | "name" | "profile">): AgentConfig {
@@ -69,6 +69,88 @@ describe("createWorkspaces", () => {
     );
     expect(result.type).toBe("none");
     expect(result.paths.size).toBe(1);
+  });
+});
+
+// ── #56 — ESSAIM_RESET_BASE nomme le répertoire à détruire ──────────────────
+//
+// resetBase lance `git checkout -- .` + `git clean -fd`. Le contrat booléen
+// `=1` autorisait l'opération sans dire SUR QUOI : le répertoire visé venait
+// d'ailleurs (workspace.base, défaut cwd), donc un `-p` distrait suffisait à
+// perdre son travail non commité. Aucune heuristique ne rattrape ça — refuser
+// quand la base vaut le cwd casse l'usage recommandé (`cd /tmp/sandbox &&
+// essaim run -p .`). Nommer le chemin est la seule autorisation sans faux
+// positif ni faux négatif : on ne peut pas détruire ce qu'on n'a pas nommé.
+describe("resetBase — ESSAIM_RESET_BASE (#56)", () => {
+  const ORIGINAL = process.env.ESSAIM_RESET_BASE;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.ESSAIM_RESET_BASE;
+    else process.env.ESSAIM_RESET_BASE = ORIGINAL;
+  });
+
+  /** Salit le bac à sable : un fichier suivi modifié + un fichier non suivi. */
+  function dirty(): void {
+    fs.writeFileSync(path.join(SANDBOX_DIR, "file.txt"), "MODIFIÉ");
+    fs.writeFileSync(path.join(SANDBOX_DIR, "untracked.txt"), "x");
+  }
+
+  function isClean(): boolean {
+    return (
+      fs.readFileSync(path.join(SANDBOX_DIR, "file.txt"), "utf-8") === "hello" &&
+      !fs.existsSync(path.join(SANDBOX_DIR, "untracked.txt"))
+    );
+  }
+
+  it("ne touche à rien quand la variable est absente", () => {
+    delete process.env.ESSAIM_RESET_BASE;
+    dirty();
+
+    resetBase(SANDBOX_DIR);
+
+    expect(isClean()).toBe(false);
+  });
+
+  it("refuse l'ancien contrat booléen =1", () => {
+    process.env.ESSAIM_RESET_BASE = "1";
+    dirty();
+
+    expect(() => resetBase(SANDBOX_DIR)).toThrow(/resetBase refused/);
+    expect(isClean()).toBe(false);
+  });
+
+  it("refuse quand la variable nomme un AUTRE répertoire", () => {
+    process.env.ESSAIM_RESET_BASE = path.join(TMP_DIR, "ailleurs");
+    dirty();
+
+    expect(() => resetBase(SANDBOX_DIR)).toThrow(/resetBase refused/);
+    expect(isClean()).toBe(false);
+  });
+
+  it("nomme les deux chemins dans le refus, pour que l'erreur soit actionnable", () => {
+    process.env.ESSAIM_RESET_BASE = "1";
+
+    expect(() => resetBase(SANDBOX_DIR)).toThrow(new RegExp(SANDBOX_DIR.replace(/[\\^$*+?.()|[\]{}]/g, "\\$&")));
+  });
+
+  it("réinitialise quand la variable nomme exactement la base", () => {
+    process.env.ESSAIM_RESET_BASE = SANDBOX_DIR;
+    dirty();
+
+    resetBase(SANDBOX_DIR);
+
+    expect(isClean()).toBe(true);
+  });
+
+  it("accepte une forme non normalisée du même chemin", () => {
+    // Un opérateur qui copie-colle avec une barre finale, ou passe par `.`,
+    // désigne bien le même répertoire — refuser là-dessus serait du zèle.
+    process.env.ESSAIM_RESET_BASE = path.join(SANDBOX_DIR, ".") + path.sep;
+    dirty();
+
+    resetBase(SANDBOX_DIR);
+
+    expect(isClean()).toBe(true);
   });
 });
 


### PR DESCRIPTION
Corrige [#56](https://github.com/swoofer/essaim/issues/56) — la moitié `resetBase` (D116). La moitié D112 (drain avant teardown) était déjà corrigée et vérifiée.

## Le défaut

`resetBase` lance `git checkout -- .` + `git clean -fd`. Le contrat booléen `ESSAIM_RESET_BASE=1` autorisait l'opération **sans dire sur quoi** : la cible venait d'ailleurs (`workspace.base`, défaut `cwd`). Un `-p` distrait suffisait à perdre son travail non commité, avec pour seul avertissement un `console.warn`.

Le garde existant ne couvrait que `workspace.base` **non renseigné** — un cas qu'aucun chemin CLI ne produit : `cli/run.ts:11` met `"."` par défaut, `run-core.ts:46` le résout, `bridge.ts:166` le pose, et `bridge.ts:34` le type `string` **requis**. Il protégeait donc l'API bibliothèque en laissant la CLI grande ouverte.

## Pourquoi pas le garde évident

Refuser quand la base vaut le `cwd` était la recommandation du triage. Je l'ai implémenté — et un test existant l'a invalidé : `cd /tmp/sandbox && essaim run -p .` donne `base === cwd`, et c'est exactement le « dedicated sandbox dir » que la doc de `resetBase` recommande. L'heuristique produit un faux positif sur l'usage prévu. Reverté.

## Le contrat retenu

**La variable nomme le répertoire à détruire.** On ne peut pas détruire ce qu'on n'a pas nommé — ni faux positif, ni faux négatif.

```bash
ESSAIM_RESET_BASE=/tmp/essaim-sandbox essaim run raid -p /tmp/essaim-sandbox
```

Comparaison sur forme résolue, insensible à la casse sous win32 où le système de fichiers l'est — une barre finale ou un `.` intermédiaire ne fait pas échouer un opérateur de bonne foi (testé).

Le refus nomme les deux chemins et **donne la valeur exacte à poser**. L'ancien message renvoyait vers `workspace.base`, un réglage qu'aucun YAML ni flag CLI n'expose — inapplicable par construction.

## Où vit la vérification

Dans `resetBase`, la fonction qui fait les dégâts, plutôt que dupliquée dans l'orchestrateur. Un seul endroit à auditer, et l'API bibliothèque est couverte au même titre que la CLI. Le garde de l'orchestrateur est retiré, devenu redondant.

## ⚠️ Breaking

`ESSAIM_RESET_BASE=1` n'autorise plus rien et lève désormais. C'est délibéré : un drapeau destructeur qui échoue bruyamment vaut mieux qu'un qui détruit le mauvais répertoire en silence.

Vérifié : 677 tests verts, build propre, aucune trace résiduelle de l'ancien contrat dans `src/`, `cli/`, `tests/`, `docs/` ni le README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
