### PR TITLE
fix(catalog): swarm.yaml double-encodé + compteurs de doc périmés

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp-data/
 tmp-essaim/
 .tmp-*.cjs
 reports/
+.claude/
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm test                                    # vitest run — 62 unit files, fileParallelism: false
+npm run test:watch
+npx vitest run tests/unit/effort.test.ts    # one file
+npx vitest run -t "nom du cas"              # one case by name
+npm run build                               # tsc → dist/src + dist/cli (rootDir is ".")
+npm run dev -- run raid -p ~/proj --dry-run # CLI via tsx, no build step
+```
+
+CI (`.github/workflows/test.yml`) runs exactly `npm install && npm test && npm run build` on Node 24. There is no lint or format script — don't invent one.
+
+**CI guard:** the `no-domain-artifacts` job fails any PR that reintroduces client-specific catalog content — it greps every tracked file for the client name and rejects `templates|presets|behaviors|compositions/<client>-*`. The term is spelled out only in `.github/workflows/test.yml`; never repeat it in another tracked file or the guard trips on its own repo. Domain-specific catalog content lives in the private repo, not here.
+
+## Three-repo split
+
+```
+essaim (this repo)   catalog + orchestrator + CLI
+  ├── @swoofer/promptweave   BCE engine: resolve preset → validate → assemble
+  └── mcp-coordinator        server: 26 MCP tools, SQLite, MQTT broker, dashboard :3100
+```
+
+promptweave is ours too — if the BCE engine misbehaves, fix it upstream rather than working around it in essaim. Coordination semantics (impact scoring, MQTT topics, `/api/claim-task`) belong to mcp-coordinator; read its README before assuming essaim owns a behavior.
+
+## Prompts are assembled, not written
+
+There are no prompt string literals to edit. An agent's `prompt.md`, `hooks/*.sh` and `.mcp.json` are emitted by promptweave from YAML:
+
+- `behaviors/` (46) — numbered sections: foundation 000-009, patterns 010-029, mission 030-050, transversal 050-099. Section numbers determine final prompt order.
+- `presets/` — a role = a list of behaviors + params.
+- `compositions/` (3) — rules that rewrite sections when two behaviors co-occur (e.g. `announce+readonly` rewrites section 020).
+- `templates/` — a swarm = presets + agent count + phase wiring. `essaim list` shows them.
+
+To change what an agent says, edit the YAML. `--dry-run` previews the assembled result without launching.
+
+## Orchestrator flow
+
+`cli/run-core.ts` is the single path shared by `run` and `pipeline`: scan → build → launch → report. Underneath:
+
+- `src/orchestrator/orchestrator.ts` (38K) — phase scheduler, worktree lifecycle, run loop.
+- `src/agent-loop/agent-loop.ts` (55K) — one agent's turn loop; `claude-stream.ts` parses the CLI stream, `coordination-protocol.ts` runs announce → detect → consult → resolve, `mqtt-listener.ts` receives push events between turns, `work-stealing.ts` claims tasks.
+- `src/bridge.ts` — the only call site into promptweave.
+
+**Phases** come from an optional `phase:` field on a behavior. `discover` (read-only, no loop) → `review` (no tools, dedups into NEW/DUPLICATE/ENRICHES) → `execute` (full tools, work-stealing loop). A preset with no phased behavior runs one-shot.
+
+**Effort** (`src/agent-loop/effort.ts`) maps a level to model + thinking keyword + maxTurns: low=haiku/none/15, mid=sonnet/think/8, high=opus/think-hard/20, max=opus/ultrathink/60. `critical:` discoveries auto-promote low→mid.
+
+## Security subsystem
+
+`essaim security` (`cli/security.ts`) chains scan → seed coordinator → swarm fixes → verify → report. Engines are out-of-process adapters (`src/security/adapters/`, v1 = Strix).
+
+`src/security/registry.ts` refuses to register any adapter whose license isn't MIT/Apache-2.0/BSD/ISC. This gate is what protects essaim's MIT posture — AGPL/GPL/SSPL engines are invoked out-of-process only, never registered. Don't loosen it.
+
+## Tests
+
+`vitest.config.ts` only picks up `tests/**/*.test.ts`. Shell tests (`tests/*.test.sh`) are bridged into vitest by `tests/unit/shell-scripts.test.ts`, which enumerates the directory — a new `.test.sh` is picked up automatically, no registration needed.
+
+One chmod test is Windows-only and skips on macOS/Linux.
+
+## `ESSAIM_RESET_BASE` is destructive
+
+It holds **the path to reset**, not a boolean. Before creating worktrees it runs `git checkout -- . && git clean -fd` on that path. The value must equal the run's `-p` base; anything else (including the legacy `=1`) is refused with both paths named. Off by default — worktrees snapshot from a git ref, so a dirty base is harmless without it.
+
+## Logging
+
+Pino JSON to stdout. Component loggers: `orchestrator`, `agent-loop`, `phase-scheduler`, `work-stealing`, `effort`, `quota`, `tokens`. `LOG_LEVEL=debug`, pretty via `NODE_ENV=development`. Per-run token report lands in `reports/YYYY-MM-DD-<run-id>.md` (gitignored).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,4 +44,4 @@ Open an issue with the "feature" template. Explain the use case before proposing
 
 ## Architecture
 
-essaim is the orchestrator. It composes behaviors via [@swoofer/promptweave](https://github.com/swoofer/promptweave) and runs them against an embedded [mcp-coordinator](https://github.com/swoofer/mcp-coordinator) instance. The 32-behavior catalog ships bundled. See `README.md` for the high-level model.
+essaim is the orchestrator. It composes behaviors via [@swoofer/promptweave](https://github.com/swoofer/promptweave) and runs them against an embedded [mcp-coordinator](https://github.com/swoofer/mcp-coordinator) instance. The 46-behavior catalog ships bundled. See `README.md` for the high-level model.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Developer A                    Developer B
 
 The consultation cycle — **announce → detect → consult → resolve** — runs in the agent-loop without a sidecar. Agents call `announce_work` before coding; the coordinator scores impact and opens a thread on score ≥ 90; MQTT pushes the thread to affected peers between turns; the thread closes on consensus, timeout, or gray-zone auto-resolve.
 
-essaim ships the orchestrator (agent-loop, preset runner, phase scheduler) and the behavior catalog (32 behaviors, 21 presets, 3 composition rules). The coordination server lives in [`mcp-coordinator`](https://github.com/swoofer/mcp-coordinator#readme); the prompt assembly engine in [`@swoofer/promptweave`](https://github.com/swoofer/promptweave#readme). essaim wires them together and ships the CLI.
+essaim ships the orchestrator (agent-loop, preset runner, phase scheduler) and the behavior catalog (46 behaviors, 29 presets, 3 composition rules). The coordination server lives in [`mcp-coordinator`](https://github.com/swoofer/mcp-coordinator#readme); the prompt assembly engine in [`@swoofer/promptweave`](https://github.com/swoofer/promptweave#readme). essaim wires them together and ships the CLI.
 
 ---
 
@@ -105,7 +105,7 @@ essaim (this package)
   +-- mcp-coordinator        (coordination server: MCP tools, SQLite, MQTT broker, dashboard)
 ```
 
-essaim owns the **catalog** (32 behaviors, 21 presets, 3 composition rules, 6 hook scripts), the **orchestrator** (phase scheduler, effort router, work-stealing loop), and the **CLI**. `@swoofer/promptweave` owns the BCE engine (resolver, validator, assembler). `mcp-coordinator` owns everything coordination-side: 26 MCP tools, impact scoring, MQTT broker + topic protocol, SQLite, and the dashboard at `http://localhost:3100/dashboard`.
+essaim owns the **catalog** (46 behaviors, 29 presets, 3 composition rules, 7 hook scripts), the **orchestrator** (phase scheduler, effort router, work-stealing loop), and the **CLI**. `@swoofer/promptweave` owns the BCE engine (resolver, validator, assembler). `mcp-coordinator` owns everything coordination-side: 26 MCP tools, impact scoring, MQTT broker + topic protocol, SQLite, and the dashboard at `http://localhost:3100/dashboard`.
 
 **For the tool reference, scoring layers, MQTT topics, dashboard panels, and server-side config, read [mcp-coordinator's README](https://github.com/swoofer/mcp-coordinator#readme).** This file documents only essaim's own surface.
 
@@ -116,7 +116,7 @@ essaim owns the **catalog** (32 behaviors, 21 presets, 3 composition rules, 6 ho
 Every agent prompt, hook, and MCP config is **assembled, not written**. essaim ships a catalog of reusable YAML modules; `@swoofer/promptweave` resolves the preset, validates, composes, and emits `prompt.md` + `hooks/*.sh` + `.mcp.json` for each agent.
 
 ```
-32 behaviors    21 presets    3 composition rules    6 hook scripts    3 workflow phases
+46 behaviors    29 presets    3 composition rules    7 hook scripts    3 workflow phases
 ```
 
 ### Three behavioral layers
@@ -308,6 +308,9 @@ Language-agnostic templates. `essaim scan` auto-detects the stack; the template 
 | `arene` | Code quiz / trivia | 3 | one-shot, keep_open |
 | `carrefour` | Intentional conflict test | 2-3 | one-shot |
 | `babel` | Documentation translation | 2 | sequential |
+| `phare` | 4 audit specialists + reconciler | 5 | one-shot, staggered |
+| `sentinelle` | Fixes security findings ingested in the coordinator | dynamic | one-shot |
+| `migrate-phase2` | Scaffolder, then one migrator per slice | 1 + per-module | one-shot, staggered |
 
 For per-template descriptions and the preset roles each one wires together, run `essaim list presets` or read [`compositions/`](./compositions/) in this repo.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1713,10 +1713,10 @@
 
     <div class="terminal fade-in" style="max-width: 760px;">
       <div><span class="t-green">$</span> essaim bce list behaviors</div>
-      <div><span class="t-dim">32 behaviors &mdash; foundation / patterns / mission / transversal</span></div>
+      <div><span class="t-dim">46 behaviors &mdash; foundation / patterns / mission / transversal</span></div>
       <div>&nbsp;</div>
       <div><span class="t-green">$</span> essaim bce list presets</div>
-      <div><span class="t-dim">21 presets &mdash; raid, melee, essaim, chaine, revue, maitre, &hellip;</span></div>
+      <div><span class="t-dim">29 presets &mdash; raid, melee, essaim, chaine, revue, maitre, &hellip;</span></div>
       <div>&nbsp;</div>
       <div><span class="t-green">$</span> essaim bce build raid <span class="t-yellow">--dry-run</span></div>
       <div><span class="t-dim"># Preview prompt.md + hooks + .mcp.json without writing to disk</span></div>

--- a/presets/swarm.yaml
+++ b/presets/swarm.yaml
@@ -1,4 +1,4 @@
-﻿name: swarm
+name: swarm
 description: “Refactoring en essaim — discovery + work-stealing”
 profile: codeur
 behaviors:
@@ -16,32 +16,32 @@ behaviors:
 params:
   phase-discover:
     discovery_mission: >
-      Identifie le code dupliquÃ©, les abstractions manquantes, les
+      Identifie le code dupliqué, les abstractions manquantes, les
       fonctions trop longues, les violations de principes SOLID, et
       le code mort.
 
-      ðŸŽ¯ SCOPE STRICT â€” cherche UNIQUEMENT dans le code source sous
-      `src/` (et `lib/` s'il existe). Le reste du dÃ©pÃ´t (tests/, docs/,
+      🎯 SCOPE STRICT — cherche UNIQUEMENT dans le code source sous
+      `src/` (et `lib/` s'il existe). Le reste du dépôt (tests/, docs/,
       bce/, cli/, dashboard/, bin/) est HORS-SUJET. Si tu lis ailleurs
       que `src/`/`lib/`, tu gaspilles ton budget de tours.
     effort: low
   phase-review:
     review_mission: >
-      Compare tes opportunitÃ©s de refactoring avec les threads existants.
-      MÃªme fichier + mÃªme pattern = probable doublon.
-      Si tu proposes une approche diffÃ©rente pour le mÃªme refactoring, enrichis le thread.
+      Compare tes opportunités de refactoring avec les threads existants.
+      Même fichier + même pattern = probable doublon.
+      Si tu proposes une approche différente pour le même refactoring, enrichis le thread.
     effort: low
   phase-execute:
     execute_mission: >
-      Effectue le refactoring identifiÃ©. VÃ©rifie que les tests passent
-      aprÃ¨s chaque modification. Ne change pas le comportement externe.
+      Effectue le refactoring identifié. Vérifie que les tests passent
+      après chaque modification. Ne change pas le comportement externe.
 
-      ðŸŽ¯ SCOPE STRICT â€” tu ne modifies QUE le fichier cible mentionnÃ©
-      dans la tÃ¢che et le code source associÃ© sous `src/`. Le reste du
-      dÃ©pÃ´t (tests/, docs/, bce/, cli/, dashboard/, bin/) est HORS-SUJET.
+      🎯 SCOPE STRICT — tu ne modifies QUE le fichier cible mentionné
+      dans la tâche et le code source associé sous `src/`. Le reste du
+      dépôt (tests/, docs/, bce/, cli/, dashboard/, bin/) est HORS-SUJET.
       Ne spawne AUCUN sous-agent.
-    # Sonnet (mid) est suffisant pour un refactoring ciblÃ© â€” Ã  "high"
-    # (Opus), l'agent dÃ©pensait son budget en exploration avant d'atteindre
+    # Sonnet (mid) est suffisant pour un refactoring ciblé — à "high"
+    # (Opus), l'agent dépensait son budget en exploration avant d'atteindre
     # DONE. Sonnet + scope strict ci-dessus = moins d'excursions.
     effort: mid
 


### PR DESCRIPTION
## Summary

- **`presets/swarm.yaml` était double-encodé** — seul fichier du catalogue avec un BOM UTF-8, corps en mojibake (`dupliquÃ©`, `dÃ©pÃ´t`, `ðŸŽ¯`). Le YAML parsait, donc rien ne cassait visiblement, mais les missions `phase-discover` / `phase-review` / `phase-execute` partaient telles quelles aux agents `swarm`. BOM retiré, 13 lignes re-décodées ; les guillemets courbes de `description` étaient corrects et sont intacts.
- **Compteurs de doc périmés** — README, CONTRIBUTING et la démo terminal de la landing page annonçaient « 32 behaviors, 21 presets » ; le disque en a 46 et 29. « 6 hook scripts » était faux dans les deux sens : les 7 scripts de `scripts/` sont tous câblés comme hooks par un behavior. Le tableau des templates listait 12 entrées sur 15 (`phare`, `sentinelle`, `migrate-phase2` ajoutés).
- **`CLAUDE.md` ajouté**, et `.claude/` + `graphify-out/` ignorés.

Les chaînes `roadmap.v30.desc` de `docs/index.html` ne sont volontairement pas touchées : elles décrivent le jalon « v0.1 — Initial release », pas l'état courant.

## Test plan

- [x] `npm test` passes — 690 passed, 1 skipped (test chmod Windows-only)
- [ ] Added tests for new behavior (if applicable) — sans objet : correction d'encodage et de documentation, aucun comportement nouveau
- [x] Verified `essaim run swarm --dry-run` still assembles correctly — 4 agents, prompt 6635 chars
- [x] `npm run build` (tsc) green
- [x] Garde-fou `no-domain-artifacts` rejoué sur l'état **suivi** après `git add` — les deux jobs OK

> Note : le premier jet de `CLAUDE.md` citait littéralement le terme que le garde-fou interdit. La vérification initiale était passée à tort, `git grep` ne voyant que les fichiers suivis alors que le fichier était encore non suivi. Le paragraphe a été réécrit — le terme n'apparaît plus que dans `.github/workflows/test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
