### PR TITLE
docs(site): remet le registry de presets et l'intégration IDE dans la v51

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2404,8 +2404,8 @@
       <div class="timeline-item">
         <div class="timeline-dot dot-planned"></div>
         <div class="timeline-badge badge-planned" data-i18n="roadmap.badge.planned">Planned</div>
-        <h4 data-i18n="roadmap.v51.title">Security engines v2/v3 and team setups</h4>
-        <p data-i18n="roadmap.v51.desc">HexStrike AI (MIT, over MCP/REST), then PentAGI (MIT, over REST/GraphQL) &mdash; both arm's-length, like Strix. TLS and a remote MQTT broker for shared coordinators, per-team quota partitioning, and a guide to authoring your own behaviors.</p>
+        <h4 data-i18n="roadmap.v51.title">Security engines v2/v3, team setups and preset registry</h4>
+        <p data-i18n="roadmap.v51.desc">HexStrike AI (MIT, over MCP/REST), then PentAGI (MIT, over REST/GraphQL) &mdash; both arm's-length, like Strix. TLS and a remote MQTT broker for shared coordinators, plus per-team quota partitioning. A community preset registry: publish and install presets over npm, a guide to authoring your own behaviors, and IDE integration for browsing them.</p>
       </div>
 
       <div class="timeline-item">
@@ -2752,8 +2752,8 @@
       "roadmap.v40.desc": "Pluggable security scanning, v1 on Strix: scan, normalize through SARIF, ingest into the coordinator, let the swarm fix, then verify deterministically. Engines are always invoked arm's-length, and a permissive-license gate refuses to register anything else.",
       "roadmap.v50.title": "v0.9+ &mdash; Remote-first hardening",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE now names the directory it resets, so no run can wipe a base you did not authorize. In flight: MQTT reconnection against a remote coordinator (#33), and putting the revised plan from decideAdjust to work (#108).",
-      "roadmap.v51.title": "Security engines v2/v3 and team setups",
-      "roadmap.v51.desc": "HexStrike AI (MIT, over MCP/REST), then PentAGI (MIT, over REST/GraphQL) &mdash; both arm's-length, like Strix. TLS and a remote MQTT broker for shared coordinators, per-team quota partitioning, and a guide to authoring your own behaviors.",
+      "roadmap.v51.title": "Security engines v2/v3, team setups and preset registry",
+      "roadmap.v51.desc": "HexStrike AI (MIT, over MCP/REST), then PentAGI (MIT, over REST/GraphQL) &mdash; both arm's-length, like Strix. TLS and a remote MQTT broker for shared coordinators, plus per-team quota partitioning. A community preset registry: publish and install presets over npm, a guide to authoring your own behaviors, and IDE integration for browsing them.",
       "roadmap.v52.title": "Cross-repo swarms and semantic conflicts",
       "roadmap.v52.desc": "Swarms spanning several repositories at once, beyond today's sequential pipeline. A shared dependency map across microservice and monorepo boundaries. AST-level detection of API contract breaks, before any thread opens.",
       "footer.text": "MIT License &nbsp;&middot;&nbsp; Built with <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"
@@ -2979,8 +2979,8 @@
       "roadmap.v40.desc": "Scan de s&eacute;curit&eacute; enfichable, v1 sur Strix : scanner, normaliser via SARIF, ing&eacute;rer dans le coordinateur, laisser l'essaim corriger, puis v&eacute;rifier de mani&egrave;re d&eacute;terministe. Les moteurs sont toujours invoqu&eacute;s &agrave; distance de bras, et un garde-fou de licence permissive refuse d'enregistrer quoi que ce soit d'autre.",
       "roadmap.v50.title": "v0.9+ &mdash; Durcissement remote-first",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE nomme d&eacute;sormais le r&eacute;pertoire qu'il r&eacute;initialise : aucun run ne peut effacer une base que vous n'avez pas autoris&eacute;e. En cours : reconnexion MQTT contre un coordinateur distant (#33), et exploitation du plan r&eacute;vis&eacute; produit par decideAdjust (#108).",
-      "roadmap.v51.title": "Moteurs de s&eacute;curit&eacute; v2/v3 et setups d'&eacute;quipe",
-      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), puis PentAGI (MIT, via REST/GraphQL) &mdash; tous deux &agrave; distance de bras, comme Strix. TLS et broker MQTT distant pour coordinateurs partag&eacute;s, partitionnement du quota par &eacute;quipe, et un guide pour &eacute;crire vos propres behaviors.",
+      "roadmap.v51.title": "Moteurs de s&eacute;curit&eacute; v2/v3, setups d'&eacute;quipe et registry de presets",
+      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), puis PentAGI (MIT, via REST/GraphQL) &mdash; tous deux &agrave; distance de bras, comme Strix. TLS et broker MQTT distant pour coordinateurs partag&eacute;s, plus le partitionnement du quota par &eacute;quipe. Un registry communautaire de presets : publication et installation via npm, un guide pour &eacute;crire vos propres behaviors, et une int&eacute;gration IDE pour les parcourir.",
       "roadmap.v52.title": "Essaims multi-d&eacute;p&ocirc;ts et conflits s&eacute;mantiques",
       "roadmap.v52.desc": "Des essaims couvrant plusieurs d&eacute;p&ocirc;ts simultan&eacute;ment, au-del&agrave; du pipeline s&eacute;quentiel actuel. Une carte de d&eacute;pendances partag&eacute;e par-dessus les fronti&egrave;res microservices et monorepo. D&eacute;tection au niveau AST des ruptures de contrat d'API, avant m&ecirc;me qu'un thread s'ouvre.",
       "footer.text": "Licence MIT &nbsp;&middot;&nbsp; Construit avec <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"
