### PR TITLE
fix(work-stealing): rend les abandons diagnosticables et moins mécaniques

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -127,8 +127,22 @@ const APPROVAL_WAIT_MS = 20_000;
 // maxTurns cap before exiting non-zero (#31).
 const DONE_PATTERN = /\bDONE\b[ \t  ]*[*_`]*[ \t  ]*:/i;
 
+/**
+ * Même tolérance typographique, mais ANCRÉ en début de ligne — et testé sur la
+ * seule FIN du contenu.
+ *
+ * `content` concatène le texte de tous les tours internes du CLI. Sans ancrage
+ * ni fenêtre, un agent qui écrit « je terminerai par DONE: ... » dans un tour
+ * intermédiaire — comportement que `extractDoneSummary` documente juste en
+ * dessous comme courant — résout le thread avant d'avoir travaillé. C'est
+ * précisément ce que la règle « pas de marqueur = jamais complete » devait
+ * empêcher.
+ */
+const DONE_LINE_PATTERN = new RegExp("^[ \t*_`]*" + DONE_PATTERN.source, "im");
+const DONE_TAIL_CHARS = 500;
+
 export function hasDoneMarker(content: string): boolean {
-  return DONE_PATTERN.test(content);
+  return DONE_LINE_PATTERN.test(content.slice(-DONE_TAIL_CHARS));
 }
 
 /**
@@ -337,6 +351,9 @@ export async function runAgentLoop(
   const startTime = Date.now();
   let totalCost = 0;
   let turnsCount = 0;
+  // Durée du dernier envoi. Sert d'estimation du coût en temps d'une tâche
+  // avant d'en réclamer une nouvelle (voir la boucle de work-stealing).
+  let lastSendMs = 0;
   let mqttMessagesProcessed = 0;
   let exitReason: ExitReason = "done";
   let summary = "";
@@ -495,6 +512,7 @@ export async function runAgentLoop(
       toolCallCount: resp.toolCalls.length,
       contentLength: resp.content.length,
     };
+    lastSendMs = resp.durationMs;
     turnDetails.push(detail);
 
     logger.info(
@@ -891,6 +909,24 @@ export async function runAgentLoop(
                 break;
               }
 
+              // Ne pas réclamer ce qu'on n'a pas le temps de finir. Le budget
+              // contraignant est l'horloge, pas maxTurns : mesuré, 7 à 17 envois
+              // pour un plafond de 50. Un SIGKILL du timeout en plein envoi
+              // laisse la tâche réclamée ; le balayage la désréclame, et cette
+              // désréclamation compte vers l'empoisonnement du thread au même
+              // titre qu'un abandon de qualité. 1,5 × la durée du dernier envoi
+              // est la marge la moins arbitraire dont on dispose.
+              if (lastSendMs > 0) {
+                const need = lastSendMs * 1.5;
+                const left = remainingBudgetMs();
+                if (left < need) {
+                  logger.info(
+                    `Work-stealing: pas de nouvelle réclamation — ${Math.round(left / 1000)}s restantes < ${Math.round(need / 1000)}s estimées`,
+                  );
+                  break;
+                }
+              }
+
               // Claim next task
               logger.debug(`Work-stealing: attempting claim (turn ${turnsCount}/${maxTurns}, done=${tasksDone})`);
               const task = await claimNextTask(config.coordinatorUrl, config.agentId);
@@ -1011,7 +1047,7 @@ export async function runAgentLoop(
                     await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
                     tasksDone++;
                   } else {
-                    logger.warn(`Work-stealing: aborting task after retry (no DONE:) — unclaiming thread=${task.id}`);
+                    logger.warn(`Work-stealing: aborting task after retry (no DONE:) — unclaiming thread=${task.id} subtype=${retryResp.subtype ?? "?"}`);
                     await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
                     claimedThreadIds.delete(task.id);
                   }
@@ -1036,7 +1072,11 @@ export async function runAgentLoop(
                 await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
                 tasksDone++;
               } else {
-                logger.warn(`Work-stealing: aborting task (no DONE: marker) — unclaiming thread=${task.id}`);
+                // subtype distingue « l'agent a divagué » (success) de « il a
+                // manqué de tours » (error_max_turns). On le JOURNALISE sans
+                // brancher dessus : la décision reste l'abandon, mais elle
+                // devient diagnosticable.
+                logger.warn(`Work-stealing: aborting task (no DONE: marker) — unclaiming thread=${task.id} subtype=${resp.subtype ?? "?"}`);
                 await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
                 claimedThreadIds.delete(task.id);
               }

--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -50,6 +50,16 @@ export interface AssistantResponse {
   rateLimited: boolean;
   rateLimitResetsAt?: number;  // Unix timestamp (seconds)
   tokens: TokenUsage;
+  /**
+   * Subtype du `result` renvoyé par le CLI : "success", "error_max_turns", …
+   *
+   * Le parseur le connaissait déjà et le journalisait, mais le jetait ensuite.
+   * Sans lui, la boucle de work-stealing ne peut pas distinguer un agent qui a
+   * divagué d'un agent qui a simplement épuisé ses tours — les deux arrivent
+   * comme « pas de marqueur DONE: ». Exposé pour être JOURNALISÉ, pas pour
+   * changer une décision : voir les deux sites d'abandon dans agent-loop.ts.
+   */
+  subtype?: string;
 }
 
 export interface ToolCall {
@@ -350,6 +360,7 @@ function runOneTurn(
           durationMs: (eventRec.duration_ms as number) ?? 0,
           sessionId: resultSessionId,
           tokens,
+          subtype,
         });
         return;
       }

