### PR TITLE
fix(release): la compilation Windows échouait et emportait darwin-arm64

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -35,6 +35,9 @@ concurrency:
 jobs:
   build:
     strategy:
+      # Sans ceci, l'échec d'UNE plateforme annule les autres : la 0.12.0 a
+      # perdu darwin-arm64 en dommage collatéral de l'échec Windows.
+      fail-fast: false
       matrix:
         include:
           - os: macos-14
@@ -77,7 +80,13 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      # `--ignore-scripts` : `better-sqlite3` (transitif via mcp-coordinator)
+      # n'a de prebuild que pour darwin, donc les autres plateformes le
+      # compilent depuis les sources — ce qui échoue sur Windows faute de
+      # Visual Studio. Le code d'essaim ne le référence jamais et le binaire
+      # bun n'en a pas besoin : l'étape Verify ci-dessous le prouve sur les
+      # quatre plateformes.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       # `shell: bash` sur toutes les plateformes : le shell par défaut du runner
       # Windows est pwsh, où `mkdir -p`, `cp -r` et `${TAG#v}` sont des erreurs.


### PR DESCRIPTION
Régression introduite par #126 : la v0.12.0 n'a publié que **2 archives sur 4**.

```
release                                          success
binaries / build (macos-14, darwin, arm64)     cancelled   ← dommage collatéral
binaries / build (windows-latest, win32, x64)  failure
binaries / build (macos-15, darwin, x64)        success
binaries / build (ubuntu-latest, linux, x64)    success
```

## Défaut 1 — l'échec Windows

```
gyp ERR! stack Error: Could not find any Visual Studio installation to use
.../node_modules/better-sqlite3 install: Failed
```

`pnpm install` compile `better-sqlite3` depuis les sources. Le module arrive **transitivement par mcp-coordinator** — le code d'essaim ne le référence nulle part (`grep` sur `src/` et `cli/` : zéro occurrence). Son dossier `prebuilds/` ne contient que `darwin-arm64` et `darwin-x64`, donc Linux le compilait déjà depuis les sources ; ça passait là-bas grâce à build-essential, pas sur Windows.

Le binaire bun n'en a pas besoin : `--ignore-scripts`. L'étape *Verify* (`--version`, `--help`, `list`) le démontrera sur les quatre plateformes — c'est elle le test, pas une affirmation de ma part.

## Défaut 2 — le plus grave : fail-fast

La matrice était en `fail-fast` par défaut. L'échec de Windows a donc **annulé darwin-arm64**, une plateforme qui fonctionnait parfaitement avant mon changement. Un ajout de plateforme ne doit jamais pouvoir casser les autres.

`fail-fast: false` isole désormais chaque plateforme.

## Vérification

Chemin CI reproduit localement sur Windows 11 — install sans scripts, compilation, puis les trois commandes de *Verify* : `0.12.0`, help OK, 15 templates listés.

Réserve : pnpm a répondu « Already up to date », donc ce n'est pas un test en vase clos. La preuve en conditions propres viendra de la CI.

## Après merge

La v0.12.0 restera incomplète (darwin-arm64 et win32 manquants). Le workflow a un levier `workflow_dispatch` prévu exactement pour ça — à déclencher sur le tag une fois ce correctif sur `main`, si tu veux compléter la release plutôt qu'attendre la 0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)