@@ -3206,8 +3206,8 @@
       "roadmap.v40.desc": "Escaneo de seguridad conectable, v1 sobre Strix: escanear, normalizar via SARIF, ingerir en el coordinador, dejar que el enjambre corrija, y despu&eacute;s verificar de forma determinista. Los motores siempre se invocan como programas separados, y una barrera de licencia permisiva se niega a registrar cualquier otra cosa.",
       "roadmap.v50.title": "v0.9+ &mdash; Endurecimiento remote-first",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE ahora nombra el directorio que reinicia, as&iacute; ninguna ejecuci&oacute;n puede borrar una base que no autorizaste. En curso: reconexi&oacute;n MQTT contra un coordinador remoto (#33), y aprovechar el plan revisado que produce decideAdjust (#108).",
-      "roadmap.v51.title": "Motores de seguridad v2/v3 y despliegues de equipo",
-      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), luego PentAGI (MIT, via REST/GraphQL) &mdash; ambos como programas separados, igual que Strix. TLS y broker MQTT remoto para coordinadores compartidos, particionado de cuota por equipo, y una gu&iacute;a para escribir tus propios behaviors.",
+      "roadmap.v51.title": "Motores de seguridad v2/v3, despliegues de equipo y registro de presets",
+      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), luego PentAGI (MIT, via REST/GraphQL) &mdash; ambos como programas separados, igual que Strix. TLS y broker MQTT remoto para coordinadores compartidos, m&aacute;s particionado de cuota por equipo. Un registro comunitario de presets: publicar e instalar presets via npm, una gu&iacute;a para escribir tus propios behaviors, e integraci&oacute;n con el IDE para explorarlos.",
       "roadmap.v52.title": "Enjambres multi-repo y conflictos sem&aacute;nticos",
       "roadmap.v52.desc": "Enjambres que abarcan varios repositorios a la vez, m&aacute;s all&aacute; del pipeline secuencial actual. Un mapa de dependencias compartido a trav&eacute;s de fronteras de microservicios y monorepo. Detecci&oacute;n a nivel AST de rupturas de contrato de API, antes de que se abra ning&uacute;n thread.",
       "footer.text": "Licencia MIT &nbsp;&middot;&nbsp; Construido con <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"
