### PR TITLE
test(orchestrator): timeout explicite sur le cas au chemin destructif

### DIFF
--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -462,7 +462,14 @@ describe("runProject — resetBase authorization", () => {
 
     expect(launchAgentLoop).toHaveBeenCalledTimes(1);
     expect(result.agent_results).toHaveLength(1);
-  });
+    // Timeout explicite : ce cas est le seul à exercer le chemin destructif
+    // (`git checkout -- . && git clean -fd`) EN PLUS de créer un worktree, donc
+    // le plus gourmand en sous-processus git du fichier. Mesuré à 4,4 s en
+    // local, il a dépassé les 30 s du timeout global sur un runner
+    // windows-latest chargé — le premier run de la matrice Windows sur `main`,
+    // pendant que quatre compilations de binaires tournaient en parallèle.
+    // Mocker git rendrait le test rapide en supprimant ce qu'il vérifie.
+  }, 120_000);
 
   it("does not throw when ESSAIM_RESET_BASE is unset, even with workspace.base omitted (no regression)", async () => {
     delete process.env.ESSAIM_RESET_BASE;


### PR DESCRIPTION
Le premier run de la **matrice Windows sur `main`** — celle ajoutée en 0.13.1 — est parti rouge. C'est exactement le point de contrôle que j'avais signalé comme non encore vérifié : jusqu'ici la jambe Windows n'avait tourné que sur des PR et des branches de release.

## Ce qui s'est passé

`Error: Test timed out in 30000ms.` sur `tests/unit/orchestrator-run.test.ts`, cas `proceeds when the variable names exactly the run's base`.

Le même commit était **vert sur la PR #136**. La différence : le run de release exécutait quatre compilations de binaires en parallèle. C'est la charge du runner, pas une régression.

## Vérifié plutôt que supposé

Reproduit en local sur Windows — la même plateforme : **4,4 s, vert**. Le test n'est pas structurellement lent.

Il est en revanche le plus gourmand en sous-processus git du fichier : le seul à exercer le chemin destructif `git checkout -- . && git clean -fd` **en plus** de créer un worktree.

## Pourquoi un timeout et pas une réécriture

Mocker git rendrait le test rapide en supprimant précisément ce qu'il vérifie : que la remise à zéro destructive s'exécute bien, et seulement sur le chemin autorisé. Ce test garde un mécanisme qui **efface des fichiers** — c'est le dernier qu'on veut rendre complaisant.

120 s, dans la convention du fichier, qui porte déjà deux timeouts explicites à 20 s sur ses cas lents.

## Vérification

778 tests au vert, 75 fichiers, `tsc` propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)