### PR TITLE
fix(pipeline): un run id par étape, et trois garde-fous qui ne gardaient rien

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,23 @@ jobs:
       # pour la même raison : c'est le plan de CETTE tâche, versionné, qui cite ces
       # jetons morts comme des défauts à corriger. Ce workflow s'exclut lui-même,
       # comme l'étape précédente.
+      #
+      # Trois jetons figés : ça ne rattrape que LEUR régression, pas la prochaine
+      # commande morte. Une vérification contre les commandes réellement
+      # enregistrées par cli/index.ts serait plus juste mais n'est pas un simple
+      # remplacement ici : deux des trois jetons ne sont pas des sous-commandes
+      # essaim (`--preset` est une option, `mcp-coordinator run` appartient à un
+      # AUTRE binaire), donc une liste de sous-commandes essaim ne les couvrirait
+      # pas ; et une extraction générique de « essaim <mot> » dans la prose de
+      # README.md tombe sur des faux positifs (« point essaim at it instead »,
+      # « essaim itself ») qui coûteraient plus de bruit CI que ce que le garde-fou
+      # rapporte. `--preset` en sous-chaîne nue matchait aussi n'importe quel futur
+      # `--preset-xxx` légitime : resserré ci-dessous à une frontière de mot (pas
+      # suivi d'un caractère alphanumérique ou d'un tiret), sans toucher aux deux
+      # autres jetons ni à la portée du garde-fou.
       - name: Refuser les commandes CLI inexistantes dans la doc
         run: |
-          if git grep -In -e 'essaim bce' -e '--preset' -e 'mcp-coordinator run' -- . ':!CHANGELOG.md' ':!docs/superpowers/plans/2026-08-27-stabilite-essaim.md' ':!.github/workflows/test.yml' > /tmp/dead-cli 2>/dev/null; then
+          if git grep -In -E -e 'essaim bce' -e '(--preset)([^A-Za-z0-9_-]|$)' -e 'mcp-coordinator run' -- . ':!CHANGELOG.md' ':!docs/superpowers/plans/2026-08-27-stabilite-essaim.md' ':!.github/workflows/test.yml' > /tmp/dead-cli 2>/dev/null; then
             echo "::error::Commandes CLI inexistantes dans la doc :"; cat /tmp/dead-cli; exit 1
           fi
           echo "OK — aucune commande CLI morte."

