### PR TITLE
docs(site): retire les documents de travail superpowers de la publication

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,19 @@
+# Configuration Jekyll de GitHub Pages (source : branche main, dossier /docs).
+#
+# Pages sert TOUT ce que contient /docs. Les documents de travail superpowers —
+# les 4 plans d'implémentation du sous-système de sécurité et leurs specs de
+# design, ~210 Ko — se retrouvaient donc publiés sur le site vitrine, avec un
+# robots.txt en `Allow: /` qui n'empêchait rien de les indexer.
+#
+# Ce sont des artefacts d'exécution internes, pas de la documentation produit :
+# ils décrivent des étapes déjà livrées, et l'un d'eux porte même un pan périmé
+# explicitement signalé. Les exclure ici les retire de la PUBLICATION, pas
+# seulement de l'indexation — Jekyll ne les copie pas dans le site généré.
+#
+# Ils restent lisibles sur le dépôt, qui est public, et à leur chemin habituel :
+# rien ne bouge sur disque, donc aucune référence croisée ne casse.
+#
+# `docs/security/` reste publié : licensing.md et THIRD_PARTY_LICENSES.md sont
+# de la conformité de licence, qui a vocation à être consultable.
+exclude:
+  - superpowers/


### PR DESCRIPTION
GitHub Pages sert **tout** `/docs`, donc les 4 plans d'implémentation du sous-système de sécurité et leurs specs de design — ~210 Ko — étaient publiés sur le site vitrine.

Vérifié avant correctif, pas supposé :

```
HTTP 200  swoofer.github.io/essaim/superpowers/plans/…-plan-1-core-primitives.html
```

Jekyll convertissait le markdown en HTML et le servait. Et `robots.txt` dit `Allow: /`, donc rien n'empêchait l'indexation.

Ce sont des artefacts d'exécution internes, pas de la documentation produit : ils décrivent des étapes déjà livrées, et l'un d'eux porte un pan explicitement signalé comme périmé depuis [#92](https://github.com/swoofer/essaim/pull/92).

## Pourquoi la config Jekyll plutôt qu'un Disallow ou un déplacement

Un `Disallow` dans `robots.txt` ne fait que **demander** aux robots de ne pas indexer — les fichiers restent servis à qui connaît l'URL. L'exclusion Jekyll les retire de la publication : ils ne sont pas copiés dans le site généré.

Un déplacement hors de `/docs` aurait marché aussi, mais aurait cassé les références croisées entre la spec et les plans, les bandeaux d'état posés récemment, et les chemins cités dans les messages de commit. Rien ne bouge sur disque.

Ils restent lisibles sur le dépôt, qui est public, à leur chemin habituel.

## Ce qui reste publié

`docs/security/` — `licensing.md` et `THIRD_PARTY_LICENSES.md` relèvent de la conformité de licence et ont vocation à être consultables.

Je vérifierai le 404 après déploiement, ainsi que le fait que la page d'accueil répond toujours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
