### PR TITLE
fix(pipeline): refuse les formes qui se chargeaient en silence (#99)

### DIFF
--- a/src/pipeline/schema.ts
+++ b/src/pipeline/schema.ts
@@ -114,6 +114,18 @@ function parseStep(raw: unknown, index: number, baseDir: string): PipelineStep {
     }
   }
 
+  // `modules` non-liste levait autrefois... rien : Array.isArray était faux, le
+  // champ était simplement omis du pas, et le run ciblait tout au lieu de ce
+  // qu'on lui demandait. Silencieux dans un --dry-run comme dans un vrai run
+  // (#99). Mieux vaut nommer la ligne fautive.
+  if (s.modules !== undefined && !Array.isArray(s.modules)) {
+    throw new Error(
+      `Step ${where}: 'modules' must be a list (e.g. [a, b]), got ${
+        s.modules === null ? "null" : typeof s.modules
+      } — a scalar or mapping would be silently dropped`,
+    );
+  }
+
   const hasModules = Array.isArray(s.modules);
   const hasModulesFile = typeof s.modules_file === "string" && s.modules_file.trim() !== "";
   if (hasModules && hasModulesFile) {
@@ -136,7 +148,17 @@ function parseStep(raw: unknown, index: number, baseDir: string): PipelineStep {
 
   if (s.set !== undefined) step.set = coerceStringMap(s.set, where, "set");
   if (s.set_file !== undefined) step.set_file = coerceStringMap(s.set_file, where, "set_file");
-  if (s.agents !== undefined) step.agents = Number(s.agents);
+  if (s.agents !== undefined) {
+    // Number({n: 2}) vaut NaN, et le NaN partait tel quel dans la boucle de
+    // lancement (#99).
+    const agents = Number(s.agents);
+    if (!Number.isInteger(agents) || agents < 1) {
+      throw new Error(
+        `Step ${where}: 'agents' must be a positive integer, got ${JSON.stringify(s.agents)}`,
+      );
+    }
+    step.agents = agents;
+  }
   if (s.timeout_minutes !== undefined) step.timeout_minutes = Number(s.timeout_minutes);
   if (s.hooks !== undefined) step.hooks = parseHooks(s.hooks, where);
 

--- a/tests/unit/pipeline-schema.test.ts
+++ b/tests/unit/pipeline-schema.test.ts
@@ -175,3 +175,77 @@ steps:
     expect(def.steps[0]!.set).toEqual({ "behavior.count": "42", "behavior.enabled": "true" });
   });
 });
+
+// ── #99 — formes scalaires/objet acceptées en silence ──────────────────────
+//
+// #59 avait corrigé la TypeError brute sur hooks.before/after et ajouté
+// coerceScalar sur modules/set/set_file. Restaient trois formes qui ne lèvent
+// pas mais dégradent : le pas se charge avec la valeur absente ou NaN, et rien
+// dans un --dry-run ne le trahit. Un auteur de YAML obtient un run qui fait
+// autre chose, plutôt qu'une erreur nommant sa ligne.
+describe("loadPipeline — formes invalides pour modules et agents (#99)", () => {
+  it("refuse un modules scalaire au lieu de le laisser disparaître", () => {
+    const p = write(
+      "scalaire.yaml",
+      `name: p
+steps:
+  - name: s
+    template: t
+    project: .
+    modules: platform
+`,
+    );
+
+    expect(() => loadPipeline(p)).toThrow(/modules/);
+  });
+
+  it("refuse un modules en mapping", () => {
+    const p = write(
+      "mapping.yaml",
+      `name: p
+steps:
+  - name: s
+    template: t
+    project: .
+    modules:
+      id: platform
+`,
+    );
+
+    expect(() => loadPipeline(p)).toThrow(/modules/);
+  });
+
+  it("refuse un agents non numérique au lieu de stocker NaN", () => {
+    const p = write(
+      "agents.yaml",
+      `name: p
+steps:
+  - name: s
+    template: t
+    project: .
+    agents:
+      n: 2
+`,
+    );
+
+    expect(() => loadPipeline(p)).toThrow(/agents/);
+  });
+
+  it("accepte toujours les formes valides — pas de régression", () => {
+    const p = write(
+      "ok.yaml",
+      `name: p
+steps:
+  - name: s
+    template: t
+    project: .
+    modules: [a, b]
+    agents: 3
+`,
+    );
+
+    const def = loadPipeline(p);
+    expect(def.steps[0].modules).toEqual(["a", "b"]);
+    expect(def.steps[0].agents).toBe(3);
+  });
+});


### PR DESCRIPTION
Corrige [#99](https://github.com/swoofer/essaim/issues/99). Même classe que #59 : le YAML est accepté, la valeur est perdue, et l'auteur obtient un run qui fait autre chose plutôt qu'une erreur pointant sa ligne.

## `modules` non-liste disparaissait

`modules: platform` (scalaire) et `modules: {id: …}` (mapping) ne levaient rien. `Array.isArray` était faux, donc `hasModules` aussi, et le champ était **simplement omis du pas** — le run ciblait alors tout au lieu de ce qu'on lui demandait. Invisible au `--dry-run` comme au vrai run.

## `agents` non numérique stockait un NaN

`agents: {n: 2}` → `Number({n: 2})` = `NaN`, stocké tel quel et propagé jusqu'à la boucle de lancement.

Les deux lèvent désormais en nommant le pas **et** la valeur reçue. Un test de non-régression garde les formes valides (`modules: [a, b]`, `agents: 3`).

RED avant correctif : les trois cas se chargeaient sans broncher.

687 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
