### PR TITLE
fix(falsifiability): git repliait les fichiers non suivis, le garde-fou passait à côté

### DIFF
--- a/src/agent-loop/falsifiability.ts
+++ b/src/agent-loop/falsifiability.ts
@@ -63,7 +63,11 @@ export async function verifyFailingTest(
   deps: FalsifiabilityDeps,
   testCommand: { cmd: string; args: string[] },
 ): Promise<FalsifiabilityVerdict> {
-  const status = await deps.exec("git", ["status", "--porcelain"]);
+  // `--untracked-files=all` est obligatoire : sans lui, git REPLIE un
+  // répertoire entièrement non suivi en une seule entrée (`?? tests/`) et le
+  // fichier de test que l'agent vient d'écrire n'est jamais vu — le verdict
+  // devient « aucun fichier de test » sur une tâche qui en a bien produit un.
+  const status = await deps.exec("git", ["status", "--porcelain", "--untracked-files=all"]);
   if (status.code !== 0) {
     return { falsifiable: true, reason: "git status indisponible — contrôle sauté", testFiles: [], sourceFiles: [] };
   }
@@ -81,7 +85,10 @@ export async function verifyFailingTest(
     return { falsifiable: true, reason: "test ajouté sans patch de production", testFiles, sourceFiles };
   }
 
-  const stash = await deps.exec("git", ["stash", "push", "--quiet", "--", ...sourceFiles]);
+  // `--include-untracked` : un patch qui CRÉE un fichier source ne serait pas
+  // remisé sans lui, la remise échouerait, et le contrôle s'ouvrirait en grand
+  // sur exactement le cas qu'il doit surveiller.
+  const stash = await deps.exec("git", ["stash", "push", "--quiet", "--include-untracked", "--", ...sourceFiles]);
   if (stash.code !== 0) {
     return { falsifiable: true, reason: "remise impossible — contrôle sauté", testFiles, sourceFiles };
   }

--- a/tests/unit/falsifiability.test.ts
+++ b/tests/unit/falsifiability.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   verifyFailingTest,
   isTestFile,
@@ -96,5 +100,77 @@ describe("verifyFailingTest", () => {
     });
     await verifyFailingTest(deps, TEST_CMD);
     expect(calls.some((c) => c.startsWith("git stash pop"))).toBe(true);
+  });
+});
+
+// ── Contre un VRAI dépôt git ───────────────────────────────────────────
+//
+// Les cas ci-dessus injectent l'exécuteur : ils valident la logique, jamais
+// le dialogue avec git. Deux défauts sont passés à travers pour cette raison
+// exacte, et seul un dépôt réel les a exposés :
+//
+//  1. `git status --porcelain` REPLIE un répertoire entièrement non suivi en
+//     une entrée (`?? tests/`). Le test que l'agent venait d'écrire n'était
+//     jamais vu → « aucun fichier de test » sur une tâche qui en produisait un.
+//  2. `git stash push -- <fichier>` ÉCHOUE sur un fichier non suivi. Un patch
+//     qui CRÉE un fichier source ouvrait le contrôle en grand.
+//
+// D'où ce test : il crée un fichier source ET un test tous deux NON SUIVIS,
+// la combinaison qui déclenchait les deux.
+describe("verifyFailingTest contre un vrai dépôt git", () => {
+  const git = (cwd: string, ...args: string[]) =>
+    spawnSync("git", args, { cwd, encoding: "utf8" });
+
+  const realExec = (cwd: string) => ({
+    async exec(cmd: string, args: string[]): Promise<ExecResult> {
+      const r = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+      return { code: r.status ?? -1, stdout: (r.stdout ?? "") + (r.stderr ?? "") };
+    },
+  });
+
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "essaim-fals-"));
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "t@t");
+    git(repo, "config", "user.name", "t");
+    writeFileSync(join(repo, "base.js"), "export const a = 1;\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "base");
+    // Le patch de l'agent : un fichier source neuf + un test, tous deux NON
+    // SUIVIS, dans un répertoire tests/ qui n'existait pas.
+    writeFileSync(join(repo, "newsrc.js"), "export const helper = () => 1;\n");
+    mkdirSync(join(repo, "tests"), { recursive: true });
+    writeFileSync(join(repo, "tests", "z.test.js"), "// complaisant\n");
+  });
+
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  it("voit le test non suivi et refuse un test complaisant", async () => {
+    // « Le test » sort 0 tant que le patch est absent du worktree — donc il
+    // ne sort 0 QUE si la remise a réellement retiré newsrc.js. Un verdict
+    // négatif prouve d'un coup que le fichier de test a été vu ET remisé.
+    const probe = {
+      cmd: process.execPath,
+      args: ["-e", "process.exit(require('fs').existsSync('newsrc.js') ? 1 : 0)"],
+    };
+    const v = await verifyFailingTest(realExec(repo), probe);
+
+    expect(v.testFiles).toEqual(["tests/z.test.js"]);
+    expect(v.sourceFiles).toEqual(["newsrc.js"]);
+    expect(v.falsifiable).toBe(false);
+    expect(v.reason).toContain("passe SANS le patch");
+  });
+
+  it("restaure le patch non suivi et ne laisse aucune remise", async () => {
+    await verifyFailingTest(realExec(repo), {
+      cmd: process.execPath,
+      args: ["-e", "process.exit(0)"],
+    });
+
+    expect(existsSync(join(repo, "newsrc.js"))).toBe(true);
+    expect(existsSync(join(repo, "tests", "z.test.js"))).toBe(true);
+    expect(git(repo, "stash", "list").stdout.trim()).toBe("");
   });
 });


