### PR TITLE
feat(coordinator): migration vers mcp-coordinator 2.2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ essaim (this repo)   catalog + orchestrator + CLI
 
 promptweave is ours too — if the BCE engine misbehaves, fix it upstream rather than working around it in essaim. Coordination semantics (impact scoring, MQTT topics, `/api/claim-task`) belong to mcp-coordinator; read its README before assuming essaim owns a behavior.
 
+MQTT topics are org-scoped from coordinator 2.x on: `coordinator/<org>/consultations/...`.
+The org comes from the `org` claim of `COORDINATOR_TOKEN`, and the broker silently
+refuses any subscription outside that prefix — a `coordinator/+/...` wildcard included,
+since the ACL test is a `startsWith`. A refusal arrives as a SUBACK failure code, not as
+a connection error, so `grantedTopics` reads those codes and warns. See `orgFromToken`
+in `src/agent-loop/mqtt-listener.ts`.
+
 ## Prompts are assembled, not written
 
 There are no prompt string literals to edit. An agent's `prompt.md`, `hooks/*.sh` and `.mcp.json` are emitted by promptweave from YAML:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ essaim ships the orchestrator (agent-loop, preset runner, phase scheduler) and t
 
 ### Prerequisites
 
-- Node.js >= 20
+- Node.js >= 22
 - `claude` CLI on PATH (install from [claude.ai/code](https://claude.ai/code))
 - `ANTHROPIC_API_KEY` environment variable set
 

--- a/docs/superpowers/plans/2026-08-24-coordinator-2.2.1-migration.md
+++ b/docs/superpowers/plans/2026-08-24-coordinator-2.2.1-migration.md
@@ -1,0 +1,757 @@
+# Migration essaim → mcp-coordinator 2.2.1 — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Faire fonctionner essaim contre `mcp-coordinator@2.2.1` — dont la rupture décisive est que les topics MQTT sont désormais scopés par organisation, ce qui rend muette toute la coordination push sans lever la moindre erreur.
+
+**Architecture:** essaim dispose déjà de l'org qu'il lui faut : elle est dans le claim `org` du `COORDINATOR_TOKEN` qu'il envoie en mot de passe MQTT. On décode ce claim côté client (jamais on ne le vérifie — le serveur reste l'autorité), on préfixe les sept topics, on décale les index de parsing, et on rend bruyant tout refus d'abonnement. Le reste est du nettoyage : deux endpoints supprimés côté serveur, un plancher Node, et une vérification des corps REST maintenant validés par zod.
+
+**Tech Stack:** TypeScript (ESM, `tsc` → `dist/`), vitest (`fileParallelism: false`), `mqtt@^5`, Node ≥ 22.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-coordinator-2.2.1-migration-findings.md`
+
+## Global Constraints
+
+- Plancher Node : `>=22`. Valeur imposée par `mcp-coordinator@2.2.1` (`engines: {"node": ">=22"}`).
+- Dépendance cible : `"mcp-coordinator": "^2.2.1"`. Un caret sur `^0.13.0` ne remonte jamais en 1.x/2.x.
+- Aucun script de lint ni de format n'existe. La CI est exactement `npm install && npm test && npm run build`. Ne pas en inventer.
+- Garde-fou CI `no-domain-artifacts` : le nom du client ne doit apparaître dans **aucun** fichier suivi hors `.github/workflows/test.yml`. Ne jamais l'écrire ailleurs, y compris dans un commentaire ou un message de commit.
+- `vitest.config.ts` ne ramasse que `tests/**/*.test.ts`. Les tests shell (`tests/*.test.sh`) sont montés automatiquement par `tests/unit/shell-scripts.test.ts` — aucune inscription manuelle.
+- Un test chmod est Windows-only et se skippe ailleurs. Un skip sur macOS/Linux n'est pas un échec.
+- Commits en Conventional Commits (`CONTRIBUTING.md:34`).
+
+---
+
+## File Structure
+
+| Fichier | Responsabilité | Tâche |
+|---|---|---|
+| `package.json` | plancher Node + version de la dépendance | 1 |
+| `src/agent-loop/mqtt-listener.ts` | dérivation de l'org, topics scopés, parsing décalé, diagnostic des refus | 2, 3 |
+| `tests/unit/mqtt-org-scoping.test.ts` | **créé** — org depuis le token, construction des topics, classification décalée | 2 |
+| `tests/unit/mqtt-diagnostics.test.ts` | **créé** — un abonnement refusé est journalisé au niveau `warn` | 3 |
+| `src/orchestrator/orchestrator.ts` | retrait de l'appel `/api/run-config` | 4 |
+| `src/agent-loop/agent-loop.ts` | retrait de l'appel `/api/token-usage` | 4 |
+| `README.md`, `CLAUDE.md` | plancher Node, forme des topics | 7 |
+
+`mqtt-listener.ts` fait 15 K et porte déjà une responsabilité claire — recevoir et classer les événements poussés. Les tâches 2 et 3 restent dedans. Pas de découpage : ce serait une restructuration non demandée.
+
+---
+
+## Task 1: Monter le plancher Node et prendre la dépendance
+
+**Files:**
+- Modify: `package.json` (clés `engines` et `dependencies.mcp-coordinator`)
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: un `node_modules/mcp-coordinator` en 2.2.x, et l'inventaire écrit de ce qui casse — dont les tâches 2 à 6 sont la réponse. Aucune signature de code.
+
+- [ ] **Step 1: Constater l'état de départ**
+
+```bash
+node -p "require('./package.json').engines.node"
+node -p "require('./package.json').dependencies['mcp-coordinator']"
+node -p "require('./node_modules/mcp-coordinator/package.json').version"
+```
+
+Attendu : `>=20`, `^0.13.0`, `0.13.0`.
+
+- [ ] **Step 2: Modifier les deux clés**
+
+Dans `package.json`, remplacer `"mcp-coordinator": "^0.13.0",` par :
+
+```json
+"mcp-coordinator": "^2.2.1",
+```
+
+et remplacer `"engines": { "node": ">=20" }` par :
+
+```json
+"engines": { "node": ">=22" }
+```
+
+- [ ] **Step 3: Installer et vérifier la version résolue**
+
+```bash
+npm install
+node -p "require('./node_modules/mcp-coordinator/package.json').version"
+```
+
+Attendu : une version `2.2.x`. Si npm rend encore `0.13.0`, le caret n'a pas été modifié — relire l'étape 2.
+
+- [ ] **Step 4: Prendre l'inventaire des dégâts, sans rien corriger**
+
+```bash
+npm test 2>&1 | tail -40
+npm run build 2>&1 | tail -20
+```
+
+Consigner la liste des échecs dans le message de commit. **Ne rien réparer ici** : chaque réparation a sa tâche. Une erreur `tsc` liée aux types du coordinator est attendue à ce stade.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "build(deps): passe a mcp-coordinator 2.2.1 et au plancher Node 22"
+```
+
+---
+
+## Task 2: Scoper les topics MQTT par organisation
+
+C'est la tâche qui débloque la coordination. Sans elle, essaim se connecte et n'entend rien.
+
+**Files:**
+- Modify: `src/agent-loop/mqtt-listener.ts` (constante `TOPICS` lignes 108-116 ; `classifyTopic` lignes 118-141 ; `buildInterrupt` lignes 144-178 ; l'appel `subscribe` ligne 361)
+- Test: `tests/unit/mqtt-org-scoping.test.ts` (créé)
+
+**Interfaces:**
+- Consumes: `coordinatorToken()` depuis `../coordinator-auth.js`, déjà importé ligne 4.
+- Produces:
+  - `export function orgFromToken(token: string | undefined): string`
+  - `export function topicsForOrg(org: string): string[]`
+  - `export function classifyTopic(topic: string, payload: Record<string, unknown>): InterruptType | null` — signature inchangée, indices décalés de un, ajout du mot-clé `export`.
+  - `export function buildInterrupt(type: InterruptType, topic: string, payload: Record<string, unknown>): MqttInterrupt` — idem.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/unit/mqtt-org-scoping.test.ts` :
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  orgFromToken,
+  topicsForOrg,
+  classifyTopic,
+  buildInterrupt,
+} from "../../src/agent-loop/mqtt-listener.js";
+
+/** Fabrique un JWT non signé : seule la charge utile compte, on ne vérifie jamais. */
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+describe("orgFromToken", () => {
+  it("lit le claim org", () => {
+    expect(orgFromToken(jwt({ org: "acme", sub: "agent-1" }))).toBe("acme");
+  });
+
+  it("retombe sur 'default' quand le claim manque, comme le coordinator", () => {
+    expect(orgFromToken(jwt({ sub: "agent-1" }))).toBe("default");
+  });
+
+  it("retombe sur 'default' sans token", () => {
+    expect(orgFromToken(undefined)).toBe("default");
+  });
+
+  it("retombe sur 'default' sur un token illisible plutot que de jeter", () => {
+    expect(orgFromToken("pas-un-jwt")).toBe("default");
+    expect(orgFromToken("a.!!!.c")).toBe("default");
+  });
+});
+
+describe("topicsForOrg", () => {
+  it("prefixe les sept topics par coordinator/<org>/", () => {
+    expect(topicsForOrg("acme")).toEqual([
+      "coordinator/acme/consultations/new",
+      "coordinator/acme/consultations/+/messages",
+      "coordinator/acme/consultations/+/status",
+      "coordinator/acme/consultations/+/claimed",
+      "coordinator/acme/consultations/+/completed",
+      "coordinator/acme/broadcast",
+      "coordinator/acme/agents/+/status",
+    ]);
+  });
+
+  it("chaque topic commence par le prefixe que l'ACL du coordinator exige", () => {
+    for (const t of topicsForOrg("acme")) {
+      expect(t.startsWith("coordinator/acme/")).toBe(true);
+    }
+  });
+});
+
+describe("classifyTopic sur la forme scopee", () => {
+  it("classe une nouvelle consultation", () => {
+    expect(classifyTopic("coordinator/acme/consultations/new", {})).toBe("consultation_new");
+  });
+
+  it("classe un message de thread", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/messages", {})).toBe(
+      "consultation_message",
+    );
+  });
+
+  it("distingue resolved de resolving sur le topic status", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/status", { status: "resolved" })).toBe(
+      "consultation_resolved",
+    );
+    expect(classifyTopic("coordinator/acme/consultations/t1/status", { status: "proposed" })).toBe(
+      "consultation_resolving",
+    );
+  });
+
+  it("classe claimed et completed", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/claimed", {})).toBe(
+      "consultation_claimed",
+    );
+    expect(classifyTopic("coordinator/acme/consultations/t1/completed", {})).toBe(
+      "consultation_completed",
+    );
+  });
+
+  it("classe le statut d'agent", () => {
+    expect(classifyTopic("coordinator/acme/agents/a1/status", { status: "offline" })).toBe(
+      "agent_offline",
+    );
+    expect(classifyTopic("coordinator/acme/agents/a1/status", { status: "online" })).toBe(
+      "agent_online",
+    );
+  });
+
+  it("classe le broadcast", () => {
+    expect(classifyTopic("coordinator/acme/broadcast", {})).toBe("broadcast");
+  });
+
+  it("ignore l'ancienne forme non scopee, que le coordinator ne publie plus", () => {
+    expect(classifyTopic("coordinator/consultations/new", {})).toBeNull();
+  });
+});
+
+describe("buildInterrupt sur la forme scopee", () => {
+  it("extrait le threadId du topic", () => {
+    const i = buildInterrupt("consultation_message", "coordinator/acme/consultations/t42/messages", {});
+    expect(i.threadId).toBe("t42");
+  });
+
+  it("laisse la charge utile primer sur le topic", () => {
+    const i = buildInterrupt("consultation_message", "coordinator/acme/consultations/t42/messages", {
+      thread_id: "t99",
+    });
+    expect(i.threadId).toBe("t99");
+  });
+
+  it("extrait l'agentId d'un topic de statut", () => {
+    const i = buildInterrupt("agent_offline", "coordinator/acme/agents/a7/status", {});
+    expect(i.agentId).toBe("a7");
+  });
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+npx vitest run tests/unit/mqtt-org-scoping.test.ts
+```
+
+Attendu : ÉCHEC — `orgFromToken` et `topicsForOrg` ne sont pas exportés.
+
+- [ ] **Step 3: Ajouter la dérivation de l'org et la construction des topics**
+
+Dans `src/agent-loop/mqtt-listener.ts`, remplacer la constante `TOPICS` (lignes 108-116) par :
+
+```ts
+/**
+ * Le segment org de chaque topic du coordinator (#330). Le coordinator le tire du
+ * claim `org` du token et refuse — SILENCIEUSEMENT, via `cb(null, null)` dans
+ * `authorizeSubscribe` — tout abonnement hors de `coordinator/<org>/`. Un joker
+ * `coordinator/+/...` est refuse aussi : le test est un `startsWith` sur le prefixe.
+ *
+ * On decode, on ne verifie jamais : le serveur reste l'autorite, on n'a besoin que
+ * du prefixe de routage. Le repli sur "default" reproduit exactement celui du
+ * coordinator (`src/auth.ts:126`), sans quoi un token sans claim `org` s'abonnerait
+ * a un prefixe que le serveur n'emploie pas.
+ */
+export function orgFromToken(token: string | undefined): string {
+  if (!token) return "default";
+  const parts = token.split(".");
+  if (parts.length < 2) return "default";
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return typeof payload.org === "string" && payload.org ? payload.org : "default";
+  } catch {
+    return "default";
+  }
+}
+
+/** Les sept topics auxquels l'agent s'abonne, prefixes par son org. */
+export function topicsForOrg(org: string): string[] {
+  const p = `coordinator/${org}`;
+  return [
+    `${p}/consultations/new`,
+    `${p}/consultations/+/messages`,
+    `${p}/consultations/+/status`,
+    `${p}/consultations/+/claimed`,
+    `${p}/consultations/+/completed`,
+    `${p}/broadcast`,
+    `${p}/agents/+/status`,
+  ];
+}
+```
+
+- [ ] **Step 4: Décaler les index de parsing**
+
+Remplacer `classifyTopic` en entier. `parts[1]` est désormais l'org — jamais testée ici, puisque l'ACL du serveur garantit qu'on ne reçoit que la sienne :
+
+```ts
+export function classifyTopic(
+  topic: string,
+  payload: Record<string, unknown>,
+): InterruptType | null {
+  const parts = topic.split("/");
+  // coordinator/<org>/... : le genre est en [2], l'identifiant en [3], la feuille en [4].
+  if (parts[0] !== "coordinator" || parts.length < 3) return null;
+
+  if (parts[2] === "consultations") {
+    if (parts[3] === "new") return "consultation_new";
+    if (parts[4] === "messages") return "consultation_message";
+    if (parts[4] === "claimed") return "consultation_claimed";
+    if (parts[4] === "completed") return "consultation_completed";
+    if (parts[4] === "status") {
+      const status = payload.status as string | undefined;
+      if (status === "resolved") return "consultation_resolved";
+      return "consultation_resolving";
+    }
+  }
+
+  if (parts[2] === "agents" && parts[4] === "status") {
+    const status = payload.status as string | undefined;
+    if (status === "offline") return "agent_offline";
+    return "agent_online";
+  }
+
+  if (parts[2] === "broadcast") return "broadcast";
+
+  return null;
+}
+```
+
+Dans `buildInterrupt`, ajouter `export` devant la déclaration, puis remplacer le bloc d'extraction du threadId :
+
+```ts
+  // Extrait le threadId : coordinator/<org>/consultations/{id}/messages|status|claimed|completed
+  if (parts[2] === "consultations" && parts.length >= 5 && parts[3] !== "new") {
+    interrupt.threadId = parts[3];
+  }
+```
+
+et le bloc d'extraction de l'agentId :
+
+```ts
+  // Topic de statut d'agent : coordinator/<org>/agents/{agentId}/status
+  if (parts[2] === "agents" && parts[4] === "status") {
+    interrupt.agentId = parts[3];
+  }
+```
+
+- [ ] **Step 5: Brancher l'abonnement sur l'org du token**
+
+Remplacer l'appel `client!.subscribe(TOPICS, ...)` (ligne 361) par :
+
+```ts
+          const org = orgFromToken(coordinatorToken());
+          const topics = topicsForOrg(org);
+          client!.subscribe(topics, (err) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            log.info("connected", { url, org });
+            resolve();
+          });
+```
+
+- [ ] **Step 6: Lancer les tests pour les voir passer**
+
+```bash
+npx vitest run tests/unit/mqtt-org-scoping.test.ts
+```
+
+Attendu : PASS sur les 15 cas.
+
+- [ ] **Step 7: Lancer toute la suite**
+
+```bash
+npm test
+```
+
+Attendu : aucun nouvel échec par rapport à l'inventaire de la tâche 1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/agent-loop/mqtt-listener.ts tests/unit/mqtt-org-scoping.test.ts
+git commit -m "fix(mqtt): scope les topics par organisation, comme le coordinator 2.x les publie"
+```
+
+---
+
+## Task 3: Rendre bruyant un abonnement refusé
+
+Sans cette tâche, la tâche 2 est invérifiable en production : un mauvais préfixe redonne exactement le silence d'aujourd'hui. C'est ce trou qui a laissé l'issue #33 survivre à un pilote entier.
+
+**Files:**
+- Modify: `src/agent-loop/mqtt-listener.ts` (callback de `subscribe` posé en tâche 2 ; handler `close` lignes 393-396 ; ajout d'un handler `error`)
+- Test: `tests/unit/mqtt-diagnostics.test.ts` (créé)
+
+**Interfaces:**
+- Consumes: `topicsForOrg`, `orgFromToken` de la tâche 2.
+- Produces: `export function grantedTopics(granted: Array<{ topic: string; qos: number }>): { ok: string[]; refused: string[] }` — partitionne le retour de `subscribe`. Un QoS ≥ 128 est un refus (code d'échec SUBACK, MQTT 3.1.1 §3.9.3).
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `tests/unit/mqtt-diagnostics.test.ts` :
+
+```ts
+import { describe, it, expect } from "vitest";
+import { grantedTopics } from "../../src/agent-loop/mqtt-listener.js";
+
+describe("grantedTopics", () => {
+  it("separe les abonnements accordes des refuses", () => {
+    const r = grantedTopics([
+      { topic: "coordinator/acme/broadcast", qos: 0 },
+      { topic: "coordinator/acme/consultations/new", qos: 1 },
+      { topic: "coordinator/autre/broadcast", qos: 128 },
+    ]);
+    expect(r.ok).toEqual([
+      "coordinator/acme/broadcast",
+      "coordinator/acme/consultations/new",
+    ]);
+    expect(r.refused).toEqual(["coordinator/autre/broadcast"]);
+  });
+
+  it("traite tout QoS >= 128 comme un refus", () => {
+    const r = grantedTopics([{ topic: "t", qos: 135 }]);
+    expect(r.refused).toEqual(["t"]);
+    expect(r.ok).toEqual([]);
+  });
+
+  it("rend deux listes vides sur une entree vide", () => {
+    expect(grantedTopics([])).toEqual({ ok: [], refused: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Lancer le test pour le voir échouer**
+
+```bash
+npx vitest run tests/unit/mqtt-diagnostics.test.ts
+```
+
+Attendu : ÉCHEC — `grantedTopics` n'est pas exporté.
+
+- [ ] **Step 3: Implémenter la partition**
+
+Dans `src/agent-loop/mqtt-listener.ts` :
+
+```ts
+/**
+ * MQTT 3.1.1 §3.9.3 : le SUBACK rend un code par topic, et tout code >= 128 est
+ * un echec. Le coordinator refuse par `cb(null, null)` dans `authorizeSubscribe`,
+ * ce qui arrive ici sous cette forme, sans erreur de connexion. Un refus non
+ * signale, c'est un run entier sans coordination et sans un mot (#33).
+ */
+export function grantedTopics(
+  granted: Array<{ topic: string; qos: number }>,
+): { ok: string[]; refused: string[] } {
+  const ok: string[] = [];
+  const refused: string[] = [];
+  for (const g of granted) {
+    (g.qos >= 128 ? refused : ok).push(g.topic);
+  }
+  return { ok, refused };
+}
+```
+
+- [ ] **Step 4: Exploiter la partition et remonter les vraies causes**
+
+Remplacer le callback de `subscribe` posé en tâche 2 par :
+
+```ts
+          client!.subscribe(topics, (err, granted) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            const { ok, refused } = grantedTopics(granted ?? []);
+            if (refused.length > 0) {
+              log.warn("subscriptions refused by the coordinator", { org, refused });
+            }
+            log.info("connected", { url, org, subscribed: ok.length });
+            resolve();
+          });
+```
+
+Puis, juste après le handler `close` (lignes 393-396), ajouter un handler `error` :
+
+```ts
+        // Sans ceci, une erreur d'upgrade WS ou d'authentification est purement
+        // avalee : `close` ne porte aucune cause, et son niveau debug la masque.
+        client.on("error", (err: Error) => {
+          log.warn("mqtt error", { url, message: err.message });
+        });
+```
+
+- [ ] **Step 5: Lancer les tests pour les voir passer**
+
+```bash
+npx vitest run tests/unit/mqtt-diagnostics.test.ts && npm test
+```
+
+Attendu : PASS sur les 3 cas, et aucun nouvel échec dans la suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent-loop/mqtt-listener.ts tests/unit/mqtt-diagnostics.test.ts
+git commit -m "fix(mqtt): signale un abonnement refuse et la vraie cause d'une deconnexion"
+```
+
+---
+
+## Task 4: Retirer les deux endpoints supprimés côté serveur
+
+**Files:**
+- Modify: `src/orchestrator/orchestrator.ts:231-241` (bloc `/api/run-config`)
+- Modify: `src/agent-loop/agent-loop.ts` (fonction `postTokenUsageSse` à partir de la ligne 455, et tous ses appels)
+
+**Interfaces:**
+- Consumes: rien des tâches précédentes.
+- Produces: rien. Suppression pure.
+
+- [ ] **Step 1: Confirmer l'absence côté coordinator avant de supprimer**
+
+```bash
+grep -rn "run-config\|token-usage" /c/Users/gagno/projet/mcp-coordinator-new/src/ || echo "absents de 2.2.1 - confirme"
+```
+
+Attendu : `absents de 2.2.1 - confirme`. **Si l'un des deux apparaît, arrêter cette tâche** : la route a été restaurée et il n'y a rien à supprimer.
+
+- [ ] **Step 2: Retirer l'appel /api/run-config**
+
+Dans `src/orchestrator/orchestrator.ts`, supprimer le commentaire `// 1b. Push run config to dashboard` et l'appel `await postJson(...)` qui le suit, jusqu'au `});` fermant inclus. Le remplacer par :
+
+```ts
+  // L'en-tete de run partait vers /api/run-config, route supprimee dans le
+  // coordinator 2.x. postJson avalait deja l'echec ; on ne garde pas un appel
+  // dont on sait qu'il ne peut plus aboutir.
+```
+
+- [ ] **Step 3: Retirer l'appel /api/token-usage**
+
+Dans `src/agent-loop/agent-loop.ts`, supprimer la fonction `postTokenUsageSse` en entier, puis localiser et retirer chacun de ses appels :
+
+```bash
+grep -n "postTokenUsageSse" src/agent-loop/agent-loop.ts
+```
+
+Supprimer toutes les lignes que cette commande renvoie. Le compteur de tokens local (`formatTokens`, le rapport par run dans `reports/`) est indépendant et reste en place.
+
+- [ ] **Step 4: Vérifier qu'il ne reste aucune référence**
+
+```bash
+grep -rn "run-config\|token-usage\|postTokenUsageSse" src/ cli/ scripts/ || echo "aucune reference - propre"
+npm run build
+```
+
+Attendu : `aucune reference - propre`, puis un build `tsc` sans erreur.
+
+- [ ] **Step 5: Lancer la suite**
+
+```bash
+npm test
+```
+
+Attendu : aucun nouvel échec. Si un test référence l'un des deux endpoints, le supprimer dans le même commit — il teste une route qui n'existe plus.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orchestrator/orchestrator.ts src/agent-loop/agent-loop.ts
+git commit -m "fix(coordinator): retire les appels aux deux routes supprimees en 2.x"
+```
+
+---
+
+## Task 5: Vérifier les corps REST contre les schémas zod
+
+Depuis la v1.0.0 du coordinator, les corps REST sont validés par zod et rendent un 400 structuré. La spec marque ce point **NON VÉRIFIÉ** : cette tâche le tranche.
+
+**Files:**
+- Read only: `/c/Users/gagno/projet/mcp-coordinator-new/src/http/rest-handlers.ts` et les schémas qu'il importe
+- Modify: le ou les fichiers essaim dont un corps dévie — inconnu avant l'étape 3
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: soit rien (si tout concorde), soit des corrections de corps de requête. Aucune nouvelle signature.
+
+- [ ] **Step 1: Extraire les schémas des routes qu'essaim appelle**
+
+```bash
+grep -rn "BodySchema\|z.object" /c/Users/gagno/projet/mcp-coordinator-new/src/http/rest-handlers.ts | head -40
+```
+
+- [ ] **Step 2: Lister les corps qu'envoie essaim**
+
+```bash
+grep -rn "JSON.stringify({" -A 12 src/agent-loop/agent-loop.ts src/agent-loop/work-stealing.ts src/orchestrator/orchestrator.ts | head -60
+```
+
+- [ ] **Step 3: Comparer champ par champ**
+
+Pour chacune des routes qu'essaim appelle — `/api/announce`, `/api/register`, `/api/claim-task`, `/api/unclaim-task`, `/api/post-to-thread`, `/api/propose-resolution`, `/api/approve-resolution`, `/api/threads-active`, `/api/session-start`, `/api/session-stop`, `/api/log-file`, `/api/hot-files`, `/api/quota`, `/api/check-interrupt`, `/api/reset` — vérifier que tout champ marqué requis par le schéma est bien émis, et qu'aucun champ émis n'est rejeté par un `.strict()`.
+
+Consigner le résultat dans le message de commit, y compris s'il est « aucun écart ».
+
+- [ ] **Step 4: Corriger les écarts trouvés**
+
+Aucun code n'est donné ici : il dépend entièrement de ce que l'étape 3 révèle. S'il n'y a aucun écart, passer à l'étape 5 sans modification — c'est un résultat valide, pas un échec de tâche.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "fix(coordinator): aligne les corps REST sur les schemas zod de 2.x"
+```
+
+Si aucun écart n'a été trouvé, ne rien committer et le noter dans le rapport de tâche.
+
+---
+
+## Task 6: Vérification de bout en bout contre un coordinator 2.2.1
+
+**Files:**
+- Aucun fichier modifié. Tâche de vérification.
+
+**Interfaces:**
+- Consumes: tout ce qui précède.
+- Produces: le verdict local sur l'issue #33.
+
+- [ ] **Step 1: Lancer un coordinator 2.2.1 en local**
+
+```bash
+npx mcp-coordinator serve --port 3100
+```
+
+Laisser tourner dans un terminal séparé.
+
+- [ ] **Step 2: Vérifier que /mqtt répond bien à l'upgrade WebSocket**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "Connection: Upgrade" -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+  http://127.0.0.1:3100/mqtt
+```
+
+Attendu : `101`. Un `404` signifie qu'un coordinator 0.13.0 tourne encore — revérifier la tâche 1.
+
+- [ ] **Step 3: Lancer un swarm réel et observer les abonnements**
+
+```bash
+LOG_LEVEL=debug npm run dev -- run raid -p . --agents 2 --timeout 5 2>&1 | grep -i "connected\|refused\|mqtt error"
+```
+
+Attendu : une ligne `connected` portant `org` et `subscribed: 7`. **Aucune** ligne `subscriptions refused`. Si `subscribed` est inférieur à 7, le préfixe d'org ne correspond pas à celui du serveur — comparer avec le claim `org` réellement porté par le token et relire la tâche 2.
+
+- [ ] **Step 4: Confirmer qu'un événement poussé arrive**
+
+```bash
+LOG_LEVEL=debug npm run dev -- run raid -p . --agents 2 --timeout 5 2>&1 | grep -i "interrupt\|consultation_"
+```
+
+Attendu : au moins un `consultation_new` ou `consultation_message`. C'est la preuve que la chaîne push fonctionne de bout en bout — le point que l'issue #33 mettait en défaut.
+
+- [ ] **Step 5: Consigner le verdict sur #33**
+
+Si les étapes 2 à 4 passent, l'écrire dans l'issue #33 en précisant que la vérification est **locale**. Fermer l'issue demande en plus une vérification contre le coordinator déployé, qui exige un token valide et l'accord de l'opérateur — hors périmètre de ce plan.
+
+- [ ] **Step 6: Pas de commit**
+
+Aucun fichier modifié. Reporter le résultat dans le rapport de tâche.
+
+---
+
+## Task 7: Mettre la documentation en accord avec le code
+
+**Files:**
+- Modify: `CLAUDE.md` (section « Three-repo split »)
+- Modify: `README.md` (prérequis Node)
+
+**Interfaces:**
+- Consumes: les faits établis par les tâches 1 à 6.
+- Produces: rien de programmatique.
+
+- [ ] **Step 1: Relever ce que la doc affirme**
+
+```bash
+grep -n "Node\|node" README.md | head -10
+grep -n "mcp-coordinator" CLAUDE.md README.md | head -10
+```
+
+- [ ] **Step 2: Corriger le prérequis Node dans README.md**
+
+Remplacer toute mention d'un plancher Node 20 par Node 22, en cohérence avec `package.json`.
+
+- [ ] **Step 3: Documenter la forme scopée des topics dans CLAUDE.md**
+
+Dans la section « Three-repo split », après la phrase sur les semantics appartenant à mcp-coordinator, ajouter :
+
+```markdown
+Les topics MQTT sont scopés par organisation depuis le coordinator 2.x :
+`coordinator/<org>/consultations/...`. L'org vient du claim `org` du
+`COORDINATOR_TOKEN`, et le broker refuse silencieusement tout abonnement hors de
+ce préfixe — joker compris. Voir `orgFromToken` dans `src/agent-loop/mqtt-listener.ts`.
+```
+
+- [ ] **Step 4: Vérifier que le garde-fou CI reste vert**
+
+```bash
+git add -A
+git grep -In -i 'mekova' -- . ':!.github/workflows/test.yml' && echo "ECHEC - terme reintroduit" || echo "OK"
+```
+
+Attendu : `OK`.
+
+- [ ] **Step 5: Lancer la suite complète et le build une dernière fois**
+
+```bash
+npm test && npm run build
+```
+
+Attendu : tout au vert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: plancher Node 22 et topics MQTT scopes par organisation"
+```
+
+---
+
+## Ordre et dépendances
+
+```
+Task 1 (deps + Node)
+   |
+   +--> Task 2 (topics scopes) --> Task 3 (diagnostic) --+
+   |                                                      |
+   +--> Task 4 (endpoints supprimes) --------------------+--> Task 6 (bout en bout) --> Task 7 (docs)
+   |                                                      |
+   +--> Task 5 (corps REST) -----------------------------+
+```
+
+Les tâches 2, 4 et 5 sont indépendantes entre elles et peuvent se mener en parallèle après la tâche 1. La tâche 3 s'appuie sur la 2. La tâche 6 exige que 2, 3, 4 et 5 soient faites.
+
+---
+
+## Ce que ce plan ne fait PAS
+
+Trois points figurent dans les constats sans tâche associée, faute d'être vérifiés — les traiter demanderait une décision ou un accès que ce plan n'a pas :
+
+1. **Fermer l'issue #33 pour de bon.** La tâche 6 la vérifie en local. Le verdict sur le coordinator *déployé* exige de re-sonder la prod : token valide et accord de l'opérateur.
+2. **Adopter l'acquittement de lot drainé (#430).** Il faut d'abord établir comment l'acquittement s'exprime dans l'appel d'outil MCP, et si cela impose de toucher le catalogue BCE.
+3. **Retirer `check-interrupt` des 24 presets qui le portent encore.** Ce behavior est marqué déprécié, mais il porte aujourd'hui la coordination quand le push est en panne. Ne rien y toucher tant que la tâche 6 n'est pas verte.
+4. **Faire ré-émettre les tokens.** La v1.0.0 du coordinator exige un claim `typ` (`"access"` / `"refresh"`) et rejette tout JWT émis avant. Aucun code essaim n'est en cause : c'est une action d'ops sur le déploiement, et tout porteur d'un ancien `COORDINATOR_TOKEN` devra se ré-authentifier. La tâche 6 n'y est pas exposée — un coordinator lancé en local part d'une base neuve et mint un token conforme.

--- a/docs/superpowers/plans/2026-08-24-coordinator-2.2.1-migration.md
+++ b/docs/superpowers/plans/2026-08-24-coordinator-2.2.1-migration.md
@@ -707,9 +707,12 @@ ce préfixe — joker compris. Voir `orgFromToken` dans `src/agent-loop/mqtt-lis
 
 - [ ] **Step 4: Vérifier que le garde-fou CI reste vert**
 
+Le terme est **lu depuis le workflow**, jamais réécrit ici : l'épeler dans un fichier suivi ferait échouer le garde-fou sur ce document même — piège dans lequel la première rédaction de ce plan est tombée.
+
 ```bash
 git add -A
-git grep -In -i 'mekova' -- . ':!.github/workflows/test.yml' && echo "ECHEC - terme reintroduit" || echo "OK"
+TERME=$(grep -oE "git grep -In -i '[a-z]+'" .github/workflows/test.yml | grep -oE "'[a-z]+'" | tr -d "'")
+git grep -In -i "$TERME" -- . ':!.github/workflows/test.yml' && echo "ECHEC - terme reintroduit" || echo "OK"
 ```
 
 Attendu : `OK`.

--- a/docs/superpowers/specs/2026-08-24-coordinator-2.2.1-migration-findings.md
+++ b/docs/superpowers/specs/2026-08-24-coordinator-2.2.1-migration-findings.md
@@ -1,0 +1,241 @@
+# essaim ↔ mcp-coordinator 2.2.1 — Constats de migration
+
+**Date:** 2026-08-24
+**Portée:** ce qu'il faut changer dans essaim pour fonctionner contre `mcp-coordinator@2.2.1`.
+**Méthode:** chaque affirmation ci-dessous a été lue dans le code, des deux côtés. Rien n'est déduit d'un
+message de commit seul. Les points non vérifiés sont marqués **NON VÉRIFIÉ** et n'ont pas de tâche associée.
+
+Sources : `C:\Users\gagno\projet\essaim-new` (essaim, HEAD `57c37d4`) et
+`C:\Users\gagno\projet\mcp-coordinator-new` (coordinator `main`, v2.2.1, HEAD `42ac8d0`).
+
+---
+
+## 0. Le point de départ
+
+| | |
+|---|---|
+| essaim épingle | `"mcp-coordinator": "^0.13.0"` (`package.json`) |
+| essaim a installé | `0.13.0` (`node_modules/mcp-coordinator/package.json`) |
+| Source du coordinator | `2.2.1` |
+
+Le caret sur une version `0.x` ne remonte pas au-delà de `0.x` : `^0.13.0` ne résoudra jamais `1.x` ni `2.x`.
+La dépendance est donc figée deux majeures en arrière et `npm update` ne la bougera pas.
+
+---
+
+## 1. RUPTURE — Les topics MQTT sont scopés par organisation
+
+**C'est la rupture qui compte.** Sans elle corrigée, essaim se connecte, s'abonne à rien, et ne reçoit
+plus aucune notification push — sans erreur visible.
+
+### Ce que publie le coordinator 2.2.1
+
+`src/mqtt-bridge.ts:298` et `:321` publient sur `coordinator/${orgId}/consultations/new`. Le segment `orgId`
+est présent sur **toutes** les formes :
+
+```
+coordinator/${orgId}/consultations/new
+coordinator/${orgId}/consultations/${threadId}/messages
+coordinator/${orgId}/consultations/${threadId}/status
+coordinator/${orgId}/consultations/${threadId}/claimed
+coordinator/${orgId}/consultations/${threadId}/completed
+coordinator/${orgId}/broadcast
+coordinator/${orgId}/agents/${agentId}/status
+```
+
+Il n'existe **aucune publication non scopée** en 2.2.1. La seule occurrence de la chaîne
+`coordinator/consultations/new` dans `src/` est un **commentaire** (`src/server-setup.ts:171`) ; l'appel réel
+juste en dessous passe `event.org_id` et publie la forme scopée. Les autres occurrences sont dans
+`docs/index.html` et ses sauvegardes.
+
+### Ce à quoi essaim s'abonne
+
+`src/agent-loop/mqtt-listener.ts:108-116`, constante `TOPICS` — les sept formes **sans** segment org :
+
+```
+coordinator/consultations/new
+coordinator/consultations/+/messages
+coordinator/consultations/+/status
+coordinator/consultations/+/claimed
+coordinator/consultations/+/completed
+coordinator/broadcast
+coordinator/agents/+/status
+```
+
+### Pourquoi un joker ne sauve pas la mise
+
+`src/mqtt-broker.ts:205-218`, `createAedesAuthorizeSubscribeHook` :
+
+```js
+const org = c.org;
+if (!org) return cb(new Error("MQTT client missing org"), null);
+const prefix = `coordinator/${org}/`;
+if (!sub.topic.startsWith(prefix)) {
+  logger.warn({ client_id: c.id, org, topic: sub.topic }, "MQTT subscribe denied (cross-org)");
+  return cb(null, null);
+}
+```
+
+Le test est un `startsWith` sur `coordinator/<org>/`. Un abonnement `coordinator/+/consultations/new` ne
+commence pas par ce préfixe : **refusé**. Les sept topics actuels d'essaim : **refusés**.
+
+Le refus est `cb(null, null)` — l'abonnement est rejeté, pas la connexion. Côté serveur il y a un `warn` ;
+côté client, un code d'échec dans le SUBACK. essaim se connecte normalement et n'entend plus rien.
+
+### D'où vient l'org
+
+`src/mqtt-broker.ts:170` attache l'org au client Aedes depuis le résultat de `authenticate()`, qui vérifie
+le token transmis dans le champ `password` du CONNECT — exactement ce qu'envoie essaim
+(`src/agent-loop/mqtt-listener.ts:344`).
+
+Côté claims, `src/auth.ts:126`, `:161`, `:227` lisent tous :
+
+```js
+typeof payload.org === "string" ? payload.org : "default"
+```
+
+**L'org est donc déjà dans le `COORDINATOR_TOKEN` d'essaim.** essaim ne le lit simplement jamais : `grep`
+sur `org_id|orgId|org` dans `src/agent-loop/mqtt-listener.ts` et `src/coordinator-auth.ts` ne renvoie
+**rien**.
+
+### Effet de bord : les index de parsing se décalent
+
+`classifyTopic` (`mqtt-listener.ts:118-141`) et `buildInterrupt` (`:144-178`) indexent en dur sur la forme
+non scopée — `parts[1]` pour le genre, `parts[2]` pour l'identifiant, `parts[3]` pour la feuille. Avec le
+segment org, tout se décale de un. Les deux fonctions doivent suivre, sinon les messages qui arrivent sont
+mal classés.
+
+---
+
+## 2. RUPTURE — Deux endpoints ont disparu
+
+Vérifié dans les deux sens :
+
+| Endpoint | 0.13.0 (installé) | 2.2.1 (source) |
+|---|---|---|
+| `/api/run-config` | présent (`node_modules/mcp-coordinator/dist/src/http/handle-rest.js`) | **absent** — zéro occurrence dans `src/` |
+| `/api/token-usage` | présent (idem) | **absent** — zéro occurrence dans `src/` |
+
+Ce sont de vraies suppressions, pas des endpoints qui n'auraient jamais existé.
+
+Appelés par essaim :
+
+- `/api/run-config` — `src/orchestrator/orchestrator.ts:232`, pousse l'en-tête de run vers le dashboard.
+- `/api/token-usage` — `src/agent-loop/agent-loop.ts:457`, pousse la télémétrie par tour.
+
+**Les deux dégradent en silence.** `postJson` (`orchestrator.ts:49-63`) attrape tout, journalise un `warn`
+et rend `false` ; `postTokenUsageSse` (`agent-loop.ts:456`) est enveloppé dans un `try/catch`. Un run
+continue. On perd l'en-tête de run et la télémétrie de tokens, rien d'autre.
+
+Les routes REST réellement servies en 2.2.1 (`src/http/handle-rest.ts`) :
+
+```
+/api/announce /api/approve-resolution /api/check-conflict /api/check-interrupt /api/claim-task
+/api/hot-files /api/introspection-response /api/log-file /api/pending-introspections
+/api/post-to-thread /api/propose-resolution /api/quota /api/register /api/reset
+/api/scoring-stats /api/session-start /api/session-stop /api/status /api/threads-active
+/api/unclaim-task
+```
+
+Plus `POST /api/working-files/start` et `POST /api/working-files/stop` (`handle-rest.ts:106-107`), qui
+gatent aussi sur la méthode — ce sont **les chemins exacts** qu'appellent `scripts/pre_track_activity.sh:83`
+et `scripts/track_activity.sh:146`. Rien à changer là.
+
+---
+
+## 3. RUPTURE — Plancher Node
+
+| | |
+|---|---|
+| coordinator 2.2.1 | `engines: {"node": ">=22"}` |
+| essaim | `engines: {"node": ">=20"}` |
+
+Motif déclaré dans le CHANGELOG du coordinator (v2.0.0) : `better-sqlite3@13` exige Node ≥ 22, et Node 20
+est en fin de vie depuis le 2026-04-30.
+
+La CI d'essaim tourne déjà en Node 24 (`.github/workflows/test.yml`) — seule la déclaration est périmée,
+mais elle laisse un utilisateur en Node 20 installer un ensemble qui ne peut pas fonctionner.
+
+---
+
+## 4. Ruptures d'ops, sans changement de code essaim
+
+Depuis le CHANGELOG du coordinator, sections `⚠ BREAKING CHANGES` :
+
+- **v1.0.0** — les JWT exigent désormais un claim `typ` (`"access"` / `"refresh"`). Les tokens émis avant
+  cette version sont rejetés : tout le monde se ré-authentifie après montée.
+- **v1.0.0** — les corps REST sont validés par zod, avec un 400 structuré en retour. Un champ qui dévie ne
+  passe plus en silence.
+
+**NON VÉRIFIÉ :** je n'ai pas comparé les schémas zod de 2.2.1 aux corps que construit essaim
+(`/api/announce`, `/api/register`, `/api/claim-task`…). C'est l'objet d'une tâche de vérification, pas d'une
+affirmation.
+
+---
+
+## 5. Ce qui ne casse PAS — vérifié
+
+Trois inquiétudes levées, chacune dans le code :
+
+- **Le contrôle d'origine sur l'upgrade WS** (commit `a7583c8`, #436) ne verrouille pas essaim.
+  `src/mqtt-broker.ts:393` utilise `isAllowedOrigin`, et le message de commit énonce la raison du choix :
+  le helper renvoie **vrai pour un header `Origin` absent**, parce que c'est le modèle same-origin du
+  navigateur qu'il défend. Il cite « mqtt.js in Node » comme client concerné — c'est celui d'essaim.
+
+- **Les scopes de service token** (#426) sont **fail-open** pour tout ce qui n'est pas un service token.
+  `src/tools/tool-scopes.ts:31-36` : « Phase 1 agent tokens, Phase 2 cookie sessions and stdio's synthetic
+  claims carry none, and must keep working exactly as before […] `undefined` therefore means unrestricted ».
+  Les tokens d'essaim sont des tokens agent Phase 1. Aucun changement requis.
+
+- **`#424` ne concerne pas `/api/claim-task`.** Le commit porte sur les claims de session MCP
+  (`getSessionClaims`) et sur le message d'erreur qui distingue « aucun id de session » de « id inconnu de
+  ce process ». Aucun rapport avec le work-stealing REST d'essaim. *(J'avais avancé le contraire avant
+  vérification ; c'était faux.)*
+
+---
+
+## 6. L'issue #33 devrait tomber avec la montée
+
+`src/mqtt-broker.ts:381-395` porte un vrai handler d'upgrade `/mqtt` en 2.2.1.
+
+Le sondage du coordinator déployé (2026-07-20, consigné en mémoire projet) avait établi que la v0.13.0
+**404** cet upgrade même avec un Bearer valide — c'est la cause racine de l'issue #33 d'essaim, dont le
+texte décrit une boucle `disconnected` pendant tout un run derrière un ingress.
+
+Le volet backoff de #33 est déjà livré côté essaim (`mqtt-listener.ts:185-186` :
+`RECONNECT_PERIOD_MS = 5_000`, `MAX_RECONNECT_ATTEMPTS = 5`, puis `giveUp`).
+
+**NON VÉRIFIÉ :** l'état actuel du coordinator *déployé*. La note de mémoire a un mois. Fermer #33 demande
+de re-sonder la prod, ce qui exige un token valide et l'accord de l'opérateur.
+
+---
+
+## 7. Le trou de diagnostic qui a laissé #33 survivre
+
+`mqtt-listener.ts:393-396` :
+
+```js
+client.on("close", () => {
+  isConnected = false;
+  log.debug("disconnected");
+});
+```
+
+Message nu, au niveau `debug`, donc invisible au niveau de log par défaut. Il n'existe **aucun**
+`client.on("error")` dans le fichier — les erreurs d'upgrade sont avalées.
+
+Avec la rupture §1, ce trou devient franchement dangereux : un abonnement refusé pour cause d'org est
+silencieux des deux côtés du point de vue d'essaim. Le même run se terminerait « normalement », sans
+coordination, sans un mot.
+
+---
+
+## 8. Piste, non chiffrée
+
+`#430` rend acquittable un lot drainé (`getQueuedMessages`), en opt-in, l'ancien contrat restant valide.
+essaim expose `wait_for_message` et `get_queued_messages` aux agents
+(`src/orchestrator/agent-launcher.ts:33-34`, `:120-121`), mais ce sont les agents qui les appellent via le
+LLM — pas du code essaim.
+
+**NON VÉRIFIÉ :** comment l'acquittement s'exprime dans l'appel d'outil, et donc s'il faut toucher au
+catalogue BCE. À instruire avant toute tâche.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@swoofer/promptweave": "^0.4.0",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
-    "mcp-coordinator": "^0.13.0",
+    "mcp-coordinator": "^2.2.1",
     "mqtt": "^5.15.0",
     "pino": "^10.3.1",
     "ws": "^8.20.0",
