### PR TITLE
fix(orchestrator): trois défauts de robustesse au lancement (#96, #97)

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -305,6 +305,15 @@ async function _runProjectBody(
     const { spawn } = await import("child_process");
     const duringScript = path.resolve(__dirname, "..", project.during_run);
     duringRunProcess = spawn("bash", [duringScript], { cwd: runDir, stdio: "ignore" });
+    // Sans ce handler, un ENOENT (bash absent, script introuvable au spawn)
+    // devient une uncaughtException, qui CONTOURNE le try/finally de runProject
+    // — coordinatorHandle.stop() ne s'exécute pas, et coordinator, broker MQTT
+    // et worktrees fuient. Le script during_run est accessoire : son échec doit
+    // dégrader le run, pas l'abattre (#96).
+    duringRunProcess.on("error", (err) => {
+      log.warn(`during_run script failed to spawn: ${err instanceof Error ? err.message : String(err)}`);
+      duringRunProcess = null;
+    });
   }
 
   // Timeout — works for both legacy (kill ChildProcess) and agent-loop
@@ -421,7 +430,12 @@ async function _runProjectBody(
   // agent's underlying work (child process exit, or agent-loop settlement)
   // completes — independent of when the caller stops waiting on it (e.g. the
   // run-level timeout race in the "Wait for all agents" section below).
-  const maxConcurrency = project.max_concurrency ?? DEFAULT_MAX_CONCURRENCY;
+  // Math.max, pas seulement `??` : celui-ci ne substitue que null/undefined, si
+  // bien que `max_concurrency: 0` construisait un limiteur qui n'accorde jamais
+  // de slot. Le premier acquireLaunchSlot() ne rendait alors jamais la main, et
+  // le timeout du run ne rattrape pas — timeoutReject n'est assigné qu'APRÈS la
+  // boucle de lancement (#97).
+  const maxConcurrency = Math.max(1, project.max_concurrency ?? DEFAULT_MAX_CONCURRENCY);
   const acquireLaunchSlot = createConcurrencyLimiter(maxConcurrency);
 
   async function launchWithLimit(agent: typeof project.agents[0]): Promise<ChildProcess | null> {
@@ -430,7 +444,11 @@ async function _runProjectBody(
     if (useAgentLoop) {
       const loopPromise = agentLoopPromises.get(agent.id);
       if (loopPromise) {
-        loopPromise.finally(release);
+        // Le .catch porte sur la promesse DÉRIVÉE par .finally, pas sur
+        // loopPromise : celle-ci est déjà gérée au site d'attente. Sans lui, un
+        // agent-loop qui rejette produit une rejection non gérée — avertissement
+        // aujourd'hui, mort du process sous --unhandled-rejections=strict (#97).
+        loopPromise.finally(release).catch(() => {});
       } else {
         release();
       }

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -114,6 +114,15 @@ function makeFetchMock(registerOk: Record<string, boolean>) {
   });
 }
 
+/** Résout en "PENDING" si la promesse n'a pas rendu la main dans les temps. */
+async function within<T>(p: Promise<T>, ms: number): Promise<T | "PENDING"> {
+  let timer: ReturnType<typeof setTimeout>;
+  const guard = new Promise<"PENDING">((r) => {
+    timer = setTimeout(() => r("PENDING"), ms);
+  });
+  return Promise.race([p, guard]).finally(() => clearTimeout(timer));
+}
+
 let TMP_DIR: string;
 let ORIGINAL_CWD: string;
 
@@ -330,6 +339,63 @@ describe("runProject — concurrency cap on agent fan-out", () => {
 
     expect(tracked.maxActive).toBe(3);
   });
+});
+
+// ── #97 — launch-loop robustness ───────────────────────────────────────────
+
+describe("runProject — launch loop", () => {
+  it("treats max_concurrency: 0 as 1 instead of waiting forever", async () => {
+    // `??` only substitutes null/undefined, so 0 built a limiter that never
+    // grants a slot — the first acquireLaunchSlot() never resolved. The run
+    // timeout cannot rescue it either: timeoutReject is only assigned AFTER
+    // the launch loop, so the run hangs with no agents and no deadline.
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      max_concurrency: 0,
+    });
+
+    const result = await within(
+      runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" }),
+      8000,
+    );
+
+    expect(result, "le run n'a jamais rendu la main — le limiteur n'accorde aucun slot").not.toBe("PENDING");
+    expect(launchAgentLoop).toHaveBeenCalledTimes(1);
+  }, 20000);
+
+  it("does not leak an unhandled rejection when an agent-loop rejects", async () => {
+    // `loopPromise.finally(release)` returns a NEW promise that rejects with
+    // the original. The original is handled at the await site; the derived one
+    // was not — an unhandled rejection warning today, a process kill under
+    // --unhandled-rejections=strict.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+      vi.mocked(launchAgentLoop).mockImplementation(async () => {
+        throw new Error("agent-loop exploded");
+      });
+
+      const project = makeProject({ agents: [makeAgent({ id: "a1", name: "Agent A" })] });
+
+      await runProject(project, "with_coordinator", false, {
+        coordinatorUrl: "http://coordinator.test",
+      }).catch(() => {});
+
+      // Laisse le microtask queue s'écouler pour que la rejection non gérée
+      // remonte si elle existe.
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  }, 20000);
 });
 
 // ── #56 — ESSAIM_RESET_BASE names the directory it is allowed to destroy ────


### PR DESCRIPTION
Corrige [#96](https://github.com/swoofer/essaim/issues/96) et [#97](https://github.com/swoofer/essaim/issues/97), tous deux issus du triage du backlog. Trois défauts, même fichier, même famille : des chemins d'échec qui abattent ou figent le run au lieu de le dégrader.

## `max_concurrency: 0` fige le run, sans deadline

`??` ne substitue que `null`/`undefined`, donc `0` construisait un limiteur qui n'accorde **jamais** de slot — le premier `acquireLaunchSlot()` ne rendait jamais la main.

Et le timeout du run ne rattrape pas : `timeoutReject` n'est assigné qu'**après** la boucle de lancement. Le run restait donc bloqué sans agent et sans échéance. Clampé par `Math.max(1, …)`.

## Rejection non gérée sur la promesse dérivée

`loopPromise.finally(release)` renvoie une **nouvelle** promesse qui rejette avec l'originale. L'originale est gérée au site d'attente ; la dérivée ne l'était pas. Un agent-loop qui rejette produisait donc une rejection non gérée — avertissement aujourd'hui, mort du process sous `--unhandled-rejections=strict`.

## Le spawn de `during_run` sans handler `error`

Un ENOENT devient une `uncaughtException`, qui **contourne** le `try/finally` de `runProject`. `coordinatorHandle.stop()` ne s'exécute pas : coordinator, broker MQTT et worktrees fuient.

## Tests

Les deux premiers ont un test de non-régression, tous deux RED avant correctif :

- `max_concurrency: 0` → le run restait `PENDING` à 8 s ;
- l'agent-loop qui rejette → `[Error: agent-loop exploded]` capturé par un écouteur `unhandledRejection` sur le process.

**Le troisième n'en a pas, et je préfère le dire.** Provoquer un ENOENT sur `bash` demanderait de mocker `child_process` en entier, ce que ce fichier de tests ne peut pas faire : `createWorkspaces` y est réel et dépend de vrais appels git. Le correctif reste défensif, court et lisible — mais il n'est pas couvert.

679 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