@@ -3433,8 +3433,8 @@
       "roadmap.v40.desc": "Steckbares Security-Scanning, v1 mit Strix: scannen, via SARIF normalisieren, in den Coordinator einspeisen, den Schwarm beheben lassen, dann deterministisch verifizieren. Engines werden stets als eigenst&auml;ndige Programme aufgerufen, und ein Lizenz-Gate f&uuml;r permissive Lizenzen weigert sich, alles andere zu registrieren.",
       "roadmap.v50.title": "v0.9+ &mdash; Remote-First-H&auml;rtung",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE benennt jetzt das Verzeichnis, das es zur&uuml;cksetzt &mdash; kein Lauf kann eine Basis l&ouml;schen, die Sie nicht autorisiert haben. In Arbeit: MQTT-Reconnect gegen einen entfernten Coordinator (#33) und die Verwertung des von decideAdjust revidierten Plans (#108).",
-      "roadmap.v51.title": "Security-Engines v2/v3 und Team-Setups",
-      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), dann PentAGI (MIT, via REST/GraphQL) &mdash; beide als eigenst&auml;ndige Programme, wie Strix. TLS und ein entfernter MQTT-Broker f&uuml;r geteilte Coordinator-Instanzen, Quota-Partitionierung pro Team und ein Leitfaden zum Schreiben eigener Behaviors.",
+      "roadmap.v51.title": "Security-Engines v2/v3, Team-Setups und Preset-Registry",
+      "roadmap.v51.desc": "HexStrike AI (MIT, via MCP/REST), dann PentAGI (MIT, via REST/GraphQL) &mdash; beide als eigenst&auml;ndige Programme, wie Strix. TLS und ein entfernter MQTT-Broker f&uuml;r geteilte Coordinator-Instanzen, dazu Quota-Partitionierung pro Team. Eine Community-Registry f&uuml;r Presets: Ver&ouml;ffentlichen und Installieren &uuml;ber npm, ein Leitfaden zum Schreiben eigener Behaviors und IDE-Integration zum Durchsuchen.",
       "roadmap.v52.title": "Repo-&uuml;bergreifende Schw&auml;rme und semantische Konflikte",
       "roadmap.v52.desc": "Schw&auml;rme &uuml;ber mehrere Repositories gleichzeitig, jenseits der heutigen sequentiellen Pipeline. Eine geteilte Abh&auml;ngigkeitskarte &uuml;ber Microservice- und Monorepo-Grenzen hinweg. Erkennung von API-Vertragsbr&uuml;chen auf AST-Ebene, bevor ein Thread &uuml;berhaupt ge&ouml;ffnet wird.",
       "footer.text": "MIT-Lizenz &nbsp;&middot;&nbsp; Gebaut mit <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"
@@ -3660,8 +3660,8 @@
       "roadmap.v40.desc": "可插拔的安全扫描，v1 基于 Strix：扫描、经 SARIF 归一化、注入 coordinator、交由 swarm 修复，然后确定性验证。引擎始终以独立进程方式调用，宽松许可证闸门拒绝注册其他任何引擎。",
       "roadmap.v50.title": "v0.9+ &mdash; 面向远程的加固",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE 现在必须写明要重置的目录，因此任何运行都无法清除你未授权的基准目录。进行中：针对远程 coordinator 的 MQTT 重连（#33），以及让 decideAdjust 产出的修订计划真正发挥作用（#108）。",
-      "roadmap.v51.title": "安全引擎 v2/v3 与团队部署",
-      "roadmap.v51.desc": "HexStrike AI（MIT，经 MCP/REST），随后是 PentAGI（MIT，经 REST/GraphQL）&mdash; 与 Strix 一样均以独立进程方式调用。为共享 coordinator 提供 TLS 与远程 MQTT broker、按团队划分配额，以及编写自定义 behaviors 的指南。",
+      "roadmap.v51.title": "安全引擎 v2/v3、团队部署与 preset 注册表",
+      "roadmap.v51.desc": "HexStrike AI（MIT，经 MCP/REST），随后是 PentAGI（MIT，经 REST/GraphQL）&mdash; 与 Strix 一样均以独立进程方式调用。为共享 coordinator 提供 TLS 与远程 MQTT broker，以及按团队划分配额。社区 preset 注册表：通过 npm 发布与安装 preset、编写自定义 behaviors 的指南，以及用于浏览的 IDE 集成。",
       "roadmap.v52.title": "跨仓库 swarm 与语义冲突",
       "roadmap.v52.desc": "同时横跨多个仓库的 swarm，超越目前的顺序流水线。跨微服务与 monorepo 边界的共享依赖图。在任何 thread 打开之前，就在 AST 层面检测 API 契约破坏。",
       "footer.text": "MIT 许可证 &nbsp;&middot;&nbsp; 用 <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> 构建 &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"