@@ -81,7 +81,7 @@
     "vitest": "^4.1.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "overrides": {
     "ip-address": "^10.4.0"

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -452,29 +452,10 @@ export async function runAgentLoop(
     return String(n);
   }
 
-  async function postTokenUsageSse(detail: TurnDetail): Promise<void> {
-    try {
-      await fetch(`${config.coordinatorUrl}/api/token-usage`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders() },
-        body: JSON.stringify({
-          agent_id: config.agentId,
-          agent_name: config.agentName,
-          turn: detail.turn,
-          phase: detail.phase,
-          model: detail.model,
-          cost_usd: detail.costUsd,
-          duration_ms: detail.durationMs,
-          input_tokens: detail.inputTokens,
-          output_tokens: detail.outputTokens,
-          cache_read_tokens: detail.cacheReadTokens,
-          cache_creation_tokens: detail.cacheCreationTokens,
-        }),
-      });
-    } catch {
-      // Never block on telemetry — coordinator might be down
-    }
-  }
+  // La télémétrie par tour partait vers /api/token-usage, route supprimée dans le
+  // coordinator 2.x. Le try/catch avalait déjà l'échec ; on ne garde pas un appel
+  // dont on sait qu'il ne peut plus aboutir. Le compteur local et le rapport
+  // reports/YYYY-MM-DD-<run-id>.md sont indépendants et restent en place.
 
   async function send(content: string, opts?: SendOptions): Promise<AssistantResponse> {
     logger.info(`Sending to claude (${content.length} chars): ${content.slice(0, 80)}...`);
@@ -523,9 +504,6 @@ export async function runAgentLoop(
       `hit=${cacheHitPct}% cost=$${resp.costUsd.toFixed(4)} ` +
       `(${resp.durationMs}ms, ${resp.toolCalls.length} tools)`,
     );
-
-    // Fire-and-forget telemetry to coordinator for live dashboard — never blocks
-    void postTokenUsageSse(detail);
 
     return resp;
   }