--- a/cli/pipeline.ts
+++ b/cli/pipeline.ts
@@ -12,6 +12,7 @@ import {
 import { executeRun } from "./run-core.js";
 import { uniqueReportBase } from "../src/orchestrator/reporter.js";
 import { parseSetParams, parseSetFileParams, buildParamTypeMap } from "./params.js";
+import { currentRunId } from "../src/run-id.js";
 
 export function createPipelineCommand(): Command {
   return new Command("pipeline")
@@ -32,6 +33,18 @@ export function createPipelineCommand(): Command {
       }) => {
         const filePath = resolve(opts.file);
         const pipelineDir = dirname(filePath);
+
+        // ensureRunId (src/run-id.ts) is idempotent: once ESSAIM_RUN_ID is set
+        // in this process's env it wins for every later call, for the rest of
+        // the process's life. A pipeline runs all its steps in this SAME
+        // process, so without this, step 2 of the same template on the same
+        // repo would inherit step 1's run id — and workspace.ts's
+        // agentBranchName() derives the worktree branch name from it, so two
+        // steps would collide on the exact branch name the recent workspace.ts
+        // fix made unique per run. Captured once, before any step runs: if the
+        // caller (a runner, CI, or a parent essaim) already set ESSAIM_RUN_ID,
+        // that external id must still win for the WHOLE pipeline, unchanged.
+        const externalRunId = currentRunId();
 
         let def: PipelineDef;
         try {
@@ -60,6 +73,10 @@ export function createPipelineCommand(): Command {
 
         const deps: PipelineDeps = {
           runStep: async (step, sh) => {
+            // Force a fresh mint for this step, unless an external id must
+            // persist across the whole pipeline (see the comment above).
+            if (!externalRunId) delete process.env.ESSAIM_RUN_ID;
+
             // Merge set + set_file (set_file wins). set_file paths are relative
             // to the pipeline file's dir.
             const setParams = parseSetParams(

--- a/tests/unit/pipeline-run-id.test.ts
+++ b/tests/unit/pipeline-run-id.test.ts
@@ -1,0 +1,91 @@
+// tests/unit/pipeline-run-id.test.ts
+//
+// ensureRunId (src/run-id.ts) is idempotent and publishes the id to
+// process.env.ESSAIM_RUN_ID, which lives for the whole process. `essaim
+// pipeline` runs every step in that SAME process (cli/pipeline.ts), so two
+// steps of the same template against the same repo used to mint (via
+// runProject → ensureRunId) the exact same run id — and workspace.ts's
+// agentBranchName() builds `mini-project-<runId>-<agentId>` from it. Same
+// runId + same (deterministic, src/bridge.ts) agentId across steps means the
+// same branch name: exactly the collision the recent workspace.ts fix
+// eliminated for separate `essaim run` invocations, reopened by the pipeline
+// running steps in-process.
+//
+// This exercises the real action closure (executeRun mocked out, like
+// run-cli.test.ts does for `essaim run`) and asserts on the run id each step
+// would see — not on git/worktree state, which is out of scope here and
+// already covered by src/orchestrator/workspace.test.ts.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../cli/run-core.js", () => ({
+  executeRun: vi.fn(),
+}));
+
+const { executeRun } = await import("../../cli/run-core.js");
+const { ensureRunId, currentRunId } = await import("../../src/run-id.js");
+const { createPipelineCommand } = await import("../../cli/pipeline.js");
+
+let dir: string;
+let pipelinePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pipeline-runid-"));
+  pipelinePath = join(dir, "pipeline.yaml");
+  // Same template + same project on both steps: exactly the narrow case the
+  // finding names — deterministic agent ids collide unless the run id differs.
+  writeFileSync(
+    pipelinePath,
+    "name: p\nsteps:\n  - name: step1\n    template: raid\n    project: .\n  - name: step2\n    template: raid\n    project: .\n",
+  );
+  vi.mocked(executeRun).mockReset();
+  delete process.env.ESSAIM_RUN_ID;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.ESSAIM_RUN_ID;
+});
+
+async function runPipeline(): Promise<void> {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await createPipelineCommand().parseAsync(["-f", pipelinePath], { from: "user" });
+  } finally {
+    exitSpy.mockRestore();
+    vi.restoreAllMocks();
+  }
+}
+
+describe("essaim pipeline — un run id par étape, pas un seul pour tout le process", () => {
+  it("deux étapes du même template mintent deux run ids DIFFÉRENTS quand aucun n'est fourni de l'extérieur", async () => {
+    const seenRunIds: string[] = [];
+    vi.mocked(executeRun).mockImplementation(async (opts) => {
+      // Simule ce que runProject fait réellement en interne (orchestrator.ts:180).
+      seenRunIds.push(ensureRunId(opts.template));
+      return undefined;
+    });
+
+    await runPipeline();
+
+    expect(seenRunIds).toHaveLength(2);
+    expect(seenRunIds[0]).not.toBe(seenRunIds[1]);
+  });
+
+  it("un ESSAIM_RUN_ID fourni de l'extérieur (runner/CI/essaim parent) prime sur TOUTES les étapes", async () => {
+    process.env.ESSAIM_RUN_ID = "external-run-id";
+    const seenRunIds: string[] = [];
+    vi.mocked(executeRun).mockImplementation(async (opts) => {
+      seenRunIds.push(ensureRunId(opts.template));
+      return undefined;
+    });
+
+    await runPipeline();
+
+    expect(seenRunIds).toEqual(["external-run-id", "external-run-id"]);
+    expect(currentRunId()).toBe("external-run-id");
+  });
+});

--- a/tests/unit/report-thread-outcomes.test.ts
+++ b/tests/unit/report-thread-outcomes.test.ts
@@ -47,4 +47,20 @@ describe("writeReport — le tableau ne promet plus un accord qu'il n'a pas mesu
     expect(md).not.toContain("| Consensus |");
     expect(md).not.toContain("| Auto-resolved |");
   });