--- a/src/agent-loop/effort.ts
+++ b/src/agent-loop/effort.ts
@@ -24,7 +24,13 @@ export const EFFORT_PROFILES: Record<ConcreteEffortLevel, EffortProfile> = {
   // against the turn limit, and with tools in the loop a "turn" can burn
   // multiple explorations before the model even attempts to synthesise text.
   low:  { model: "claude-haiku-4-5-20251001", thinking: "none",       maxTurns: 15 },
-  mid:  { model: "claude-sonnet-4-6",         thinking: "think",      maxTurns: 8 },
+  // 8 → 16 : sur un raid mesuré, 21 `error_max_turns` pour 19 tâches
+  // abandonnées — c'est le plafond, pas la qualité de l'agent, qui causait
+  // l'abandon. On DOUBLE sans aller plus loin : à ~3,9 min pour 8 tours, un
+  // mid à 25 produirait un envoi de ~12 min contre un timeout de run par
+  // défaut de 15 min (orchestrator.ts), donc une mort par deadline en pleine
+  // tâche — l'état le plus destructeur, puisqu'il la laisse réclamée.
+  mid:  { model: "claude-sonnet-4-6",         thinking: "think",      maxTurns: 16 },
   high: { model: "claude-opus-4-6",           thinking: "think-hard", maxTurns: 20 },
   max:  { model: "claude-opus-4-6",           thinking: "ultrathink", maxTurns: 60 },
 };

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1082,12 +1082,12 @@ describe("runAgentLoop — phased mode", () => {
     for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
     await loopPromise;
 
-    // Second send() = execute for task t-1. Should be nudged to mid (Sonnet, 8 turns).
+    // Second send() = execute for task t-1. Should be nudged to mid (Sonnet, 16 turns).
     const executeCall = mockSend.mock.calls[1];
     expect(executeCall[1]).toMatchObject({
       model: "claude-sonnet-4-6",
       thinking: "think",
-      maxTurns: 8,
+      maxTurns: 16,
     });
   });
 
@@ -1130,7 +1130,7 @@ describe("runAgentLoop — phased mode", () => {
     expect(executeCall[1]).toMatchObject({
       model: "claude-sonnet-4-6",
       thinking: "think",
-      maxTurns: 8,
+      maxTurns: 16,
     });
   });
 

--- a/tests/unit/done-marker.test.ts
+++ b/tests/unit/done-marker.test.ts
@@ -62,3 +62,21 @@ describe('extractDoneSummary (#31)', () => {
     expect(extractDoneSummary('rien ici', 'fallback')).toBe('fallback');
   });
 });
+
+describe('hasDoneMarker — ancrage et fenêtre de fin', () => {
+  it('refuse un DONE: annoncé en milieu de phrase', () => {
+    expect(hasDoneMarker('je terminerai par DONE: <résumé> quand ce sera fini')).toBe(false);
+  });
+
+  it('refuse un DONE: enfoui loin de la fin du contenu cumulé', () => {
+    // `content` concatène tous les tours internes du CLI : un marqueur promis
+    // au premier tour ne doit pas résoudre le thread au dernier.
+    const contenu = 'DONE: je vais le faire\n' + 'exploration du code...\n'.repeat(200);
+    expect(hasDoneMarker(contenu)).toBe(false);
+  });
+
+  it('accepte un DONE: en début de ligne à la fin du contenu', () => {
+    const contenu = 'exploration...\n'.repeat(200) + '\nDONE: bug exposé dans work-stealing.ts';
+    expect(hasDoneMarker(contenu)).toBe(true);
+  });
+});