--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -105,43 +105,75 @@ export interface MqttListener {
   readonly connected: boolean;
 }
 
-const TOPICS = [
-  "coordinator/consultations/new",
-  "coordinator/consultations/+/messages",
-  "coordinator/consultations/+/status",
-  "coordinator/consultations/+/claimed",
-  "coordinator/consultations/+/completed",
-  "coordinator/broadcast",
-  "coordinator/agents/+/status",
-];
+/**
+ * Le segment org de chaque topic du coordinator (#330). Le coordinator le tire du
+ * claim `org` du token et refuse — SILENCIEUSEMENT, via `cb(null, null)` dans
+ * `authorizeSubscribe` — tout abonnement hors de `coordinator/<org>/`. Un joker
+ * `coordinator/+/...` est refusé aussi : le test est un `startsWith` sur le préfixe.
+ *
+ * On décode, on ne vérifie jamais : le serveur reste l'autorité, on n'a besoin que
+ * du préfixe de routage. Le repli sur "default" reproduit exactement celui du
+ * coordinator (src/auth.ts), sans quoi un token sans claim `org` s'abonnerait à un
+ * préfixe que le serveur n'emploie pas.
+ */
+export function orgFromToken(token: string | undefined): string {
+  if (!token) return "default";
+  const parts = token.split(".");
+  if (parts.length < 2) return "default";
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return typeof payload.org === "string" && payload.org ? payload.org : "default";
+  } catch {
+    return "default";
+  }
+}
 
