### PR TITLE
fix(work-stealing): le garde-fou « un agent par fichier » n'a jamais rien bloqué

### DIFF
--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -17,9 +17,28 @@ export interface Task {
   relatedDone?: string[];
 }
 
+// target_files est stocké côté coordinator via JSON.stringify dans une colonne
+// TEXT (database.js), et consultation.js#listThreads renvoie les lignes SQLite
+// brutes sans désérialisation : /api/threads-active le livre donc en CHAÎNE
+// JSON, jamais en tableau. Un Array.isArray dessus était toujours faux, ce qui
+// rendait threadFiles() constamment vide et computeBusyFiles() — le garde-fou
+// « un seul agent par fichier » (#30) — inopérant depuis son introduction.
+// Même remède que parseTargetModules dans mqtt-listener.ts (#98) : le tableau
+// reste accepté au cas où un appelant le fournirait déjà décodé, une chaîne
+// illisible dégrade vers "aucun fichier connu" plutôt que de jeter.
 function threadFiles(thread: Record<string, unknown>): string[] {
   const files = thread.target_files;
-  return Array.isArray(files) ? (files as string[]).filter((f) => typeof f === "string" && f) : [];
+  const arr = Array.isArray(files) ? files : typeof files === "string" ? safeParseArray(files) : [];
+  return arr.filter((f): f is string => typeof f === "string" && f.length > 0);
+}
+
+function safeParseArray(raw: string): unknown[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 const DISCOVERY_MARKER = "DISCOVERY:";

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -77,6 +77,36 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
     expect(task?.id).toBe('t2');
   });
 
+  it('le coordinator renvoie target_files en JSON stringifié (pas un tableau) — le garde-fou doit quand même bloquer', async () => {
+    // Preuve de bout en bout du défaut : database.js stocke target_files en
+    // colonne TEXT via JSON.stringify, et consultation.js#listThreads renvoie
+    // les lignes SQLite brutes sans désérialisation. /api/threads-active livre
+    // donc une CHAÎNE JSON, jamais un tableau — exactement ce que ce fixture
+    // reproduit, à la différence des autres cas de ce fichier.
+    const fetchMock = mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: 'hunter-1', target_files: '["src/report.ts"]' },
+      { id: 't2', status: 'open', claimed_by: null, target_files: '["src/report.ts"]' },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task).toBeNull();
+    const claimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/claim-task'));
+    expect(claimed).toHaveLength(0); // on n'a même pas tenté
+  });
+
+  it('une chaîne target_files malformée dégrade vers "aucun fichier connu" sans jeter', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: 'hunter-1', target_files: '{not json' },
+      { id: 't2', status: 'open', claimed_by: null, target_files: '["src/csv.ts"]' },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t2'); // t1 illisible n'exclut aucun fichier, ne bloque pas t2
+  });
+
   it('remonte le travail DÉJÀ résolu sur le même fichier — de quoi marquer DUP au lieu de recommiter', async () => {
     vi.stubGlobal('fetch', mockCoordinator([
       {


### PR DESCRIPTION
Cause racine de la redondance mesurée sur un run réel : **4 défauts dans 4 fichiers distincts, mais 11 corrections tentées** — trois agents convergeant sur le même fichier. Redondance de 2,75×.

## Le défaut

`threadFiles()` testait `Array.isArray(thread.target_files)`. Or le coordinator ne renvoie jamais un tableau :

1. `database.js` — la colonne est `target_files TEXT DEFAULT '[]'`
2. insertion via `JSON.stringify(...)`
3. `listThreads` se termine par `return db.prepare(sql).all(...)` — les **lignes brutes**, sans désérialisation
4. `/api/threads-active` les relaie telles quelles

La valeur arrive donc en **chaîne JSON**, `Array.isArray` est faux, et la fonction rendait **toujours `[]`**.

Elle alimente `computeBusyFiles()`, le garde-fou de l'issue #30. Celui-ci **n'a donc jamais rien bloqué depuis son introduction**.

## Pourquoi la suite de tests ne l'a jamais vu

Toutes les fixtures de `claim-dedup.test.ts` passaient de vrais tableaux — la forme que le coordinator ne produit pas. Le test vérifiait un chemin qui n'existe pas en production.

## Le dépôt s'était déjà fait mordre

`mqtt-listener.ts` porte **déjà** un `parseTargetModules` pour exactement cette classe de bug sur un champ voisin (régression #98). La leçon avait été apprise là, et jamais appliquée ici. Le correctif suit ce patron.

## Vérification

- Le test passe `target_files` sous forme de **chaîne JSON**, comme le coordinator le renvoie. Le relecteur a rejoué l'ancienne implémentation sur cette fixture pour confirmer qu'il échoue avant le patch.
- Une chaîne malformée dégrade vers « aucun fichier connu » sans jeter — le garde-fou ne doit pas faire tomber la boucle d'agent.
- Les autres champs entrants ont été audités : `depends_on_files`, `exports_affected`, `expected_respondents` n'apparaissent que dans des corps de requête sortants ; le `target_modules` entrant est déjà couvert.
- **780 tests au vert**, `tsc` propre.

## Ce que ça éclaire

La « fenêtre de claim » avait été laissée en suspens dans le plan de stabilité, faute de preuve qu'elle serve encore. La preuve est là — mais la cause n'était pas la fenêtre de course : c'était ce garde-fou inerte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)