### PR TITLE
fix(agent-loop): libère les tâches réclamées au CLEANUP (#101)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -943,8 +943,17 @@ export async function runAgentLoop(
               // Execute one task. When work already landed on this file, say so:
               // an agent is otherwise blind to its peers, which is how three
               // hunters each committed a near-identical repro test for one bug
-              // (#30). The file-level claim exclusion stops the concurrent case;
-              // this covers the sequential one.
+              // (#30). Ce contexte couvre le cas SÉQUENTIEL — un pair a déjà
+              // livré sur ce fichier avant nous.
+              //
+              // Le cas CONCURRENT n'est pas couvert, contrairement à ce que
+              // disait ce commentaire : work-stealing.ts:226-231 est explicite,
+              // claim-task est atomique sur thread_id seul, pas sur le fichier,
+              // donc deux agents peuvent réclamer deux threads distincts qui
+              // partagent un fichier. Le correctif est côté coordinator
+              // (swoofer/mcp-coordinator#258). Un commentaire qui affirmait le
+              // contraire de son propre module a déjà envoyé un triage sur une
+              // fausse piste (#107).
               let taskPrompt = phase.prompt.replace(/\{\{params\.current_task\}\}/g, task.description);
               if (task.relatedDone?.length) {
                 taskPrompt += `\n\n## Déjà livré sur ce fichier (par un autre agent, ce run)\n`
@@ -1138,6 +1147,18 @@ export async function runAgentLoop(
   claude.close();
   interruptClaude.close();
   await mqtt.close().catch(() => {});
+
+  // Chaque sortie nominale dépareille unclaimTask avec un
+  // claimedThreadIds.delete(), donc ce balayage ne voit normalement rien. Il
+  // couvre le cas qui échappait à toutes : une exception entre le claim et
+  // l'une de ces sorties laissait le thread réservé sur le coordinator,
+  // assigné à un agent mort, et donc involable par les autres (#101).
+  // Best-effort : le run se termine de toute façon, et un unclaim qui échoue
+  // ne doit pas masquer l'exitReason déjà déterminé.
+  for (const threadId of claimedThreadIds) {
+    await unclaimTask(config.coordinatorUrl, threadId, config.agentId).catch(() => {});
+  }
+  claimedThreadIds.clear();
 
   const result: AgentLoopResult = {
     agentId: config.agentId,

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -19,6 +19,13 @@ vi.mock("../../src/agent-loop/claude-stream.js", () => ({
   BudgetExceededError: class BudgetExceededError extends Error {
     constructor(msg?: string) { super(msg ?? "Budget exceeded"); this.name = "BudgetExceededError"; }
   },
+  // Le catch de runAgentLoop teste `err instanceof AbortError` avant de
+  // retomber sur "error". Sans cet export, tout test qui fait échouer un tour
+  // meurt sur « No "AbortError" export is defined » au lieu d'exercer le
+  // chemin d'erreur — c'est pourquoi aucun ne l'exerçait.
+  AbortError: class AbortError extends Error {
+    constructor(msg?: string) { super(msg ?? "Aborted"); this.name = "AbortError"; }
+  },
 }));
 
 // Mock mqtt-listener
@@ -849,6 +856,42 @@ describe("runAgentLoop — phased mode", () => {
     expect(mockPostDiscoveries).not.toHaveBeenCalled();
     // Verify the flow completes
     expect(result.exitReason).toBe("done");
+  });
+
+  // #101 — chaque sortie nominale dépareille unclaimTask avec
+  // claimedThreadIds.delete(). Mais le bloc CLEANUP ne balayait pas ce qui
+  // restait dans le set : une exception entre le claim et l'une de ces sorties
+  // laissait le thread réservé sur le coordinator, assigné à un agent mort, et
+  // aucun autre agent ne pouvait le voler.
+  it("libère la tâche réclamée quand le tour explose avant toute sortie nominale", async () => {
+    vi.useFakeTimers();
+
+    const config = makeConfig({
+      phases: [
+        { name: "execute", prompt: "Fix: {{params.current_task}}", toolsMode: "full", loop: true },
+      ],
+    });
+
+    mockClaimNextTask.mockImplementation(async () => {
+      // Une seule tâche, puis plus rien — l'exception tombe pendant son
+      // traitement, donc le second appel n'arrive jamais.
+      return { id: "t-orpheline", description: "Bug A", file: undefined, severity: undefined };
+    });
+
+    mockSend.mockRejectedValue(new Error("boom pendant le traitement de la tâche"));
+
+    const loopPromise = runAgentLoop(config, silentLogger);
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(10_000);
+    }
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("error");
+    expect(mockUnclaimTask).toHaveBeenCalledWith(
+      "http://localhost:3100",
+      "t-orpheline",
+      "test-agent",
+    );
   });
 
   it("respects maxTurns during work-stealing loop", async () => {


### PR DESCRIPTION
Corrige [#101](https://github.com/swoofer/essaim/issues/101), et le point le plus coûteux de [#107](https://github.com/swoofer/essaim/issues/107).

## Une tâche réclamée pouvait rester réservée à un agent mort

Chaque sortie nominale dépareille `unclaimTask` avec un `claimedThreadIds.delete()` — cinq chemins le font correctement. Mais le bloc CLEANUP ne balayait pas ce qui restait dans le set.

Une exception entre le claim et l'une de ces sorties laissait donc le thread réservé sur le coordinator, `assigned_to` un agent qui n'existe plus. Aucun autre agent ne peut le voler : la tâche est perdue pour le run.

Vérifié que CLEANUP est bien atteint sur ce chemin — le `catch` de `runAgentLoop` ne relance pas, il fixe `exitReason`. Le balayage y a donc de l'effet.

## Ce que le test a révélé

Le mock de `claude-stream` n'exportait pas `AbortError`, que le `catch` teste avant de retomber sur `"error"`. Tout test faisant échouer un tour mourait donc sur *« No "AbortError" export is defined »* — ce qui explique qu'**aucun test n'exerçait le chemin d'erreur**. L'export est ajouté au mock.

RED avant correctif : `unclaimTask` appelé 0 fois.

## Le commentaire trompeur

`agent-loop.ts:946` affirmait que l'exclusion au niveau fichier « stops the concurrent case ». `work-stealing.ts:226-231` dit explicitement l'inverse : `claim-task` est atomique sur `thread_id` seul, pas sur le fichier.

Ce commentaire a envoyé la première passe du triage de #51 sur une fausse piste. Il pointe désormais vers le vrai correctif, côté coordinator ([swoofer/mcp-coordinator#258](https://github.com/swoofer/mcp-coordinator/issues/258)).

## Ce que je ne corrige pas, et pourquoi

#107 listait deux autres résidus. Après relecture :

- **le `continue` sur `assigned_to` n'est pas un défaut.** Le refetch de `busyFiles` se déclenche sur une *preuve de course* — on vient d'en perdre une. Sauter un thread en dispatch dirigé n'est pas cette preuve ; y ajouter un refetch n'ajouterait que des appels HTTP.
- **la branche `catch`** pourrait légitimement rafraîchir, un claim qui lève ayant pu aboutir côté serveur. Mais `work-stealing.ts` n'a aucune couture injectable : le tester demanderait de refactorer les seams du module pour un bénéfice marginal. Je préfère ne pas livrer de code de production non testé sur un chemin d'erreur.

683 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
