### PR TITLE
feat(release): binaire Windows, et la version cesse de répondre 0.0.0

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,14 +41,22 @@ jobs:
             platform: darwin
             arch: arm64
             bun_target: bun-darwin-aarch64
+            ext: ""
           - os: macos-15
             platform: darwin
             arch: x64
             bun_target: bun-darwin-x64
+            ext: ""
           - os: ubuntu-latest
             platform: linux
             arch: x64
             bun_target: bun-linux-x64
+            ext: ""
+          - os: windows-latest
+            platform: win32
+            arch: x64
+            bun_target: bun-windows-x64
+            ext: ".exe"
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -71,10 +79,18 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # `shell: bash` sur toutes les plateformes : le shell par défaut du runner
+      # Windows est pwsh, où `mkdir -p`, `cp -r` et `${TAG#v}` sont des erreurs.
+      # Git Bash est préinstallé sur windows-latest.
       - name: Build binary
+        shell: bash
         run: |
           mkdir -p bin
-          bun build --compile cli/index.ts --outfile bin/essaim
+          # La version DOIT être injectée : le binaire compilé n'a pas de
+          # package.json résolvable (bunfs), et sans ce --define `essaim
+          # --version` répond "0.0.0".
+          TAG="${{ inputs.tag || github.ref_name }}"
+          bun build --compile cli/index.ts             --define "__ESSAIM_VERSION__=\"${TAG#v}\""             --outfile "bin/essaim${{ matrix.ext }}"
 
       - name: Sign binary (macOS)
         if: matrix.platform == 'darwin'
@@ -96,12 +112,14 @@ jobs:
           EOF
 
       - name: Verify binary
+        shell: bash
         run: |
-          ./bin/essaim --version
-          ./bin/essaim --help
-          ./bin/essaim list
+          ./bin/essaim${{ matrix.ext }} --version
+          ./bin/essaim${{ matrix.ext }} --help
+          ./bin/essaim${{ matrix.ext }} list
 
       - name: Package tarball
+        shell: bash
         run: |
           # When called via workflow_dispatch / workflow_call, GITHUB_REF_NAME
           # is the caller's branch (typically `main`), not the tag — so we use
@@ -112,7 +130,7 @@ jobs:
           DIST_NAME="essaim-${VERSION}-${{ matrix.platform }}-${{ matrix.arch }}"
           mkdir -p "dist/${DIST_NAME}/behaviors" "dist/${DIST_NAME}/presets" "dist/${DIST_NAME}/compositions" "dist/${DIST_NAME}/scripts"
 
-          cp bin/essaim "dist/${DIST_NAME}/"
+          cp "bin/essaim${{ matrix.ext }}" "dist/${DIST_NAME}/"
           cp package.json "dist/${DIST_NAME}/"
           cp -r behaviors/* "dist/${DIST_NAME}/behaviors/"
           cp -r presets/* "dist/${DIST_NAME}/presets/"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ reports/
 .claude/
 graphify-out/
 runs/
+
+# Binaire natif produit par `bun build --compile` (release-binaries.yml)
+bin/

--- a/cli/version.ts
+++ b/cli/version.ts
@@ -2,7 +2,22 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
 
+// Injecté par `bun build --define` au moment de compiler le binaire natif.
+// Déclaré, jamais défini : tsc se contente de la déclaration, et `typeof` sur
+// un identifiant absent ne jette pas — sous node/tsx la constante n'existe
+// simplement pas et on retombe sur la recherche de package.json ci-dessous.
+declare const __ESSAIM_VERSION__: string | undefined;
+
 export function getVersion(): string {
+  // Le binaire compilé n'a pas de package.json à côté de lui : sous
+  // `bun --compile`, import.meta.url désigne le système de fichiers synthétique
+  // de bun, donc AUCUN des deux candidats ci-dessous ne résout — y compris
+  // quand la tarball place package.json à côté de l'exécutable. Sans cette
+  // injection, `essaim --version` répond "0.0.0" sur les quatre plateformes.
+  try {
+    if (typeof __ESSAIM_VERSION__ === "string" && __ESSAIM_VERSION__) return __ESSAIM_VERSION__;
+  } catch {}
+
   // dist/cli/version.js -> ../../package.json
   // cli/version.ts (tsx) -> ../package.json
   // Wrap fileURLToPath in the try as well — under Bun --compile, import.meta.url


### PR DESCRIPTION
## 1. Le binaire Windows

La matrice ne produisait que `darwin-arm64`, `darwin-x64` et `linux-x64`. Ajoute `windows-latest` / `bun-windows-x64`.

Trois étapes passent en `shell: bash` — le shell par défaut du runner Windows est **pwsh**, où `mkdir -p`, `cp -r` et `${TAG#v}` sont des erreurs de syntaxe. Git Bash est préinstallé sur `windows-latest`.

Compilé et exécuté localement sur Windows 11, avec les trois commandes exactes de l'étape *Verify* : `--version`, `--help`, `list`. Toutes passent.

## 2. `--version` répondait `0.0.0` — sur les quatre plateformes

Trouvé en faisant tourner l'étape *Verify* pour de vrai plutôt qu'en la supposant bonne.

Sous `bun --compile`, `import.meta.url` désigne le système de fichiers synthétique de bun. La recherche de `package.json` dans `getVersion()` ne résout donc **jamais** — y compris quand la tarball place `package.json` juste à côté de l'exécutable, parce que la résolution part de `import.meta.url`, pas du chemin de l'exe. La fonction retombe sur sa valeur par défaut.

Le commentaire du code anticipait déjà le cas (« under Bun --compile, import.meta.url may be a synthetic non-file URL ») sans le corriger.

**Portée** : mesuré en compilant localement sur Windows. Le mécanisme ne dépend pas de la plateforme — les binaires macOS et linux déjà publiés répondent donc `0.0.0` eux aussi. Je ne l'ai pas vérifié sur ces plateformes, faute de runner sous la main.

La version est injectée par `--define` à la compilation. `__ESSAIM_VERSION__` est *déclaré, jamais défini* : tsc se contente de la déclaration, et `typeof` sur un identifiant absent ne jette pas — sous node/tsx la constante n'existe pas et la recherche de package.json reprend la main.

Vérifié sur les trois chemins :

| chemin | avant | après |
|---|---|---|
| `tsx cli/index.ts` | 0.11.0 | 0.11.0 |
| `node dist/cli/index.js` | 0.11.0 | 0.11.0 |
| binaire `bun --compile` | **0.0.0** | **0.11.0** |

## 3. `bin/` n'était pas ignoré

Un `git add -A` après une compilation locale commettait 94 Mo.

## Vérification

735 tests au vert, `tsc` propre, YAML validé.

Le binaire Windows lui-même ne sera produit qu'à la prochaine release — je n'ai pas déclenché le workflow contre `v0.11.0`, parce que `action-gh-release` y tourne avec `generate_release_notes: true` et réécrirait les notes de release-please sur une release déjà publiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)