### PR TITLE
feat(agent-loop): un DONE: n'est plus accepté sans test qui échoue (opt-in)

### DIFF
--- a/behaviors/phase-execute.yaml
+++ b/behaviors/phase-execute.yaml
@@ -33,6 +33,10 @@ params:
     type: number
     required: false
     description: "Override maxTurns explicitly. Omit to use maxTurns from effort profile. Note: phase-execute's maxTurns override is deliberately ignored at runtime because per-task severity upgrades drive the turn budget."
+  requireFailingTest:
+    type: boolean
+    required: false
+    description: "Quand true, un DONE: n'est accepté que si le test ajouté échoue SANS le patch. Opt-in : réservé aux missions qui exigent explicitement un test qui échoue d'abord."
 
 sections:
   "030-execute":

--- a/behaviors/security-fix.yaml
+++ b/behaviors/security-fix.yaml
@@ -21,6 +21,10 @@ params:
     type: string
     default: high
     description: "Effort profile — security patches need code-writing capability"
+  requireFailingTest:
+    type: boolean
+    required: false
+    description: "Quand true, un DONE: n'est accepté que si le test ajouté échoue SANS le patch. Opt-in : réservé aux missions qui exigent explicitement un test qui échoue d'abord."
 
 sections:
   "030-security-fix":

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "test:watch": "vitest",
     "cli": "tsx cli/index.ts",
     "dev": "tsx cli/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",
-    "@swoofer/promptweave": "^0.4.0",
+    "@swoofer/promptweave": "^0.5.1",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
     "mcp-coordinator": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.30.0
         version: 0.30.1
       '@swoofer/promptweave':
-        specifier: ^0.4.0
-        version: 0.4.1
+        specifier: ^0.5.1
+        version: 0.5.1
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -425,8 +425,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swoofer/promptweave@0.4.1':
-    resolution: {integrity: sha512-HJy/TAEffB1Wh/9Qn0l00jA4jtTR5oDBaonsVDzGQ/0pb/1+Bz/qBlH68joMA7po/+d0+qNilvf5aBV5FlaBrA==}
+  '@swoofer/promptweave@0.5.1':
+    resolution: {integrity: sha512-hA1tpAO/qfx3Veke7XnKvalE/7RHA/3wj0xhoAUzipshdqXeKjeC2zil6ixQM8hzCJZAC8AtzePiSqVHi4MB4A==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -1934,7 +1934,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swoofer/promptweave@0.4.1':
+  '@swoofer/promptweave@0.5.1':
     dependencies:
       commander: 14.0.3
       handlebars: 4.7.9

--- a/presets/raid.yaml
+++ b/presets/raid.yaml
@@ -47,3 +47,4 @@ params:
     # à "high" (Opus), l'agent dépensait son budget en exploration avant
     # d'atteindre DONE. Sonnet + scope strict ci-dessus = moins d'excursions.
     effort: mid
+    requireFailingTest: true

--- a/presets/sentinelle.yaml
+++ b/presets/sentinelle.yaml
@@ -20,3 +20,4 @@ params:
       strict : uniquement ton fichier ciblé (+ son test). Résous "DONE: <résumé>" ou
       "FALSE_POSITIVE: <raison>". N'exécute jamais de PoC contre un système vivant.
     effort: high
+    requireFailingTest: true

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -11,6 +11,8 @@ import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, unclaim
 import { createLogger } from "../logger.js";
 import { resolveEffort, upgradeEffort, parseSeverity, EFFORT_PROFILES, isThinkingLevel, type EffortLevel, type ConcreteEffortLevel, type ThinkingLevel } from "./effort.js";
 import { authHeaders } from "../coordinator-auth.js";
+import { verifyFailingTest, type FalsifiabilityDeps } from "./falsifiability.js";
+import { spawn } from "node:child_process";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -59,6 +61,9 @@ export interface AgentLoopConfig {
     effort?: string;
     model?: string;
     thinking?: string;
+    // Opt-in, propagé par promptweave depuis le YAML du behavior. Quand vrai,
+    // un DONE: n'est accepté que si le test ajouté échoue SANS le patch.
+    requireFailingTest?: boolean;
   }>;
 }
 
