### PR TITLE
feat(orchestrator): le rapport peut enfin nommer les threads empoisonnés

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@swoofer/promptweave": "^0.5.1",
     "commander": "^14.0.3",
     "handlebars": "^4.7.0",
-    "mcp-coordinator": "^2.2.1",
+    "mcp-coordinator": "^2.3.0",
     "mqtt": "^5.15.0",
     "pino": "^10.3.1",
     "ws": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.9
       mcp-coordinator:
-        specifier: ^2.2.1
-        version: 2.2.1(@opentelemetry/api@1.9.1)(hono@4.13.3)
+        specifier: ^2.3.0
+        version: 2.3.0(@opentelemetry/api@1.9.1)(hono@4.13.3)
       mqtt:
         specifier: ^5.15.0
         version: 5.15.2
@@ -996,8 +996,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mcp-coordinator@2.2.1:
-    resolution: {integrity: sha512-F2cK3u9FXw68H1A6i1JqZQwVtK/A5gtGWTzytY8H6uGsU/wpRkGE5fx1Uu3qvv8Od1D/wp/bKFDe/lFn5lAuoA==}
+  mcp-coordinator@2.3.0:
+    resolution: {integrity: sha512-Q+ECCHfcDvnO2haokUtyrwva/YHxgJiTXW+JFlOsJKxJI+sqPuMF5anRyLcw/NxTfR1vojTmEUgMWyYorl06MA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -1173,6 +1173,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -2522,7 +2523,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-coordinator@2.2.1(@opentelemetry/api@1.9.1)(hono@4.13.3):
+  mcp-coordinator@2.3.0(@opentelemetry/api@1.9.1)(hono@4.13.3):
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
       '@modelcontextprotocol/core': 2.0.0

--- a/src/orchestrator/metrics.ts
+++ b/src/orchestrator/metrics.ts
@@ -1,5 +1,6 @@
 import type { CoordinatorMetrics } from "./types.js";
 import { authHeaders } from "../coordinator-auth.js";
+import { currentRunId } from "../run-id.js";
 
 export interface SseEvent {
   id: number;
@@ -305,7 +306,69 @@ export async function fetchCoordinatorMetrics(coordinatorUrl: string, sinceEvent
     }
   } catch {}
 
+  const runId = currentRunId();
+  if (runId) {
+    metrics.threads_final = await fetchThreadsSummary(coordinatorUrl, runId);
+  }
+
   return metrics;
+}
+
+/**
+ * Final, authoritative thread-status tally for this run, straight off the
+ * coordinator's DB (mcp-coordinator ≥2.3.0, POST /api/threads-summary).
+ *
+ * Everything else in this file is derived from a windowed SSE replay. This
+ * reads the DB directly instead, so it is the only source here that can see
+ * a 'poisoned' thread (handleUnclaimTask, unclaimed too many times) or a
+ * 'cancelled' one — both are a table UPDATE with no matching SSE event, and
+ * were structurally invisible to the rest of computeMetrics.
+ *
+ * `run_id` is required server-side (strict equality) so a run's summary
+ * can't be inflated by a concurrent session sharing the same coordinator —
+ * matches the scoping already used by work-stealing.ts and mqtt-listener.ts.
+ *
+ * Returns undefined — never throws — on anything short of a clean 200: an
+ * older coordinator that 404s (the route doesn't exist below 2.3.0), an
+ * unreachable one, or a malformed response. Callers fall back to the
+ * SSE-derived estimate, same fail-open posture as the rest of this file.
+ */
+export async function fetchThreadsSummary(
+  coordinatorUrl: string,
+  runId: string,
+): Promise<CoordinatorMetrics["threads_final"]> {
+  try {
+    const resp = await getWithBudget(
+      `${coordinatorUrl}/api/threads-summary`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders() },
+        body: JSON.stringify({ run_id: runId }),
+      },
+      2000,
+    );
+    if (!resp.ok) {
+      // 404 is the expected shape of "coordinator predates this route" — not
+      // worth warning about. Anything else (401, 500, ...) is unexpected
+      // enough to surface, same as the /api/events warning above.
+      if (resp.status !== 404) {
+        console.warn(`[metrics] /api/threads-summary → ${resp.status} — final thread state unavailable`);
+      }
+      return undefined;
+    }
+    const data = JSON.parse(resp.body) as { total?: number; counts?: Record<string, number> };
+    const c = data.counts ?? {};
+    return {
+      total: data.total ?? 0,
+      open: c.open ?? 0,
+      resolving: c.resolving ?? 0,
+      resolved: c.resolved ?? 0,
+      cancelled: c.cancelled ?? 0,
+      poisoned: c.poisoned ?? 0,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -92,13 +92,36 @@ export function writeReport(results: RunResult[], outputDir: string): string {
     md += `| Métrique | Valeur |\n|----------|--------|\n`;
     md += `| Durée | ${(r.duration_ms / 1000).toFixed(1)}s |\n`;
     md += `| Agents | ${r.coordinator_metrics.agents_count} |\n`;
-    md += `| Threads ouverts | ${r.coordinator_metrics.threads_opened} |\n`;
-    md += `| Consensus (approuvé par tous) | ${r.coordinator_metrics.threads_resolved_consensus} |\n`;
-    md += `| Auto-résolus (aucun agent concerné) | ${r.coordinator_metrics.threads_auto_resolved} |\n`;
-    md += `| Sans consensus (timeout, empoisonnés, abandonnés) | ${r.coordinator_metrics.threads_without_consensus} |\n`;
-    md += `| Messages | ${r.coordinator_metrics.messages_exchanged} |\n`;
-    md += `| Introspections | ${r.coordinator_metrics.introspections_triggered} |\n`;
-    md += `| Hot files | ${r.coordinator_metrics.hot_files.length} |\n`;
+    const cm = r.coordinator_metrics;
+    const finalState = cm.threads_final;
+    // finalState, when present, is the coordinator DB's own tally for this run
+    // (mcp-coordinator ≥2.3.0) — it replaces the SSE-windowed estimate for
+    // "Threads ouverts" and "Sans consensus" below. "Consensus" / "Auto-résolus"
+    // stay SSE-derived either way: resolution_type only exists on the
+    // thread_resolved event, not in this tally, which lumps every resolved
+    // thread together regardless of how it got there.
+    const threadsOpened = finalState ? finalState.total : cm.threads_opened;
+    const withoutConsensus = finalState
+      ? finalState.open + finalState.resolving + finalState.poisoned + finalState.cancelled +
+        // Whatever the DB calls "resolved" minus the two outcomes counted
+        // above is every other way a thread closed (timeout, max_rounds,
+        // closed, agent_departure). Clamped: consensus/auto-résolus aren't
+        // run-scoped the way finalState is, so a coordinator shared with a
+        // concurrent run could in principle make this subtraction negative.
+        Math.max(0, finalState.resolved - cm.threads_resolved_consensus - cm.threads_auto_resolved)
+      : cm.threads_without_consensus;
+
+    md += `| Threads ouverts | ${threadsOpened} |\n`;
+    md += `| Consensus (approuvé par tous) | ${cm.threads_resolved_consensus} |\n`;
+    md += `| Auto-résolus (aucun agent concerné) | ${cm.threads_auto_resolved} |\n`;
+    md += `| Sans consensus (timeout, empoisonnés, abandonnés) | ${withoutConsensus} |\n`;
+    md += `| Messages | ${cm.messages_exchanged} |\n`;
+    md += `| Introspections | ${cm.introspections_triggered} |\n`;
+    md += `| Hot files | ${cm.hot_files.length} |\n`;
+
+    if (finalState) {
+      md += `\n> État final (coordinator, faisant autorité) : ${finalState.open} ouvert(s), ${finalState.resolving} en résolution, ${finalState.poisoned} empoisonné(s), ${finalState.cancelled} annulé(s), ${finalState.resolved} résolu(s) au total.\n`;
+    }
 
     if (Object.keys(r.coordinator_metrics.conflicts_by_layer).length > 0) {
       md += `\n### Conflits par layer\n\n`;

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -94,22 +94,24 @@ export function writeReport(results: RunResult[], outputDir: string): string {
     md += `| Agents | ${r.coordinator_metrics.agents_count} |\n`;
     const cm = r.coordinator_metrics;
     const finalState = cm.threads_final;
-    // finalState, when present, is the coordinator DB's own tally for this run
-    // (mcp-coordinator ≥2.3.0) — it replaces the SSE-windowed estimate for
-    // "Threads ouverts" and "Sans consensus" below. "Consensus" / "Auto-résolus"
-    // stay SSE-derived either way: resolution_type only exists on the
-    // thread_resolved event, not in this tally, which lumps every resolved
-    // thread together regardless of how it got there.
+    // finalState, when present, is the coordinator DB's own tally for this
+    // run (mcp-coordinator ≥2.3.0), scoped by run_id server-side. Every
+    // number below it (threads_opened aside) comes from the SSE replay,
+    // which is windowed by event id but NOT scoped by run — see the
+    // docstring on fetchCoordinatorMetrics. "Threads ouverts" is a pure
+    // substitution — finalState.total answers the exact same question as
+    // threads_opened, just from a better source — so it's safe to replace.
+    // "Sans consensus" is NOT: subtracting the SSE-derived
+    // consensus/auto-résolus counts from a run-scoped finalState.resolved
+    // mixes an unscoped source into a scoped one. On a coordinator shared
+    // with a concurrent run, thread_resolved events belonging to THAT run
+    // can inflate the SSE counts past finalState.resolved, and clamping the
+    // result to 0 doesn't fix that — it erases real unresolved threads from
+    // the report, exactly the bug removed from metrics.ts (see the comment
+    // above computeMetrics). So this stays the SSE estimate unconditionally;
+    // the footnote below is what makes 'poisoned'/'cancelled' visible.
     const threadsOpened = finalState ? finalState.total : cm.threads_opened;
-    const withoutConsensus = finalState
-      ? finalState.open + finalState.resolving + finalState.poisoned + finalState.cancelled +
-        // Whatever the DB calls "resolved" minus the two outcomes counted
-        // above is every other way a thread closed (timeout, max_rounds,
-        // closed, agent_departure). Clamped: consensus/auto-résolus aren't
-        // run-scoped the way finalState is, so a coordinator shared with a
-        // concurrent run could in principle make this subtraction negative.
-        Math.max(0, finalState.resolved - cm.threads_resolved_consensus - cm.threads_auto_resolved)
-      : cm.threads_without_consensus;
+    const withoutConsensus = cm.threads_without_consensus;
 
     md += `| Threads ouverts | ${threadsOpened} |\n`;
     md += `| Consensus (approuvé par tous) | ${cm.threads_resolved_consensus} |\n`;

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -94,35 +94,28 @@ export function writeReport(results: RunResult[], outputDir: string): string {
     md += `| Agents | ${r.coordinator_metrics.agents_count} |\n`;
     const cm = r.coordinator_metrics;
     const finalState = cm.threads_final;
-    // finalState, when present, is the coordinator DB's own tally for this
-    // run (mcp-coordinator ≥2.3.0), scoped by run_id server-side. Every
-    // number below it (threads_opened aside) comes from the SSE replay,
-    // which is windowed by event id but NOT scoped by run — see the
-    // docstring on fetchCoordinatorMetrics. "Threads ouverts" is a pure
-    // substitution — finalState.total answers the exact same question as
-    // threads_opened, just from a better source — so it's safe to replace.
-    // "Sans consensus" is NOT: subtracting the SSE-derived
-    // consensus/auto-résolus counts from a run-scoped finalState.resolved
-    // mixes an unscoped source into a scoped one. On a coordinator shared
-    // with a concurrent run, thread_resolved events belonging to THAT run
-    // can inflate the SSE counts past finalState.resolved, and clamping the
-    // result to 0 doesn't fix that — it erases real unresolved threads from
-    // the report, exactly the bug removed from metrics.ts (see the comment
-    // above computeMetrics). So this stays the SSE estimate unconditionally;
-    // the footnote below is what makes 'poisoned'/'cancelled' visible.
-    const threadsOpened = finalState ? finalState.total : cm.threads_opened;
-    const withoutConsensus = cm.threads_without_consensus;
-
-    md += `| Threads ouverts | ${threadsOpened} |\n`;
+    // The table stays entirely SSE-derived — one source, one window, rows
+    // that add up against each other. finalState (mcp-coordinator ≥2.3.0,
+    // scoped by run_id server-side) answers a DIFFERENT question than the
+    // SSE replay (windowed by event id, NOT scoped by run — see the
+    // docstring on fetchCoordinatorMetrics) and the two must never share a
+    // row: mixing "Threads ouverts" from finalState with "Consensus" from
+    // SSE let a coordinator shared with a concurrent run print a total
+    // smaller than the consensus count it's supposed to contain — the same
+    // class of silent contradiction already ruled out for "Sans consensus".
+    // finalState surfaces only in the footnote below, clearly labeled as a
+    // separate, authoritative source — that's what makes 'poisoned' and
+    // 'cancelled' visible, and it needs nothing from the table to do it.
+    md += `| Threads ouverts | ${cm.threads_opened} |\n`;
     md += `| Consensus (approuvé par tous) | ${cm.threads_resolved_consensus} |\n`;
     md += `| Auto-résolus (aucun agent concerné) | ${cm.threads_auto_resolved} |\n`;
-    md += `| Sans consensus (timeout, empoisonnés, abandonnés) | ${withoutConsensus} |\n`;
+    md += `| Sans consensus (timeout, empoisonnés, abandonnés) | ${cm.threads_without_consensus} |\n`;
     md += `| Messages | ${cm.messages_exchanged} |\n`;
     md += `| Introspections | ${cm.introspections_triggered} |\n`;
     md += `| Hot files | ${cm.hot_files.length} |\n`;
 
     if (finalState) {
-      md += `\n> État final (coordinator, faisant autorité) : ${finalState.open} ouvert(s), ${finalState.resolving} en résolution, ${finalState.poisoned} empoisonné(s), ${finalState.cancelled} annulé(s), ${finalState.resolved} résolu(s) au total.\n`;
+      md += `\n> État final (coordinator, faisant autorité) : ${finalState.total} thread(s) au total — ${finalState.open} ouvert(s), ${finalState.resolving} en résolution, ${finalState.poisoned} empoisonné(s), ${finalState.cancelled} annulé(s), ${finalState.resolved} résolu(s).\n`;
     }
 
     if (Object.keys(r.coordinator_metrics.conflicts_by_layer).length > 0) {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -97,6 +97,21 @@ export interface CoordinatorMetrics {
   introspections_concerned: number;
   avg_resolution_time_ms: number;
   hot_files: string[];
+  // Final, authoritative thread-status tally for this run, straight off the
+  // coordinator's DB (mcp-coordinator ≥2.3.0, POST /api/threads-summary).
+  // Unlike every field above — all derived from a windowed SSE replay — this
+  // sees 'poisoned' (unclaimed too many times) and 'cancelled' threads,
+  // neither of which ever emits an event. Absent on an older coordinator
+  // (404), an unreachable one, or when run scoping is disabled (no run_id):
+  // the reporter then falls back to the SSE-derived estimate above.
+  threads_final?: {
+    total: number;
+    open: number;
+    resolving: number;
+    resolved: number;
+    cancelled: number;
+    poisoned: number;
+  };
 }
 
 export interface RunResult {

--- a/tests/unit/report-counters.test.ts
+++ b/tests/unit/report-counters.test.ts
@@ -152,6 +152,74 @@ describe('fetchCoordinatorMetrics — scoping the SSE cursor to this run (#108)'
   });
 });
 
+// threads-summary (mcp-coordinator 2.3.0) — l'état final réel des threads,
+// que la fenêtre SSE ne peut pas voir : un thread 'poisoned' (trop de
+// unclaims) ou 'cancelled' est une UPDATE de table, jamais un événement.
+describe('fetchCoordinatorMetrics — état final des threads (threads-summary, mcp-coordinator 2.3.0)', () => {
+  afterEach(() => { delete process.env.ESSAIM_RUN_ID; });
+
+  it('interroge /api/threads-summary avec le run_id courant et peuple threads_final', async () => {
+    process.env.ESSAIM_RUN_ID = 'run-99';
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.includes('/api/threads-summary')) {
+        return new Response(JSON.stringify({
+          run_id: 'run-99', total: 6,
+          counts: { open: 1, resolving: 0, resolved: 3, cancelled: 0, poisoned: 2 },
+        }), { status: 200 });
+      }
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+
+    expect(metrics.threads_final).toEqual({ total: 6, open: 1, resolving: 0, resolved: 3, cancelled: 0, poisoned: 2 });
+    const call = fetchMock.mock.calls.find(([url]) => (url as string).includes('/api/threads-summary'));
+    expect(call).toBeDefined();
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body.run_id).toBe('run-99');
+  });
+
+  it("sans run_id, ne tente même pas la requête (le coordinateur la refuserait de toute façon: run_id requis)", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+
+    expect(metrics.threads_final).toBeUndefined();
+    expect(fetchMock.mock.calls.some(([url]) => (url as string).includes('/api/threads-summary'))).toBe(false);
+  });
+
+  // Le cas de robustesse qui compte le plus : un coordinateur plus ancien que
+  // 2.3.0 n'a pas cette route et répond 404 — le run ne doit ni échouer ni
+  // voir son rapport pollué, juste se replier sur les compteurs SSE connus.
+  it('se replie proprement quand le coordinateur ne connaît pas la route (404, coordinateur < 2.3.0)', async () => {
+    process.env.ESSAIM_RUN_ID = 'run-42';
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.includes('/api/threads-summary')) return new Response('not found', { status: 404 });
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+
+    expect(metrics.threads_final).toBeUndefined();
+    expect(metrics.threads_opened).toBe(0);
+  });
+
+  it('se replie proprement quand le coordinateur est injoignable', async () => {
+    process.env.ESSAIM_RUN_ID = 'run-42';
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.includes('/api/threads-summary')) throw new Error('ECONNREFUSED');
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const metrics = await fetchCoordinatorMetrics('https://coordinator.test');
+    expect(metrics.threads_final).toBeUndefined();
+  });
+});
+
 describe('fetchLatestEventId (#108)', () => {
   it('captures the max event id currently buffered by the coordinator', async () => {
     const sse = [

--- a/tests/unit/report-thread-outcomes.test.ts
+++ b/tests/unit/report-thread-outcomes.test.ts
@@ -66,16 +66,16 @@ describe("writeReport — le tableau ne promet plus un accord qu'il n'a pas mesu
 });
 
 // mcp-coordinator 2.3.0 — POST /api/threads-summary renvoie l'état FINAL des
-// threads, faisant autorité et scopé par run_id côté serveur (là où tout ce
-// qui précède est dérivé d'une fenêtre d'événements SSE non scopée par run —
-// voir le docstring de fetchCoordinatorMetrics). Quand il est disponible, il
-// remplace l'estimation pour "Threads ouverts" — une substitution pure,
-// finalState.total répondant à la même question que threads_opened depuis
-// une meilleure source. "Sans consensus" reste l'estimation SSE : la mélanger
-// avec finalState.resolved reviendrait à soustraire un compteur non scopé
-// (consensus/auto-résolus) d'un total scopé, ce qui peut s'effacer
-// silencieusement sur un coordinateur partagé (round 1, finding critique).
-describe("writeReport — état final du coordinator (threads-summary) remplace l'estimation quand disponible", () => {
+// threads, faisant autorité et scopé par run_id côté serveur (là où tout le
+// tableau reste dérivé d'une fenêtre d'événements SSE non scopée par run —
+// voir le docstring de fetchCoordinatorMetrics). Les deux sources répondent
+// à des questions différentes et ne doivent JAMAIS partager une ligne du
+// tableau : mélanger même un seul champ (round 2, finding critique) suffit
+// à faire imprimer un "Threads ouverts" inférieur à son propre "Consensus".
+// Le tableau reste donc entièrement SSE ; threads_final ne sert que dans la
+// ligne de note distincte, qui suffit à elle seule à rendre 'poisoned' et
+// 'cancelled' visibles.
+describe("writeReport — état final du coordinator (threads-summary) reste hors du tableau", () => {
   function runAvecEtatFinal(): RunResult {
     const base = runReel();
     // total(9) = open(0) + resolving(0) + resolved(2) + cancelled(1) + poisoned(6).
@@ -85,19 +85,17 @@ describe("writeReport — état final du coordinator (threads-summary) remplace 
     return base;
   }
 
-  it("remplace « Threads ouverts » par le total réel, sans toucher « Sans consensus » ni contredire Consensus", () => {
+  it("le tableau reste celui du SSE (threads_opened, pas finalState.total) même quand l'état final est disponible", () => {
     dir = mkdtempSync(join(tmpdir(), "rep-outcomes-final-"));
     const md = readFileSync(writeReport([runAvecEtatFinal()], dir), "utf8");
 
-    // 9 (le total réel du coordinator), pas 4 (le compte SSE fenêtré de runReel()).
-    expect(md).toContain("| Threads ouverts | 9 |");
+    // 4 (threads_opened, la source SSE de runReel()), pas 9 (finalState.total).
+    expect(md).toContain("| Threads ouverts | 4 |");
     expect(md).toContain("| Consensus (approuvé par tous) | 2 |");
-    // threads_without_consensus reste celui de runReel() (4) — l'estimation
-    // SSE, inchangée par la présence de threads_final.
     expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
   });
 
-  it("rend le statut 'poisoned' visible — jusqu'ici structurellement invisible au rapport", () => {
+  it("rend le statut 'poisoned' visible dans la ligne de note — jusqu'ici structurellement invisible au rapport", () => {
     dir = mkdtempSync(join(tmpdir(), "rep-outcomes-final-"));
     const md = readFileSync(writeReport([runAvecEtatFinal()], dir), "utf8");
 
@@ -127,5 +125,26 @@ describe("writeReport — état final du coordinator (threads-summary) remplace 
 
     expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
     expect(md).not.toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 1 |");
+  });
+
+  // Finding critique (round 2) : "Threads ouverts" était substitué par
+  // finalState.total alors que "Consensus" restait SSE — deux sources dans
+  // la même ligne de présentation. Réutilise le scénario de contamination :
+  // finalState.total(3) tombe sous le Consensus SSE de CE run (9). L'ancien
+  // calcul aurait imprimé "Threads ouverts 3" à côté de "Consensus 9" — un
+  // total plus petit que le compteur qu'il est censé contenir. threads_opened
+  // (10) est ici cohérent avec son propre Consensus (9) : même source, donc
+  // pas de contradiction — ce que finalState.total(3) aurait cassé.
+  it("« Threads ouverts » vient du SSE, jamais de threads_final : le tableau ne contredit jamais son propre Consensus", () => {
+    const base = runReel();
+    base.coordinator_metrics.threads_opened = 10;
+    base.coordinator_metrics.threads_resolved_consensus = 9;
+    base.coordinator_metrics.threads_final = { total: 3, open: 1, resolving: 0, resolved: 2, cancelled: 0, poisoned: 0 };
+
+    dir = mkdtempSync(join(tmpdir(), "rep-outcomes-nomix-"));
+    const md = readFileSync(writeReport([base], dir), "utf8");
+
+    expect(md).toContain("| Threads ouverts | 10 |");
+    expect(md).not.toContain("| Threads ouverts | 3 |");
   });
 });

--- a/tests/unit/report-thread-outcomes.test.ts
+++ b/tests/unit/report-thread-outcomes.test.ts
@@ -64,3 +64,39 @@ describe("writeReport — le tableau ne promet plus un accord qu'il n'a pas mesu
     expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
   });
 });
+
+// mcp-coordinator 2.3.0 — POST /api/threads-summary renvoie l'état FINAL des
+// threads, faisant autorité (là où tout ce qui précède est dérivé d'une
+// fenêtre d'événements SSE). Quand il est disponible, il remplace l'estimation
+// pour "Threads ouverts" et "Sans consensus" — sans jamais contredire
+// "Consensus", qui reste sa seule vraie source (resolution_type n'existe que
+// sur thread_resolved, pas dans ce tally).
+describe("writeReport — état final du coordinator (threads-summary) remplace l'estimation quand disponible", () => {
+  function runAvecEtatFinal(): RunResult {
+    const base = runReel();
+    // total(9) = open(0) + resolving(0) + resolved(2) + cancelled(1) + poisoned(6).
+    base.coordinator_metrics.threads_final = { total: 9, open: 0, resolving: 0, resolved: 2, cancelled: 1, poisoned: 6 };
+    base.coordinator_metrics.threads_resolved_consensus = 2;
+    base.coordinator_metrics.threads_auto_resolved = 0;
+    return base;
+  }
+
+  it("remplace « Threads ouverts » et « Sans consensus » par le compte réel, sans contredire Consensus", () => {
+    dir = mkdtempSync(join(tmpdir(), "rep-outcomes-final-"));
+    const md = readFileSync(writeReport([runAvecEtatFinal()], dir), "utf8");
+
+    // 9 (le total réel du coordinator), pas 4 (le compte SSE fenêtré de runReel()).
+    expect(md).toContain("| Threads ouverts | 9 |");
+    expect(md).toContain("| Consensus (approuvé par tous) | 2 |");
+    // open(0) + resolving(0) + poisoned(6) + cancelled(1) + (resolved(2) - consensus(2) - auto(0)) = 7
+    expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 7 |");
+  });
+
+  it("rend le statut 'poisoned' visible — jusqu'ici structurellement invisible au rapport", () => {
+    dir = mkdtempSync(join(tmpdir(), "rep-outcomes-final-"));
+    const md = readFileSync(writeReport([runAvecEtatFinal()], dir), "utf8");
+
+    expect(md).toMatch(/empoisonné/i);
+    expect(md).toMatch(/6/);
+  });
+});

--- a/tests/unit/report-thread-outcomes.test.ts
+++ b/tests/unit/report-thread-outcomes.test.ts
@@ -66,11 +66,15 @@ describe("writeReport — le tableau ne promet plus un accord qu'il n'a pas mesu
 });
 
 // mcp-coordinator 2.3.0 — POST /api/threads-summary renvoie l'état FINAL des
-// threads, faisant autorité (là où tout ce qui précède est dérivé d'une
-// fenêtre d'événements SSE). Quand il est disponible, il remplace l'estimation
-// pour "Threads ouverts" et "Sans consensus" — sans jamais contredire
-// "Consensus", qui reste sa seule vraie source (resolution_type n'existe que
-// sur thread_resolved, pas dans ce tally).
+// threads, faisant autorité et scopé par run_id côté serveur (là où tout ce
+// qui précède est dérivé d'une fenêtre d'événements SSE non scopée par run —
+// voir le docstring de fetchCoordinatorMetrics). Quand il est disponible, il
+// remplace l'estimation pour "Threads ouverts" — une substitution pure,
+// finalState.total répondant à la même question que threads_opened depuis
+// une meilleure source. "Sans consensus" reste l'estimation SSE : la mélanger
+// avec finalState.resolved reviendrait à soustraire un compteur non scopé
+// (consensus/auto-résolus) d'un total scopé, ce qui peut s'effacer
+// silencieusement sur un coordinateur partagé (round 1, finding critique).
 describe("writeReport — état final du coordinator (threads-summary) remplace l'estimation quand disponible", () => {
   function runAvecEtatFinal(): RunResult {
     const base = runReel();
@@ -81,15 +85,16 @@ describe("writeReport — état final du coordinator (threads-summary) remplace 
     return base;
   }
 
-  it("remplace « Threads ouverts » et « Sans consensus » par le compte réel, sans contredire Consensus", () => {
+  it("remplace « Threads ouverts » par le total réel, sans toucher « Sans consensus » ni contredire Consensus", () => {
     dir = mkdtempSync(join(tmpdir(), "rep-outcomes-final-"));
     const md = readFileSync(writeReport([runAvecEtatFinal()], dir), "utf8");
 
     // 9 (le total réel du coordinator), pas 4 (le compte SSE fenêtré de runReel()).
     expect(md).toContain("| Threads ouverts | 9 |");
     expect(md).toContain("| Consensus (approuvé par tous) | 2 |");
-    // open(0) + resolving(0) + poisoned(6) + cancelled(1) + (resolved(2) - consensus(2) - auto(0)) = 7
-    expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 7 |");
+    // threads_without_consensus reste celui de runReel() (4) — l'estimation
+    // SSE, inchangée par la présence de threads_final.
+    expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
   });
 
   it("rend le statut 'poisoned' visible — jusqu'ici structurellement invisible au rapport", () => {
@@ -98,5 +103,29 @@ describe("writeReport — état final du coordinator (threads-summary) remplace 
 
     expect(md).toMatch(/empoisonné/i);
     expect(md).toMatch(/6/);
+  });
+
+  // Finding critique (round 1) : un calcul antérieur faisait
+  // `Math.max(0, finalState.resolved - consensus - autoResolved)`, mélangeant
+  // le tally run-scopé de threads_final avec des compteurs SSE NON scopés par
+  // run. Sur un coordinateur partagé, un thread_resolved d'un run CONCURRENT
+  // peut gonfler consensus/auto-résolus bien au-delà de finalState.resolved —
+  // reproduit ici en donnant à la base un total de seulement 3 threads pour
+  // CE run, contre un compteur SSE de consensus à 9. L'ancien calcul aurait
+  // donné 1 + 0 + 0 + 0 + max(0, 2 - 9 - 0) = 1 : un nombre plus petit et
+  // faux qui efface silencieusement les vrais threads sans consensus — le
+  // même bug que celui déjà corrigé dans metrics.ts (voir computeMetrics).
+  it("des compteurs SSE dépassant le total de la base n'effacent pas « Sans consensus »", () => {
+    const base = runReel();
+    base.coordinator_metrics.threads_resolved_consensus = 9;
+    base.coordinator_metrics.threads_auto_resolved = 0;
+    base.coordinator_metrics.threads_without_consensus = 4; // estimation SSE réelle
+    base.coordinator_metrics.threads_final = { total: 3, open: 1, resolving: 0, resolved: 2, cancelled: 0, poisoned: 0 };
+
+    dir = mkdtempSync(join(tmpdir(), "rep-outcomes-contam-"));
+    const md = readFileSync(writeReport([base], dir), "utf8");
+
+    expect(md).toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 4 |");
+    expect(md).not.toContain("| Sans consensus (timeout, empoisonnés, abandonnés) | 1 |");
   });
 });


### PR DESCRIPTION
Boucle le dernier point resté ouvert : le rapport de run peut enfin nommer les threads **empoisonnés**. Consomme la route `POST /api/threads-summary` livrée par [mcp-coordinator#442](https://github.com/swoofer/mcp-coordinator/pull/442) et publiée en 2.3.0.

## Le manque

Le rapport comptait des **événements** SSE, jamais l'état **final** des threads. Le statut `poisoned` — posé quand un thread est dé-réclamé trop souvent — et `cancelled` n'émettent **aucun événement** : ce sont des mises à jour de table pures, structurellement invisibles au flux.

Sur un run mesuré, la base montrait 9 threads abandonnés et 6 « résolus par timeout » — zéro accord réel — pendant que le rapport annonçait « Consensus 4 ».

## Le fait qui a décidé de la conception

En vérifiant la source réelle de 2.3.0 plutôt que sa documentation : en base, `status='resolved'` **amalgame** consensus, auto-résolution, timeout, dépassement de tours, fermeture et départ d'agent. La colonne ne porte aucun type de résolution — celui-ci n'existe que dans le payload de l'événement, jamais persisté.

Les deux sources répondent donc à des questions **différentes** :

| | ce qu'elle seule sait dire |
|---|---|
| **SSE** | *lesquels* ont eu un vrai consensus plutôt qu'une auto-résolution |
| **Base (nouvelle route)** | le décompte final **exhaustif**, `poisoned` et `cancelled` compris |

D'où la mise en forme : **le tableau reste entièrement SSE**, cohérent avec lui-même — une source, une fenêtre, des lignes qui s'additionnent. Et une **ligne de note distincte** porte l'état final de la base, explicitement étiquetée comme faisant autorité, où `poisoned` et `cancelled` sont nommés.

## Deux rounds de correction, sur le même piège

Les deux premières versions mélangeaient les sources, chacune à sa manière :

1. **Arithmétiquement** — soustraire des compteurs SSE **non scopés par run** d'un total base **scopé par run**, puis borner le négatif à zéro. C'est exactement le défaut du clamp-qui-efface que ce dépôt venait de supprimer de `metrics.ts` (« didn't only guard against a negative — it ERASED »), rouvert dans `reporter.ts`.
2. **Dans le tableau** — « Threads ouverts » tiré de la base à côté d'un « Consensus » tiré du SSE. Sur un coordinator partagé, le rapport pouvait afficher un total **inférieur** à son propre compteur de consensus.

Le second avait été classé « préexistant » par la re-revue. Vérifié : sur `main`, cette ligne lisait la même source SSE que les autres — le tableau était cohérent. C'est bien cette branche qui introduisait la divergence.

Les deux ont un test qui **échoue** si on les réintroduit, construit sur un scénario de contamination réel (total base 3, consensus SSE 9).

## Robustesse

Un coordinator antérieur à 2.3.0 renvoie 404 : traité comme attendu et silencieux, `finalState` reste indéfini, la ligne de note ne s'affiche pas, et le tableau retombe **à l'identique** sur l'état d'avant cette branche — comparé champ par champ. Tout autre code non-ok journalise un avertissement, comme le chemin `/api/events` voisin. Coordinator injoignable : même repli.

Le repli est couvert par des tests dédiés (404, injoignable, absence de `run_id`).

## Vérification

- **778 tests au vert**, 75 fichiers, `tsc` propre
- Chaque round de correction vérifié rouge avant, vert après, en restaurant la version précédente du fichier
- Aucune assertion affaiblie pour faire passer un test : le seul nombre modifié reflète le comportement corrigé

## Réserve

Le nombre « Sans consensus » du tableau (SSE) peut structurellement diverger de `poisoned + cancelled` lus dans la ligne de note (base). C'est voulu et documenté : ils ne mesurent pas la même chose sur la même fenêtre. La note dit laquelle fait autorité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