### PR DESCRIPTION
Suite de #124. Le garde-fou n'avait jamais tourné contre un vrai dépôt git — les 9 tests unitaires injectent l'exécuteur et **simulent** la sortie de git. Deux défauts sont passés à travers pour cette raison exacte.

## 1. Le fichier de test n'était pas vu

`git status --porcelain` **replie** un répertoire entièrement non suivi en une seule entrée :

```
?? newsrc.js
?? tests/          ← tests/z.test.js n'apparaît jamais
```

`isTestFile("tests/")` est faux, `testFiles` est vide, verdict : « aucun fichier de test modifié ». Un agent qui écrit le premier test d'un répertoire neuf se fait **refuser à tort**, et sa tâche repart en boucle.

→ `--untracked-files=all`

## 2. La remise échouait sur un fichier neuf — le plus grave

`git stash push -- <fichier>` **échoue** si le fichier n'est pas suivi. Un patch qui *crée* un fichier source ne pouvait donc pas être remisé. La remise échouait, le fail-open s'appliquait, et le contrôle s'ouvrait en grand :

```json
{ "falsifiable": true, "reason": "remise impossible — contrôle sauté" }
```

C'est exactement le cas qu'il doit surveiller. Après correctif, sur le même dépôt :

```json
{ "falsifiable": false, "reason": "le test passe SANS le patch — il ne démontre aucun défaut" }
```

→ `--include-untracked`

## Deux tests contre un vrai dépôt

La sonde sort 0 **uniquement si la remise a réellement retiré le fichier source du worktree** — un verdict négatif prouve d'un coup que le test a été vu et que la remise a fonctionné.

Vérifié que les deux **échouent contre le code non corrigé** :

| | code corrigé | correctifs retirés | `stash pop` saboté |
|---|---|---|---|
| voit le test non suivi et refuse | ✅ | ❌ | ✅ |
| restaure et ne laisse aucune remise | ✅ | ✅ | ❌ |

C'était le minimum pour le garde-fou dont tout l'objet est de refuser les tests qui ne prouvent rien.

## Vérification

- 735 tests au vert (11 sur `falsifiability`), `tsc` propre
- dépôt réel intégralement restauré après chaque passage : les deux fichiers non suivis reviennent, pile de remise vide

🤖 Generated with [Claude Code](https://claude.com/claude-code)