@@ -3887,8 +3887,8 @@
       "roadmap.v40.desc": "差し替え可能なセキュリティスキャン、v1 は Strix。スキャン、SARIF による正規化、coordinator への取り込み、swarm による修正、そして決定的な検証。エンジンは常に別プロセスとして呼び出され、パーミッシブライセンス・ゲートがそれ以外の登録を拒否します。",
       "roadmap.v50.title": "v0.9+ &mdash; リモート前提の堅牢化",
       "roadmap.v50.desc": "ESSAIM_RESET_BASE はリセット対象のディレクトリ自体を指定する方式になり、承認していないベースが消えることはなくなりました。進行中：リモート coordinator に対する MQTT 再接続（#33）と、decideAdjust が生成する修正済みプランの活用（#108）。",
-      "roadmap.v51.title": "セキュリティエンジン v2/v3 とチーム構成",
-      "roadmap.v51.desc": "HexStrike AI（MIT、MCP/REST 経由）、続いて PentAGI（MIT、REST/GraphQL 経由）&mdash; いずれも Strix と同様に別プロセスとして呼び出します。共有 coordinator 向けの TLS とリモート MQTT broker、チーム単位のクォータ分割、独自 behaviors の作成ガイド。",
+      "roadmap.v51.title": "セキュリティエンジン v2/v3、チーム構成、preset レジストリ",
+      "roadmap.v51.desc": "HexStrike AI（MIT、MCP/REST 経由）、続いて PentAGI（MIT、REST/GraphQL 経由）&mdash; いずれも Strix と同様に別プロセスとして呼び出します。共有 coordinator 向けの TLS とリモート MQTT broker、そしてチーム単位のクォータ分割。コミュニティ preset レジストリ：npm での preset 公開とインストール、独自 behaviors の作成ガイド、閲覧用の IDE 統合。",
       "roadmap.v52.title": "リポジトリ横断 swarm と意味的コンフリクト",
       "roadmap.v52.desc": "現在の逐次パイプラインを超えて、複数リポジトリにまたがる swarm。マイクロサービスと monorepo の境界をまたぐ共有依存マップ。thread が開く前に、AST レベルで API 契約の破壊を検出。",
       "footer.text": "MIT ライセンス &nbsp;&middot;&nbsp; <a href=\"https://claude.ai/code\" target=\"_blank\">Claude Code</a> で構築 &nbsp;&middot;&nbsp; <a href=\"https://github.com/swoofer/essaim\" target=\"_blank\">essaim v0.9.x</a>"


### PR DESCRIPTION
## Summary

En réécrivant la roadmap (#115), j'avais écarté de l'ancienne entrée v0.3 le **registry communautaire**, la **publication npm des presets** et l'**intégration IDE**, ne gardant que le guide d'écriture de behaviors. C'était mon arbitrage, pas une décision du mainteneur — il le corrige.

Les trois reviennent dans la v51. Le titre s'élargit, sinon il ne couvrait plus son contenu :

| | |
|---|---|
| Avant | Moteurs de sécurité v2/v3 et setups d'équipe |
| Après | Moteurs de sécurité v2/v3, setups d'équipe **et registry de presets** |

Description mise à jour dans les 6 langues (en, fr, es, de, zh, ja) + la balise inline.

## Test plan

- [x] Dictionnaire i18n évaluable en JS, **225 clés toujours synchronisées** sur les 6 langues
- [x] Page rendue en local : zéro erreur console, bascule testée en `en/fr/zh/ja`
- [x] Timeline inchangée : `done, done, progress, planned, future`
- [ ] `npm test` — sans objet : aucun fichier suivi par les tests n'est touché
- [ ] Added tests for new behavior (if applicable) — sans objet : contenu éditorial d'une page statique
- [ ] Verified `essaim run swarm --dry-run` — sans objet : le catalogue n'est pas touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)