-function classifyTopic(topic: string, payload: Record<string, unknown>): InterruptType | null {
+/** Les sept topics auxquels l'agent s'abonne, préfixés par son org. */
+export function topicsForOrg(org: string): string[] {
+  const p = `coordinator/${org}`;
+  return [
+    `${p}/consultations/new`,
+    `${p}/consultations/+/messages`,
+    `${p}/consultations/+/status`,
+    `${p}/consultations/+/claimed`,
+    `${p}/consultations/+/completed`,
+    `${p}/broadcast`,
+    `${p}/agents/+/status`,
+  ];
+}
+
+export function classifyTopic(
+  topic: string,
+  payload: Record<string, unknown>,
+): InterruptType | null {
   const parts = topic.split("/");
+  // coordinator/<org>/... : le genre est en [2], l'identifiant en [3], la feuille en [4].
+  if (parts[0] !== "coordinator" || parts.length < 3) return null;
 
-  if (parts[1] === "consultations") {
-    if (parts[2] === "new") return "consultation_new";
-    if (parts[3] === "messages") return "consultation_message";
-    if (parts[3] === "claimed") return "consultation_claimed";
-    if (parts[3] === "completed") return "consultation_completed";
-    if (parts[3] === "status") {
+  if (parts[2] === "consultations") {
+    if (parts[3] === "new") return "consultation_new";
+    if (parts[4] === "messages") return "consultation_message";
+    if (parts[4] === "claimed") return "consultation_claimed";
+    if (parts[4] === "completed") return "consultation_completed";
+    if (parts[4] === "status") {
       const status = payload.status as string | undefined;
       if (status === "resolved") return "consultation_resolved";
       return "consultation_resolving";
     }
   }
 
-  if (parts[1] === "agents" && parts[3] === "status") {
+  if (parts[2] === "agents" && parts[4] === "status") {
     const status = payload.status as string | undefined;
     if (status === "offline") return "agent_offline";
     return "agent_online";
   }
 
-  if (parts[1] === "broadcast") return "broadcast";
+  if (parts[2] === "broadcast") return "broadcast";
 
   return null;
 }
 
-function buildInterrupt(
+export function buildInterrupt(
   type: InterruptType,
   topic: string,
   payload: Record<string, unknown>,
@@ -153,9 +185,9 @@ function buildInterrupt(
     raw: payload,
   };
 
-  // Extract threadId from topic structure: coordinator/consultations/{id}/messages|status
-  if (parts[1] === "consultations" && parts.length >= 4 && parts[2] !== "new") {
-    interrupt.threadId = parts[2];
+  // Extrait le threadId : coordinator/<org>/consultations/{id}/messages|status|claimed|completed
+  if (parts[2] === "consultations" && parts.length >= 5 && parts[3] !== "new") {
+    interrupt.threadId = parts[3];
   }
 
   // Map common payload fields
@@ -169,9 +201,9 @@ function buildInterrupt(
   if (payload.status !== undefined) interrupt.status = payload.status as string;
   if (payload.summary !== undefined) interrupt.content = payload.summary as string;
 
-  // For agent status topics, extract agentId from topic
-  if (parts[1] === "agents" && parts[3] === "status") {
-    interrupt.agentId = parts[2];
+  // Topic de statut d'agent : coordinator/<org>/agents/{agentId}/status
+  if (parts[2] === "agents" && parts[4] === "status") {
+    interrupt.agentId = parts[3];
   }
 
   return interrupt;
@@ -358,12 +390,14 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
           isConnected = true;
           reconnectAttempts = 0; // a successful connect earns a fresh budget
           void catchUpOpenConsultations();
-          client!.subscribe(TOPICS, (err) => {
+          const org = orgFromToken(coordinatorToken());
+          const topics = topicsForOrg(org);
+          client!.subscribe(topics, (err) => {
             if (err) {
               reject(err);
               return;
             }
-            log.info("connected", { url });
+            log.info("connected", { url, org });
             resolve();
           });
         });

--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -128,6 +128,24 @@ export function orgFromToken(token: string | undefined): string {
   }
 }
 
+/**
+ * MQTT 3.1.1 §3.9.3 : le SUBACK rend un code par topic, et tout code >= 128 est
+ * un échec. Le coordinator refuse par `cb(null, null)` dans `authorizeSubscribe`,
+ * ce qui arrive ici sous cette forme — sans erreur de connexion. Un refus non
+ * signalé, c'est un run entier sans coordination et sans un mot (#33).
+ */
+export function grantedTopics(granted: Array<{ topic: string; qos: number }>): {
+  ok: string[];
+  refused: string[];
+} {
+  const ok: string[] = [];
+  const refused: string[] = [];
+  for (const g of granted) {
+    (g.qos >= 128 ? refused : ok).push(g.topic);
+  }
+  return { ok, refused };
+}
+
 /** Les sept topics auxquels l'agent s'abonne, préfixés par son org. */
 export function topicsForOrg(org: string): string[] {
   const p = `coordinator/${org}`;
@@ -392,12 +410,16 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
           void catchUpOpenConsultations();
           const org = orgFromToken(coordinatorToken());
           const topics = topicsForOrg(org);
-          client!.subscribe(topics, (err) => {
+          client!.subscribe(topics, (err, granted) => {
             if (err) {
               reject(err);
               return;
             }
-            log.info("connected", { url, org });
+            const { ok, refused } = grantedTopics(granted ?? []);
+            if (refused.length > 0) {
+              log.warn("subscriptions refused by the coordinator", { org, refused });
+            }
+            log.info("connected", { url, org, subscribed: ok.length });
             resolve();
           });
         });
@@ -427,6 +449,12 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
         client.on("close", () => {
           isConnected = false;
           log.debug("disconnected");
+        });
+
+        // Sans ceci, une erreur d'upgrade WS ou d'authentification est purement
+        // avalée : `close` ne porte aucune cause, et son niveau debug la masque.
+        client.on("error", (err: Error) => {
+          log.warn("mqtt error", { url, message: err.message });
         });
 
         client.on("reconnect", () => {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -228,17 +228,9 @@ async function _runProjectBody(
     }
   }
 
-  // 1b. Push run config to dashboard
-  await postJson(`${effectiveCoordinatorUrl}/api/run-config`, {
-    name: project.name,
-    description: project.description,
-    phase: project.phase,
-    agents: project.agents.map(a => ({ name: a.name, profile: a.profile, role: a.role })),
-    workspace: project.workspace,
-    stagger: project.stagger,
-    timeout_minutes: project.timeout_minutes,
-    compare_mode: project.compare_mode,
-  });
+  // 1b. L'en-tête de run partait vers /api/run-config, route supprimée dans le
+  // coordinator 2.x. postJson avalait déjà l'échec ; on ne garde pas un appel
+  // dont on sait qu'il ne peut plus aboutir.
 
   // 2. Create workspaces (resetBase FIRST, then setup, then worktrees)
   const basePath = project.workspace.base || DEFAULT_BASE;

--- a/tests/unit/mqtt-diagnostics.test.ts
+++ b/tests/unit/mqtt-diagnostics.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { grantedTopics } from "../../src/agent-loop/mqtt-listener.js";
+
+describe("grantedTopics", () => {
+  it("separe les abonnements accordes des refuses", () => {
+    const r = grantedTopics([
+      { topic: "coordinator/acme/broadcast", qos: 0 },
+      { topic: "coordinator/acme/consultations/new", qos: 1 },
+      { topic: "coordinator/autre/broadcast", qos: 128 },
+    ]);
+    expect(r.ok).toEqual(["coordinator/acme/broadcast", "coordinator/acme/consultations/new"]);
+    expect(r.refused).toEqual(["coordinator/autre/broadcast"]);
+  });
+
+  it("traite tout QoS >= 128 comme un refus", () => {
+    const r = grantedTopics([{ topic: "t", qos: 135 }]);
+    expect(r.refused).toEqual(["t"]);
+    expect(r.ok).toEqual([]);
+  });
+
+  it("rend deux listes vides sur une entree vide", () => {
+    expect(grantedTopics([])).toEqual({ ok: [], refused: [] });
+  });
+});

--- a/tests/unit/mqtt-listener.test.ts
+++ b/tests/unit/mqtt-listener.test.ts
@@ -50,7 +50,7 @@ describe("MqttListener", () => {
   describe("topic classification", () => {
     it("classifies consultation_new", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/new", {
+      simulateMessage("coordinator/default/consultations/new", {
         thread_id: "t-1",
         subject: "Auth redesign",
         target_modules: ["auth"],
@@ -65,7 +65,7 @@ describe("MqttListener", () => {
 
     it("classifies consultation_message", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/t-42/messages", {
+      simulateMessage("coordinator/default/consultations/t-42/messages", {
         agent_id: "agent-2",
         type: "opinion",
         content: "I agree",
@@ -80,7 +80,7 @@ describe("MqttListener", () => {
 
     it("classifies consultation_resolving", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/t-42/status", {
+      simulateMessage("coordinator/default/consultations/t-42/status", {
         status: "resolving",
         summary: "Proposed consensus",
       });
@@ -92,7 +92,7 @@ describe("MqttListener", () => {
 
     it("classifies consultation_resolved", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/t-42/status", {
+      simulateMessage("coordinator/default/consultations/t-42/status", {
         status: "resolved",
         summary: "Final decision",
       });
@@ -104,7 +104,7 @@ describe("MqttListener", () => {
 
     it("classifies consultation_claimed", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/t-42/claimed", {
+      simulateMessage("coordinator/default/consultations/t-42/claimed", {
         agent_id: "agent-2",
         status: "claimed",
       });
@@ -117,7 +117,7 @@ describe("MqttListener", () => {
 
     it("classifies consultation_completed", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/t-42/completed", {
+      simulateMessage("coordinator/default/consultations/t-42/completed", {
         agent_id: "agent-2",
         status: "completed",
         summary: "Task finished successfully",
@@ -132,7 +132,7 @@ describe("MqttListener", () => {
 
     it("classifies agent_online", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/agents/agent-2/status", {
+      simulateMessage("coordinator/default/agents/agent-2/status", {
         status: "online",
         name: "Backend Agent",
       });
@@ -145,7 +145,7 @@ describe("MqttListener", () => {
 
     it("classifies agent_offline", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/agents/agent-2/status", {
+      simulateMessage("coordinator/default/agents/agent-2/status", {
         status: "offline",
       });
       const msgs = listener.drain();
@@ -156,7 +156,7 @@ describe("MqttListener", () => {
 
     it("classifies broadcast", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/broadcast", {
+      simulateMessage("coordinator/default/broadcast", {
         agent_id: "agent-2",
         message: "Deploying in 5 min",
       });
@@ -170,7 +170,7 @@ describe("MqttListener", () => {
   describe("self-message filtering", () => {
     it("filters messages from own agent_id", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/new", {
+      simulateMessage("coordinator/default/consultations/new", {
         agent_id: "agent-1", // same as OPTIONS.agentId
         thread_id: "t-self",
         subject: "My own consultation",
@@ -182,7 +182,7 @@ describe("MqttListener", () => {
 
     it("accepts messages from other agents", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/consultations/new", {
+      simulateMessage("coordinator/default/consultations/new", {
         agent_id: "agent-2",
         thread_id: "t-other",
         subject: "Other consultation",
@@ -195,9 +195,9 @@ describe("MqttListener", () => {
   describe("drain and peek", () => {
     it("drain empties the queue and returns all messages", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/broadcast", { agent_id: "a2", message: "msg1" });
-      simulateMessage("coordinator/broadcast", { agent_id: "a3", message: "msg2" });
-      simulateMessage("coordinator/broadcast", { agent_id: "a4", message: "msg3" });
+      simulateMessage("coordinator/default/broadcast", { agent_id: "a2", message: "msg1" });
+      simulateMessage("coordinator/default/broadcast", { agent_id: "a3", message: "msg2" });
+      simulateMessage("coordinator/default/broadcast", { agent_id: "a4", message: "msg3" });
 
       expect(listener.peek()).toBe(3);
       const msgs = listener.drain();
@@ -208,8 +208,8 @@ describe("MqttListener", () => {
 
     it("peek returns correct count without consuming", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/broadcast", { agent_id: "a2", message: "msg1" });
-      simulateMessage("coordinator/broadcast", { agent_id: "a3", message: "msg2" });
+      simulateMessage("coordinator/default/broadcast", { agent_id: "a2", message: "msg1" });
+      simulateMessage("coordinator/default/broadcast", { agent_id: "a3", message: "msg2" });
 
       expect(listener.peek()).toBe(2);
       expect(listener.peek()).toBe(2); // still 2 — not consumed
@@ -243,13 +243,13 @@ describe("MqttListener", () => {
   describe("malformed messages", () => {
     it("ignores non-JSON payloads", async () => {
       const listener = await connectListener();
-      mockClient.emit("message", "coordinator/broadcast", Buffer.from("not json"));
+      mockClient.emit("message", "coordinator/default/broadcast", Buffer.from("not json"));
       expect(listener.peek()).toBe(0);
     });
 
     it("ignores unrecognized topics", async () => {
       const listener = await connectListener();
-      simulateMessage("coordinator/unknown/something", { agent_id: "a2" });
+      simulateMessage("coordinator/default/unknown/something", { agent_id: "a2" });
       expect(listener.peek()).toBe(0);
     });
   });
@@ -289,7 +289,7 @@ describe("MqttListener", () => {
         target_modules: ["auth"],
         extra_field: 42,
       };
-      simulateMessage("coordinator/consultations/new", payload);
+      simulateMessage("coordinator/default/consultations/new", payload);
       const msgs = listener.drain();
       expect(msgs[0].raw).toEqual(payload);
     });
@@ -412,7 +412,7 @@ describe("MqttListener", () => {
       await connectPromise;
 
       // The live message arrives (and is queued) before the catch-up fetch resolves.
-      simulateMessage("coordinator/consultations/new", {
+      simulateMessage("coordinator/default/consultations/new", {
         agent_id: "agent-2",
         thread_id: "t-1",
         subject: "Auth redesign",

--- a/tests/unit/mqtt-org-scoping.test.ts
+++ b/tests/unit/mqtt-org-scoping.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  orgFromToken,
+  topicsForOrg,
+  classifyTopic,
+  buildInterrupt,
+} from "../../src/agent-loop/mqtt-listener.js";
+
+/** Fabrique un JWT non signé : seule la charge utile compte, on ne vérifie jamais. */
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+describe("orgFromToken", () => {
+  it("lit le claim org", () => {
+    expect(orgFromToken(jwt({ org: "acme", sub: "agent-1" }))).toBe("acme");
+  });
+
+  it("retombe sur 'default' quand le claim manque, comme le coordinator", () => {
+    expect(orgFromToken(jwt({ sub: "agent-1" }))).toBe("default");
+  });
+
+  it("retombe sur 'default' sans token", () => {
+    expect(orgFromToken(undefined)).toBe("default");
+  });
+
+  it("retombe sur 'default' sur un token illisible plutot que de jeter", () => {
+    expect(orgFromToken("pas-un-jwt")).toBe("default");
+    expect(orgFromToken("a.!!!.c")).toBe("default");
+  });
+});
+
+describe("topicsForOrg", () => {
+  it("prefixe les sept topics par coordinator/<org>/", () => {
+    expect(topicsForOrg("acme")).toEqual([
+      "coordinator/acme/consultations/new",
+      "coordinator/acme/consultations/+/messages",
+      "coordinator/acme/consultations/+/status",
+      "coordinator/acme/consultations/+/claimed",
+      "coordinator/acme/consultations/+/completed",
+      "coordinator/acme/broadcast",
+      "coordinator/acme/agents/+/status",
+    ]);
+  });
+
+  it("chaque topic commence par le prefixe que l'ACL du coordinator exige", () => {
+    for (const t of topicsForOrg("acme")) {
+      expect(t.startsWith("coordinator/acme/")).toBe(true);
+    }
+  });
+});
+
+describe("classifyTopic sur la forme scopee", () => {
+  it("classe une nouvelle consultation", () => {
+    expect(classifyTopic("coordinator/acme/consultations/new", {})).toBe("consultation_new");
+  });
+
+  it("classe un message de thread", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/messages", {})).toBe(
+      "consultation_message",
+    );
+  });
+
+  it("distingue resolved de resolving sur le topic status", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/status", { status: "resolved" })).toBe(
+      "consultation_resolved",
+    );
+    expect(classifyTopic("coordinator/acme/consultations/t1/status", { status: "proposed" })).toBe(
+      "consultation_resolving",
+    );
+  });
+
+  it("classe claimed et completed", () => {
+    expect(classifyTopic("coordinator/acme/consultations/t1/claimed", {})).toBe(
+      "consultation_claimed",
+    );
+    expect(classifyTopic("coordinator/acme/consultations/t1/completed", {})).toBe(
+      "consultation_completed",
+    );
+  });
+
+  it("classe le statut d'agent", () => {
+    expect(classifyTopic("coordinator/acme/agents/a1/status", { status: "offline" })).toBe(
+      "agent_offline",
+    );
+    expect(classifyTopic("coordinator/acme/agents/a1/status", { status: "online" })).toBe(
+      "agent_online",
+    );
+  });
+
+  it("classe le broadcast", () => {
+    expect(classifyTopic("coordinator/acme/broadcast", {})).toBe("broadcast");
+  });
+
+  it("ignore l'ancienne forme non scopee, que le coordinator ne publie plus", () => {
+    expect(classifyTopic("coordinator/consultations/new", {})).toBeNull();
+  });
+});
+
+describe("buildInterrupt sur la forme scopee", () => {
+  it("extrait le threadId du topic", () => {
+    const i = buildInterrupt(
+      "consultation_message",
+      "coordinator/acme/consultations/t42/messages",
+      {},
+    );
+    expect(i.threadId).toBe("t42");
+  });
+
+  it("laisse la charge utile primer sur le topic", () => {
+    const i = buildInterrupt(
+      "consultation_message",
+      "coordinator/acme/consultations/t42/messages",
+      { thread_id: "t99" },
+    );
+    expect(i.threadId).toBe("t99");
+  });
+
+  it("extrait l'agentId d'un topic de statut", () => {
+    const i = buildInterrupt("agent_offline", "coordinator/acme/agents/a7/status", {});
+    expect(i.agentId).toBe("a7");
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -56,10 +56,12 @@ describe("Types", () => {
       introspection_completed: true,
       agent_activity: true,
       task_claimed: true,
-      token_usage: true,
+      // token_usage a disparu de EventType dans le coordinator 2.x, en même temps
+      // que la route /api/token-usage. Le `satisfies` ci-dessous est ce qui l'a
+      // signalé : une clé de trop y est une erreur de compilation, pas un test rouge.
       quota_update: true,
     } as const satisfies Record<CoordinatorEvent["type"], true>;
-    expect(Object.keys(keys)).toHaveLength(16);
+    expect(Object.keys(keys)).toHaveLength(15);
   });
 
   it("ConflictReport types are exhaustive", () => {


### PR DESCRIPTION
Les topics MQTT sont **scopés par organisation** depuis le coordinator 2.x. essaim s'abonnait aux sept formes non scopées, et l'ACL du broker (`authorizeSubscribe`) refuse par un `cb(null, null)` tout topic qui ne commence pas par `coordinator/<org>/` — joker `coordinator/+/...` compris, puisque le test est un `startsWith`.

Contre un coordinator 2.x, essaim se serait connecté, n'aurait rien souscrit, et n'aurait plus rien reçu. **Sans erreur** : le refus arrive dans le SUBACK, pas comme une erreur de connexion.

L'org était déjà là, dans le claim `org` du `COORDINATOR_TOKEN` qu'essaim envoie en mot de passe MQTT. Il ne le lisait simplement jamais.

## Contenu

| Commit | Contenu |
|---|---|
| `d325f1a` | Constats sourcés + plan d'implémentation en 7 tâches |
| `2160639` | Topics scopés par org — `orgFromToken`, `topicsForOrg`, index de parsing décalés (16 tests) |
| `308856c` | Un abonnement refusé et une erreur MQTT deviennent visibles — `grantedTopics` (3 tests) |
| `3c05a81` | Retrait de `/api/run-config` et `/api/token-usage`, supprimés en 2.x |
| `cc90799` | Plancher Node 22, doc des topics scopés |
| `4cf5d6d` | `token_usage` a quitté `EventType` avec sa route |

Le code et la montée de dépendance sont **inséparables** : vérifié, le `dist` de 0.13.0 publie `coordinator/consultations/new` non scopé. Merger l'un sans l'autre introduirait la panne silencieuse que cette PR corrige.

## Trois hypothèses invalidées par lecture du code

- Le contrôle d'origine sur l'upgrade WS (#436) **ne bloque pas** essaim : `isAllowedOrigin` renvoie vrai pour un `Origin` absent, et le commit cite « mqtt.js in Node » comme cas visé.
- Les scopes de service token (#426) sont **fail-open** pour les tokens agent Phase 1 — zéro changement requis.
- `#424` **ne concerne pas** `/api/claim-task` mais les claims de session MCP.

La tâche 5 du plan (corps REST contre schémas zod) n'a relevé **aucun écart** : `.strict()` n'apparaît nulle part, tous les champs requis sont émis, l'enum `type` de `post-to-thread` est respecté.

## Correction : le blocage annoncé n'existait pas

La première version de cette description affirmait un défaut d'empaquetage bloquant dans `mcp-coordinator@2.2.1`, autour des pairs `tree-sitter`. **C'était faux, et la CI de cette PR l'a démenti.**

Le conflit de plages est réel — `tree-sitter-cpp@0.23.4` exige `tree-sitter@^0.21.1` quand `tree-sitter-c@0.24.1` exige `^0.22.4`, plages disjointes — mais ces pairs sont `peerOptional`. npm émet des `warn ERESOLVE` et poursuit ; l'install passe en moins d'une minute sur la CI.

Ce qui boucle jusqu'à épuiser la heap V8, c'est **npm sous Windows sur ma machine**. Un environnement, pas un paquet. Le diagnostic avait été tiré d'un seul poste.

L'échec réel de la première CI était ailleurs : `tsc` refusait `tests/unit/types.test.ts`, invisible en local puisque `node_modules` y était resté en 0.13.0. Corrigé en `4cf5d6d`.

## Reste à faire

La tâche 6 du plan — vérification de bout en bout contre un coordinator 2.2.1 local, et verdict sur #33 — n'a pas été menée : elle exige un `npm install` qui aboutisse, ce que ma machine ne permet pas. Elle est faisable sur tout poste où l'install passe, et le plan en donne les étapes exactes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