@@ -112,6 +117,29 @@ export interface AgentLoopLogger {
   info(msg: string, data?: Record<string, unknown>): void;
   warn(msg: string, data?: Record<string, unknown>): void;
   error(msg: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Commande de test du dépôt cible. `vitest run <fichiers>` filtre par chemin,
+ * donc seuls les tests que l'agent vient d'écrire sont rejoués — pas les 64
+ * fichiers de la suite.
+ */
+const TEST_COMMAND = { cmd: "pnpm", args: ["exec", "vitest", "run"] };
+
+/** Exécuteur réel pour le contrôle de falsifiabilité. Ne jette jamais. */
+function gitExec(cwd: string): FalsifiabilityDeps {
+  return {
+    exec(cmd, args) {
+      return new Promise((resolve) => {
+        const child = spawn(cmd, args, { cwd, shell: process.platform === "win32" });
+        let stdout = "";
+        child.stdout?.on("data", (d) => { stdout += String(d); });
+        child.stderr?.on("data", (d) => { stdout += String(d); });
+        child.on("error", () => resolve({ code: -1, stdout }));
+        child.on("close", (code) => resolve({ code: code ?? -1, stdout }));
+      });
+    },
+  };
 }
 
 const DEFAULT_MAX_TURNS = 50;
@@ -1068,9 +1096,23 @@ export async function runAgentLoop(
               // blocking the real work from ever happening.
               if (hasDoneMarker(resp.content)) {
                 const taskSummary = extractDoneSummary(resp.content, "Done");
-                logger.info(`Work-stealing: completed — "${taskSummary.slice(0, 80)}"`);
-                await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
-                tasksDone++;
+                // Le DONE: ne suffit pas quand le behavior exige une preuve.
+                // Mesuré : un agent a « corrigé » deux champs non contrôlables
+                // par le moteur, avec un test qui passait avant comme après.
+                const verdict = phase.requireFailingTest
+                  ? await verifyFailingTest(gitExec(config.workspacePath), TEST_COMMAND)
+                  : null;
+                if (verdict && !verdict.falsifiable) {
+                  logger.warn(`Work-stealing: DONE refusé — ${verdict.reason}`, {
+                    taskId: task.id,
+                    testFiles: verdict.testFiles,
+                  });
+                  await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
+                } else {
+                  logger.info(`Work-stealing: completed — "${taskSummary.slice(0, 80)}"`);
+                  await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
+                  tasksDone++;
+                }
               } else {
                 // subtype distingue « l'agent a divagué » (success) de « il a
                 // manqué de tours » (error_max_turns). On le JOURNALISE sans

--- a/src/agent-loop/falsifiability.ts
+++ b/src/agent-loop/falsifiability.ts
@@ -1,0 +1,107 @@
+import { createLogger } from "../logger.js";
+
+const log = createLogger("falsifiability");
+
+/**
+ * Vérifie qu'un test de régression ÉCHOUE sans le patch.
+ *
+ * Les missions de chasse aux bugs et de remédiation exigent déjà « écris un
+ * test qui échoue avant ton patch ». Rien ne le vérifiait. Mesuré : un agent a
+ * « corrigé » deux champs qui ne sont pas contrôlables par le moteur — un SHA-1
+ * calculé localement et une valeur passée par une allowlist stricte — avec un
+ * test qui passait dans les deux cas, et a conclu DONE.
+ *
+ * Le principe : remiser les fichiers NON-test modifiés, relancer les tests
+ * touchés, et exiger un échec. Si le test passe sans le patch, il ne prouve
+ * rien — la tâche n'est pas terminée.
+ */
+
+export interface ExecResult {
+  code: number;
+  stdout: string;
+}
+
+export interface FalsifiabilityDeps {
+  /** Exécute une commande dans le worktree. Ne doit jamais jeter. */
+  exec(cmd: string, args: string[]): Promise<ExecResult>;
+}
+
+export interface FalsifiabilityVerdict {
+  /** true = le test échoue sans le patch, donc il prouve quelque chose. */
+  falsifiable: boolean;
+  reason: string;
+  /** Fichiers de test détectés dans le diff. */
+  testFiles: string[];
+  /** Fichiers de production remisés le temps du contrôle. */
+  sourceFiles: string[];
+}
+
+/** Un chemin de test au sens de vitest.config.ts : tests/ **.test.ts */
+export function isTestFile(path: string): boolean {
+  return /(^|\/)tests\/.*\.test\.(ts|js)$/.test(path.replace(/\\/g, "/"));
+}
+
+/** `git status --porcelain` → chemins modifiés ou ajoutés. */
+export function parseChangedFiles(porcelain: string): string[] {
+  return porcelain
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 3)
+    .map((l) => l.slice(3).trim())
+    .filter(Boolean);
+}
+
+/**
+ * Rejoue les tests sans les modifications de production.
+ *
+ * Fail-open sur toute anomalie d'outillage (git indisponible, remise
+ * impossible) : ce garde-fou doit attraper un test complaisant, pas bloquer
+ * une tâche légitime parce que git a hoqueté. Le seul verdict négatif est
+ * « le test passe sans le patch ».
+ */
+export async function verifyFailingTest(
+  deps: FalsifiabilityDeps,
+  testCommand: { cmd: string; args: string[] },
+): Promise<FalsifiabilityVerdict> {
+  const status = await deps.exec("git", ["status", "--porcelain"]);
+  if (status.code !== 0) {
+    return { falsifiable: true, reason: "git status indisponible — contrôle sauté", testFiles: [], sourceFiles: [] };
+  }
+
+  const changed = parseChangedFiles(status.stdout);
+  const testFiles = changed.filter(isTestFile);
+  const sourceFiles = changed.filter((f) => !isTestFile(f));
+
+  if (testFiles.length === 0) {
+    return { falsifiable: false, reason: "aucun fichier de test modifié — rien ne prouve le défaut", testFiles, sourceFiles };
+  }
+  if (sourceFiles.length === 0) {
+    // Un test seul, sans patch : c'est le cas « j'expose le bug sans le
+    // corriger », parfaitement valide pour une phase de chasse.
+    return { falsifiable: true, reason: "test ajouté sans patch de production", testFiles, sourceFiles };
+  }
+
+  const stash = await deps.exec("git", ["stash", "push", "--quiet", "--", ...sourceFiles]);
+  if (stash.code !== 0) {
+    return { falsifiable: true, reason: "remise impossible — contrôle sauté", testFiles, sourceFiles };
+  }
+
+  try {
+    const run = await deps.exec(testCommand.cmd, [...testCommand.args, ...testFiles]);
+    if (run.code === 0) {
+      return {
+        falsifiable: false,
+        reason: "le test passe SANS le patch — il ne démontre aucun défaut",
+        testFiles,
+        sourceFiles,
+      };
+    }
+    return { falsifiable: true, reason: "le test échoue sans le patch", testFiles, sourceFiles };
+  } finally {
+    const pop = await deps.exec("git", ["stash", "pop", "--quiet"]);
+    if (pop.code !== 0) {
+      // Laisser un worktree amputé de son patch serait pire que tout.
+      log.error("git stash pop a échoué — le patch est resté remisé", { sourceFiles });
+    }
+  }
+}

--- a/tests/unit/falsifiability.test.ts
+++ b/tests/unit/falsifiability.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  verifyFailingTest,
+  isTestFile,
+  parseChangedFiles,
+  type ExecResult,
+} from "../../src/agent-loop/falsifiability.js";
+
+/** Faux executeur : git n'est jamais appele pour de vrai. */
+function fakeExec(responses: Record<string, ExecResult>) {
+  const calls: string[] = [];
+  return {
+    calls,
+    deps: {
+      async exec(cmd: string, args: string[]): Promise<ExecResult> {
+        const key = `${cmd} ${args[0] ?? ""}`;
+        calls.push(`${cmd} ${args.join(" ")}`);
+        return responses[key] ?? { code: 0, stdout: "" };
+      },
+    },
+  };
+}
+
+const TEST_CMD = { cmd: "pnpm", args: ["exec", "vitest", "run"] };
+
+describe("isTestFile", () => {
+  it("reconnait un test vitest", () => {
+    expect(isTestFile("tests/unit/foo.test.ts")).toBe(true);
+    expect(isTestFile("tests\\unit\\foo.test.ts")).toBe(true);
+  });
+  it("rejette le code de production", () => {
+    expect(isTestFile("src/security/ingest.ts")).toBe(false);
+    expect(isTestFile("tests/fixtures/data.json")).toBe(false);
+  });
+});
+
+describe("parseChangedFiles", () => {
+  it("extrait les chemins du porcelain", () => {
+    expect(parseChangedFiles(" M src/a.ts\n?? tests/unit/b.test.ts\n")).toEqual([
+      "src/a.ts",
+      "tests/unit/b.test.ts",
+    ]);
+  });
+});
+
+describe("verifyFailingTest", () => {
+  it("refuse quand le test passe SANS le patch", async () => {
+    const { deps } = fakeExec({
+      "git status": { code: 0, stdout: " M src/security/ingest.ts\n M tests/unit/x.test.ts\n" },
+      "git stash": { code: 0, stdout: "" },
+      "pnpm exec": { code: 0, stdout: "all passed" },
+    });
+    const v = await verifyFailingTest(deps, TEST_CMD);
+    expect(v.falsifiable).toBe(false);
+    expect(v.reason).toContain("passe SANS le patch");
+  });
+
+  it("accepte quand le test echoue sans le patch", async () => {
+    const { deps } = fakeExec({
+      "git status": { code: 0, stdout: " M src/security/ingest.ts\n M tests/unit/x.test.ts\n" },
+      "git stash": { code: 0, stdout: "" },
+      "pnpm exec": { code: 1, stdout: "1 failed" },
+    });
+    const v = await verifyFailingTest(deps, TEST_CMD);
+    expect(v.falsifiable).toBe(true);
+  });
+
+  it("refuse quand aucun test n'a ete modifie", async () => {
+    const { deps } = fakeExec({
+      "git status": { code: 0, stdout: " M src/security/ingest.ts\n" },
+    });
+    const v = await verifyFailingTest(deps, TEST_CMD);
+    expect(v.falsifiable).toBe(false);
+    expect(v.reason).toContain("aucun fichier de test");
+  });
+
+  it("accepte un test seul, sans patch", async () => {
+    const { deps } = fakeExec({
+      "git status": { code: 0, stdout: "?? tests/unit/x.test.ts\n" },
+    });
+    const v = await verifyFailingTest(deps, TEST_CMD);
+    expect(v.falsifiable).toBe(true);
+  });
+
+  it("fail-open si git est indisponible", async () => {
+    const { deps } = fakeExec({ "git status": { code: 128, stdout: "" } });
+    const v = await verifyFailingTest(deps, TEST_CMD);
+    expect(v.falsifiable).toBe(true);
+  });
+
+  it("restaure toujours le patch remise", async () => {
+    const { deps, calls } = fakeExec({
+      "git status": { code: 0, stdout: " M src/a.ts\n M tests/unit/x.test.ts\n" },
+      "git stash": { code: 0, stdout: "" },
+      "pnpm exec": { code: 0, stdout: "" },
+    });
+    await verifyFailingTest(deps, TEST_CMD);
+    expect(calls.some((c) => c.startsWith("git stash pop"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Le défaut mesuré

Le swarm `sentinelle` a produit un correctif de sécurité sur deux champs de `renderPlan()` — `f.severity` et `f.fingerprint`. Vérification : `fingerprint` est un SHA-1 calculé localement (`finding.ts:14-17`), `severity` passe par `mapSeverity()` (`strix-parse.ts:25-33`) qui applique une allowlist de cinq valeurs. Ni l'un ni l'autre n'est contrôlable par le moteur. Faux positif.

L'agent a écrit un test — qui passait avant comme après son patch — puis a conclu `DONE:`. Sa mission exigeait déjà « écris un test de régression qui échoue avant ton patch ». **Rien ne le vérifiait.**

## Le garde-fou

`verifyFailingTest` (`src/agent-loop/falsifiability.ts") :
1. `git status --porcelain` → sépare fichiers de test et fichiers de production
2. remise (`git stash push`) les fichiers de production
3. rejoue `vitest run <les seuls tests écrits par l'agent>`
4. **sortie 0 = le test ne prouve rien** → tâche déréclamée, pas complete
5. `git stash pop` dans un `finally`, toujours

## Portée : opt-in, 2 presets sur 29

Réponse à « est-ce que ce sera implanté pour tous les templates ? » : non. Seuls `raid` et `sentinelle` demandent explicitement un test qui échoue d'abord. Un preset de doc ou d'audit read-only n'a aucun test à produire — le garde-fou y bloquerait des tâches légitimes.

Le champ passe par le catalogue plutôt que par un test de nom de preset codé en dur : `requireFailingTest: true` dans les params, propagé par promptweave 0.5.1 jusqu'à `phases[].requireFailingTest`.

Chaîne vérifiée bout-en-bout :
```
raid       | discover | undefined
raid       | review   | undefined
raid       | execute  | true
sentinelle | execute  | true
```

## Fail-open assumé

git indisponible, remise impossible → contrôle sauté, tâche acceptée. Ce garde-fou doit attraper un test complaisant, pas bloquer une tâche légitime parce que git a hoqueté. Le seul verdict négatif est « le test passe sans le patch ».

Un test seul, sans patch de production, est **accepté** : c'est le cas « j'expose le bug sans le corriger », valide pour une phase de chasse.

## En amont

swoofer/promptweave#25 — `requireFailingTest` manquait à `PHASE_KNOBS` dans `param-usage.ts`, oubli de #23. Le lint de catalogue d'essaim signalait donc les 2 behaviors comme ayant un param orphelin. Corrigé et publié en 0.5.1.

## Vérification

- 67 fichiers / 732 tests au vert, dont 9 nouveaux sur `falsifiability` (git n'est jamais appelé — l'exécuteur est injecté)
- `tsc` propre
- propagation du champ vérifiée à l'exécution sur les 2 templates

## Aussi

`prepublishOnly` utilisait encore npm — reliquat de la migration pnpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)