### PR TITLE
fix(mqtt): le catch-up lisait deux colonnes que le coordinator n'expose pas (#98)

### DIFF
--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -239,6 +239,26 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
   // via the coordinator's existing /api/threads-active endpoint — the same
   // one work-stealing.ts already polls for open threads — and re-queue
   // anything this listener hasn't seen yet.
+  /**
+   * `target_modules` est stocké côté coordinator via JSON.stringify dans une
+   * colonne TEXT (consultation.ts:182), donc /api/threads-active le renvoie en
+   * CHAÎNE. Un Array.isArray dessus est toujours faux, ce qui perdait
+   * silencieusement le ciblage par module à chaque catch-up (#98). Le tableau
+   * reste accepté au cas où un appelant le fournirait déjà décodé.
+   */
+  function parseTargetModules(raw: unknown): string[] | undefined {
+    if (Array.isArray(raw)) return raw as string[];
+    if (typeof raw !== "string") return undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? (parsed as string[]) : undefined;
+    } catch {
+      // Colonne illisible : on perd le ciblage, pas le thread. Le renvoyer sans
+      // modules vaut mieux que de le laisser tomber.
+      return undefined;
+    }
+  }
+
   async function catchUpOpenConsultations(): Promise<void> {
     if (!coordinatorUrl) return; // no REST base configured — nothing to catch up on
 
@@ -263,7 +283,15 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
     let recovered = 0;
     for (const thread of threads) {
       if (thread.status !== "open") continue;
-      if (thread.agent_id === agentId) continue; // filter self, same as handleMessage
+      // `initiator_id` est la colonne réelle de la table threads du coordinator
+      // (consultation.ts:174) ; `agent_id` n'y existe pas. Le filtre ne pouvait
+      // donc jamais matcher et chaque agent se réinjectait ses propres
+      // consultations à chaque reconnexion (#98). `agent_id` reste accepté en
+      // repli au cas où une version du coordinator l'exposerait sous ce nom —
+      // le commentaire d'origine invoquait une parité avec handleMessage, qui
+      // lit bien `payload.agent_id`, mais d'une charge MQTT, pas d'une ligne SQL.
+      const initiatorId = (thread.initiator_id ?? thread.agent_id) as string | undefined;
+      if (initiatorId === agentId) continue;
 
       const threadId = thread.id as string | undefined;
       if (!threadId || seenThreadIds.has(threadId)) continue;
@@ -273,7 +301,7 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         type: "consultation_new",
         threadId,
         subject: typeof thread.subject === "string" ? thread.subject : undefined,
-        targetModules: Array.isArray(thread.target_modules) ? (thread.target_modules as string[]) : undefined,
+        targetModules: parseTargetModules(thread.target_modules),
         timestamp: Date.now(),
         raw: thread,
       });

--- a/tests/unit/mqtt-listener.test.ts
+++ b/tests/unit/mqtt-listener.test.ts
@@ -339,6 +339,66 @@ describe("MqttListener", () => {
       expect(msgs[0].subject).toBe("Missed while offline");
     });
 
+    // #98 — le catch-up lisait deux champs que le coordinator n'expose pas sous
+    // cette forme. Les fixtures ci-dessus utilisaient `agent_id`, ce que la
+    // table `threads` ne contient pas : l'initiateur y est `initiator_id`
+    // (consultation.ts:174). Le filtre « pas mes propres threads » ne pouvait
+    // donc jamais matcher, et un agent se réinjectait ses propres consultations
+    // à chaque reconnexion.
+    it("filtre ses propres threads via initiator_id, la colonne réellement exposée", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { id: "t-mine", status: "open", subject: "Le mien", initiator_id: "agent-1" },
+          { id: "t-other", status: "open", subject: "Celui d'un pair", initiator_id: "agent-2" },
+        ],
+      });
+
+      const listener = await connectWithCatchUp(fetchMock);
+
+      const msgs = listener.drain();
+      expect(msgs.map((m) => m.threadId)).toEqual(["t-other"]);
+    });
+
+    // `target_modules` est écrit en JSON.stringify et stocké en TEXT
+    // (consultation.ts:182), donc il revient en CHAÎNE. Array.isArray était
+    // toujours faux et le ciblage par module systématiquement perdu.
+    it("reparse target_modules, qui revient en JSON texte et non en tableau", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            id: "t-mod",
+            status: "open",
+            subject: "Refonte auth",
+            initiator_id: "agent-2",
+            target_modules: '["auth","billing"]',
+          },
+        ],
+      });
+
+      const listener = await connectWithCatchUp(fetchMock);
+
+      const msgs = listener.drain();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].targetModules).toEqual(["auth", "billing"]);
+    });
+
+    it("survit à un target_modules illisible sans perdre le thread", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { id: "t-bad", status: "open", subject: "x", initiator_id: "agent-2", target_modules: "{pas du json" },
+        ],
+      });
+
+      const listener = await connectWithCatchUp(fetchMock);
+
+      const msgs = listener.drain();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].targetModules).toBeUndefined();
+    });
+
     it("does not reprocess a consultation already seen via a live message", async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,


### PR DESCRIPTION
Corrige [#98](https://github.com/swoofer/essaim/issues/98). Le catch-up HTTP ajouté par #63 lisait **deux champs que le coordinator n'expose pas sous cette forme**, ce qui annulait précisément ce qu'il devait faire.

## Le filtre « pas mes propres threads » ne matchait jamais

Il testait `thread.agent_id`. La table `threads` du coordinator n'a pas cette colonne — l'initiateur y est `initiator_id` (`consultation.ts:174`). Le filtre était donc inopérant, et **chaque agent se réinjectait ses propres consultations ouvertes à chaque reconnexion**.

Le commentaire d'origine invoquait une parité avec `handleMessage`. Elle est illusoire : `handleMessage` lit bien `payload.agent_id`, mais d'une charge MQTT, pas d'une ligne SQL. Deux formes différentes.

`agent_id` reste accepté en repli, au cas où une version du coordinator l'exposerait ainsi.

## Le ciblage par module était systématiquement perdu

`target_modules` est écrit en `JSON.stringify` dans une colonne `TEXT` (`consultation.ts:182`), donc l'endpoint le renvoie en **chaîne**. `Array.isArray` dessus est toujours faux → `targetModules` toujours `undefined`.

Effet combiné : à chaque reconnexion, tout le pool ouvert était réinjecté, non filtré et non ciblé.

Reparsé, le tableau restant accepté au cas où un appelant le fournirait décodé. Une colonne illisible fait perdre le ciblage, **pas le thread** — un test le fixe.

## Sur les tests existants

Leurs fixtures utilisaient `agent_id`, la forme que le coordinator ne produit pas. C'est pour ça qu'ils passaient : ils validaient une fiction. Les nouveaux partent de la forme réelle, vérifiée dans la source du coordinator.

RED avant correctif : `['t-mine', 't-other']` au lieu de `['t-other']`, et `undefined` au lieu de `['auth','billing']`.

680 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