--- a/tests/unit/effort.test.ts
+++ b/tests/unit/effort.test.ts
@@ -10,11 +10,11 @@ describe("EFFORT_PROFILES", () => {
     });
   });
 
-  it("maps mid to sonnet with 8 turns and think", () => {
+  it("maps mid to sonnet with 16 turns and think", () => {
     expect(EFFORT_PROFILES.mid).toEqual({
       model: "claude-sonnet-4-6",
       thinking: "think",
-      maxTurns: 8,
+      maxTurns: 16,
     });
   });
 


### PR DESCRIPTION
Mesuré sur un raid réel de 27 min à 3 agents : **20 tâches réclamées, 19 abandonnées, 1 terminée**, 8 threads empoisonnés — pour **21 `error_max_turns`** dans les logs.

Un workflow de conception à 9 agents a **réfuté la solution évidente** (relancer la tâche au lieu de l'abandonner). Deux faits l'ont tuée :

- `agent-launcher.ts` fixe `freshSessionPerTask: true` **en dur** : chaque `send()` tire un `randomUUID()` neuf et saute la mémorisation de session. Une continuation « qui reprend le travail » repartirait de zéro.
- Le budget contraignant n'est pas `maxTurns` mais **l'horloge** : 7 à 17 envois pour un plafond de 50.

## Ce que livre cette PR — ~8 lignes de production

**1. `DONE_LINE_PATTERN`, ancré et fenêtré.** `content` concatène tous les tours internes du CLI. Un agent qui écrivait « je terminerai par DONE: » dans un tour intermédiaire **résolvait le thread avant d'avoir travaillé** — exactement ce que la règle « pas de marqueur = jamais complete » devait empêcher. Bug latent, indépendant du reste, présent aujourd'hui.

Le motif est **construit à partir de `DONE_PATTERN`** plutôt que retapé : ses classes contiennent des espaces insécables (U+00A0, U+202F) invisibles, que j'ai effectivement perdus à la première tentative — un test les a rattrapés.

**2. `subtype` exposé et journalisé** aux deux sites d'abandon. Le parseur le connaissait et le jetait. **Pour mesurer, pas pour brancher dessus** : la décision reste l'abandon, mais on saura distinguer une divagation d'un épuisement mécanique.

**3. Garde-fou temps avant réclamation.** On ne réclame plus si le temps restant < 1,5 × la durée du dernier envoi. Un SIGKILL du timeout en pleine tâche la laisse réclamée ; le balayage la désréclame, et **cette désréclamation compte vers l'empoisonnement** au même titre qu'un abandon de qualité. C'est le lien le plus direct avec les 8 threads empoisonnés.

**4. `mid.maxTurns` 8 → 16.** Doubler, pas tripler : à ~3,9 min pour 8 tours, un `mid` à 25 donnerait un envoi de ~12 min contre un timeout de run par défaut de 15 min — une mort par deadline en pleine tâche, l'état le plus destructeur.

## L'abandon n'est pas supprimé, et c'est volontaire

Il reste le bon comportement quand l'agent a divagué — le commentaire `agent-loop.ts:1028-1032` décrit un vrai bug. Ce qui était faux, c'est qu'il était **indiscriminé** et **destructeur**.

## Écarté, avec raison

| Approche | Pourquoi non |
|---|---|
| Continuation / reprise | `freshSessionPerTask` en dur ; reprise jamais exercée |
| Découpe en deux passes | Paie deux explorations sur chaque tâche, y compris celles qui réussissaient |
| Couche d'apprentissage | Échantillon de taille 1 par slot |
| Monter `high` 20→30 | `raid.yaml:46-48` documente qu'Opus avec de la corde est ce qui avait échoué |

## La métrique

**Pas le taux d'abandon** — les tâches complétées par minute-agent. Ligne de base mesurable dans `reports/` : **1 complétion pour 81 minutes-agent**.

`pnpm test` — 723 passants, 1 skippé. `pnpm build` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