+
+  // Les deux libellés anglais ci-dessus ont déjà été renommés une première fois
+  // (en français) avant même ce test : `not.toContain` sur "| Consensus |" /
+  // "| Auto-resolved |" est donc vrai que les trois lignes de compteurs soient
+  // présentes ou que quelqu'un les supprime purement et simplement — le test ne
+  // discriminait que dans un sens. Ceci vérifie l'autre : les trois lignes du
+  // tableau existent réellement, avec les valeurs mesurées.
+  it("écrit les trois compteurs de threads avec leurs valeurs mesurées", () => {
+    dir = mkdtempSync(join(tmpdir(), "rep-outcomes-"));
+    const md = readFileSync(writeReport([runReel()], dir), "utf8");
+
+    expect(md).toContain("| Threads ouverts | 4 |");
+    expect(md).toContain("| Consensus (approuvé par tous) | 9 |");
+    expect(md).toContain("| Auto-résolus (aucun agent concerné) | 0 |");
+    expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
+  });
 });

--- a/tests/unit/run-cli.test.ts
+++ b/tests/unit/run-cli.test.ts
@@ -1,0 +1,73 @@
+// tests/unit/run-cli.test.ts
+//
+// run-exit-code.test.ts covers runExitCode() as a pure decision. Nothing
+// verified that createRunCommand()'s action actually feeds its RunResult
+// through that function and into process.exit — deleting the call, or
+// hardcoding `process.exit(0)` in its place, leaves that suite green (it
+// never touches the command). This exercises the real action closure:
+// executeRun (network/orchestrator/coordinator) is mocked, process.exit is
+// spied on, and only the wiring between the two is asserted.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentResult, RunResult } from "../../src/orchestrator/types.js";
+
+vi.mock("../../cli/run-core.js", () => ({
+  executeRun: vi.fn(),
+}));
+
+const { executeRun } = await import("../../cli/run-core.js");
+const { createRunCommand } = await import("../../cli/run.js");
+
+function agent(id: string, exit_code: number): AgentResult {
+  return { agent_id: id, agent_name: id, exit_code, diff: "", stdout_length: 0 };
+}
+
+function runResult(agents: AgentResult[]): RunResult {
+  return {
+    project_id: "p",
+    project_name: "proj",
+    mode: "with_coordinator",
+    duration_ms: 1,
+    coordinator_metrics: {
+      agents_count: agents.length, duration_total_ms: 1, threads_opened: 0,
+      threads_resolved_consensus: 0, threads_auto_resolved: 0, threads_without_consensus: 0,
+      messages_exchanged: 0, conflicts_by_layer: {}, introspections_triggered: 0,
+      introspections_concerned: 0, avg_resolution_time_ms: 0, hot_files: [],
+    },
+    agent_results: agents,
+    custom_metrics: {},
+  };
+}
+
+async function runAction(): Promise<void> {
+  await createRunCommand().parseAsync(["raid", "-p", "."], { from: "user" });
+}
+
+describe("essaim run — wiring de runExitCode dans l'action commander", () => {
+  beforeEach(() => {
+    vi.mocked(executeRun).mockReset();
+  });
+
+  it("sort en 1 quand TOUS les agents ont échoué", async () => {
+    vi.mocked(executeRun).mockResolvedValue(runResult([agent("a1", 1), agent("a2", 1)]));
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await runAction();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("sort en 0 sur une défaillance PARTIELLE — pas un exit(0) figé qui masquerait aussi le cas ci-dessus", async () => {
+    vi.mocked(executeRun).mockResolvedValue(
+      runResult([agent("a1", 1), agent("a2", 0), agent("a3", 1), agent("a4", 0)]),
+    );
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    await runAction();
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+});

--- a/tests/unit/self-update-cli.test.ts
+++ b/tests/unit/self-update-cli.test.ts
@@ -1,0 +1,39 @@
+// tests/unit/self-update-cli.test.ts
+//
+// self-update-platform.test.ts covers unsupportedPlatformNotice() as a pure
+// decision, well isolated from I/O. But nothing verifies that
+// createSelfUpdateCommand()'s action actually CALLS it and exits 1 — deleting
+// that guard, or hardcoding a `process.exit(0)` in its place, leaves that
+// suite green (it never touches the command). This exercises the real action
+// closure instead of the decision function alone.
+//
+// Scoped to win32 on purpose: the guard fires before any network call, so
+// invoking the real action here is side-effect-free on Windows — no curl, no
+// gh, no filesystem writes. Off win32 the guard is a no-op (returns null) and
+// the action goes on to hit the network (fetchLatestTag) and spawn `mktemp`;
+// that's not something a unit test should do, and it's also not the behavior
+// under test here — so it's skipped rather than faked. The repo's CI matrix
+// (.github/workflows/test.yml) runs a windows-latest leg, so this still
+// executes for real in CI, not just in local dev on Windows.
+import { describe, it, expect, vi } from "vitest";
+import { createSelfUpdateCommand } from "../../cli/self-update.js";
+
+describe.skipIf(process.platform !== "win32")(
+  "essaim self-update — wiring de la garde Windows",
+  () => {
+    it("l'action appelle bien la garde et sort en 1, sans toucher au réseau", async () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await createSelfUpdateCommand().parseAsync([], { from: "user" });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("ne fonctionne pas sur Windows"),
+      );
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  },
+);


### PR DESCRIPTION
Les quatre findings mineurs différés par la revue de #133. Trois ne touchent que des tests ou la CI ; **le troisième est un vrai bug** qui réintroduisait par une autre porte la collision de worktrees que #133 venait d'éliminer.

## 3. `pipeline` partageait un identifiant de run entre ses étapes — bug réel

`ensureRunId` est idempotent et publie l'identifiant dans `process.env`, qui persiste pour toute la durée du processus. `cli/pipeline.ts` enchaîne ses étapes dans le **même** processus, et les identifiants d'agent sont déterministes.

Deux étapes du même template sur le même dépôt produisaient donc les mêmes noms de branche `mini-project-<runId>-<agentId>` — c'est-à-dire exactement la collision que le correctif de `workspace.ts` dans #133 venait de supprimer, revenue par le pipeline.

Chaque étape obtient maintenant son propre identifiant. Un identifiant fourni de l'extérieur — runner, CI, essaim parent — continue de primer sur toutes les étapes.

Reproduit en rouge avant correctif, et le relecteur l'a re-vérifié en restaurant le fichier d'origine.

## 2. Un test qui ne pouvait plus rien attraper

`report-thread-outcomes.test.ts` n'assertait que des **absences** — et ces absences portaient sur des libellés **anglais qui ne correspondent plus à rien** depuis deux renommages successifs. Supprimer les trois lignes de compteurs du rapport le laissait vert.

Il assert désormais positivement sur les libellés réels et leurs valeurs.

## 1. Deux correctifs testaient la décision, pas le câblage

`unsupportedPlatformNotice` et `runExitCode` sont des fonctions pures bien testées — mais rien ne vérifiait que l'action commander les **appelle**. Supprimer la garde, ou revenir à un `process.exit(0)` en dur, laissait les deux suites vertes.

Le test de `self-update` est borné à Windows via `skipIf` : il ne tourne donc que sur la jambe `windows-latest` de la CI, ajoutée par #133. Compromis assumé et visible, pas du théâtre.

## 4. Le garde-fou CI cherchait une option en sous-chaîne nue

Un futur `--preset-file` légitime aurait fait rougir la CI à tort. Motif resserré.

L'idée de vérifier contre les commandes réellement enregistrées a été **écartée avec preuve** : l'un des jetons est une option et non une sous-commande, un autre appartient à un binaire tiers, et une extraction générique produit des faux positifs sur la prose du README. Le garde-fou reste une liste de jetons connus — assumé et documenté en commentaire, pas silencieux.

## Vérification

- **770 tests au vert**, 75 fichiers, `tsc` propre
- Chaque correctif de code vérifié rouge avant, vert après ; le relecteur a re-testé la discrimination du finding 3 en restaurant le fichier d'origine
- Le job `no-domain-artifacts` vérifié **inchangé octet pour octet** — seule l'étape des commandes mortes bouge

## Réserve

Le `delete` de la variable d'environnement se fait au début de l'étape, donc **après** ses hooks `before` : un hook `before` verrait encore l'identifiant de l'étape précédente. Aucun usage de cette variable dans un hook n'existe aujourd'hui — angle mort signalé, pas bug actif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
