### PR TITLE
fix(work-stealing): rétrécir la fenêtre de course sur les fichiers, après un claim réussi

### DIFF
--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -169,6 +169,56 @@ function computeBusyFiles(openThreads: Array<Record<string, unknown>>, agentId: 
   return busyFiles;
 }
 
+// Résiduel de la fenêtre TOCTOU (#140) : au démarrage parallèle, les N
+// instantanés précèdent structurellement les N claims, donc computeBusyFiles()
+// ci-dessus ne peut rien voir au premier tour — deux agents peuvent chacun
+// réussir un claim atomique (claim-task est atomique PAR THREAD, jamais par
+// fichier) sur deux threads distincts qui ciblent le même fichier. Après un
+// claim RÉUSSI, on re-vérifie une fois : si un pair détient déjà un claim
+// ouvert sur un de nos fichiers, l'un des deux doit céder.
+//
+// Les deux agents évaluent ça indépendamment, sans se parler — le critère
+// doit donc être une fonction pure des données que les deux côtés voient
+// déjà identiques. L'horodatage a été écarté : les horloges dérivent et les
+// requêtes courent, donc les deux agents peuvent chacun se croire "arrivé
+// premier". Le thread_id n'a ni défaut : claim-task le distribue déjà unique
+// (clé primaire côté coordinator) et strictement identique quel que soit qui
+// le lit — l'ordonner (comparaison lexicographique de chaîne) donne donc aux
+// deux agents la même réponse sans le moindre message échangé. Celui qui NE
+// détient PAS le plus petit id parmi les threads en conflit cède : cette
+// règle ne peut jamais désigner les deux camps gagnants (elle est stricte),
+// ni les deux perdants (l'un des deux id est forcément strictement plus
+// petit) — donc jamais de double-cession, jamais de double-rétention, pour
+// peu que les deux refetch post-claim voient bien les deux claims (résiduel
+// documenté en bas de fichier : un refetch qui course en avance de la course
+// adverse peut encore rater le conflit — fenêtre rétrécie, pas fermée).
+async function resolveFileConflict(
+  coordinatorUrl: string,
+  agentId: string,
+  threadId: string,
+  files: string[],
+): Promise<{ won: boolean; openThreads: Array<Record<string, unknown>> | null }> {
+  if (files.length === 0) return { won: true, openThreads: null };
+
+  const refreshed = await fetchActiveThreads(coordinatorUrl);
+  if (refreshed === null) {
+    // Coordinator injoignable juste après notre propre claim : dégrade vers
+    // le comportement actuel (on garde) plutôt que de perdre un travail déjà
+    // confirmé sur la seule base d'un aller-retour qui a échoué.
+    return { won: true, openThreads: null };
+  }
+
+  const open = refreshed.filter((t) => t.status === "open");
+  const rivals = open.filter((t) => {
+    const owner = t.claimed_by as string | null | undefined;
+    return owner && owner !== agentId && t.id !== threadId && threadFiles(t).some((f) => files.includes(f));
+  });
+  if (rivals.length === 0) return { won: true, openThreads: open };
+
+  const smallestRivalId = rivals.map((t) => t.id as string).sort()[0];
+  return { won: threadId < smallestRivalId, openThreads: open };
+}
+
 /**
  * Atomically claim the next available task from the coordinator.
  * Uses POST /api/claim-task which does UPDATE WHERE claimed_by IS NULL.
@@ -226,6 +276,13 @@ export async function claimNextTask(
         agent_id: agentId,
       });
       if ((result as Record<string, unknown>).success === true) {
+        const { won, openThreads } = await resolveFileConflict(coordinatorUrl, agentId, threadId, files);
+        if (!won) {
+          log.info(`ceding thread=${threadId} — pair holds a lexicographically prior claim on ${files.join(", ")}`);
+          await unclaimTask(coordinatorUrl, threadId, agentId);
+          if (openThreads !== null) busyFiles = computeBusyFiles(openThreads, agentId);
+          continue;
+        }
         log.info(`claimed thread=${threadId}: ${subject.slice(0, 80)}`);
         const relatedDone = files.flatMap((f) => doneByFile.get(f) ?? []);
         if (relatedDone.length > 0) {

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -184,14 +184,25 @@ function computeBusyFiles(openThreads: Array<Record<string, unknown>>, agentId: 
 // premier". Le thread_id n'a ni défaut : claim-task le distribue déjà unique
 // (clé primaire côté coordinator) et strictement identique quel que soit qui
 // le lit — l'ordonner (comparaison lexicographique de chaîne) donne donc aux
-// deux agents la même réponse sans le moindre message échangé. Celui qui NE
-// détient PAS le plus petit id parmi les threads en conflit cède : cette
-// règle ne peut jamais désigner les deux camps gagnants (elle est stricte),
-// ni les deux perdants (l'un des deux id est forcément strictement plus
-// petit) — donc jamais de double-cession, jamais de double-rétention, pour
-// peu que les deux refetch post-claim voient bien les deux claims (résiduel
-// documenté en bas de fichier : un refetch qui course en avance de la course
-// adverse peut encore rater le conflit — fenêtre rétrécie, pas fermée).
+// deux agents la même réponse sans le moindre message échangé.
+//
+// Ce que la comparaison garantit vraiment — et ce qu'elle ne garantit PAS :
+// SI un agent voit au moins un rival au refetch, la règle est stricte
+// (thread_id le plus petit gagne) donc JAMAIS DOUBLE-CESSION : deux agents
+// en conflit direct calculent le même couple d'id, obtiennent des booléens
+// strictement complémentaires, il ne peut pas y avoir égalité (id unique).
+// Mais `rivals.length === 0` gagne EN DESSOUS, sans comparer aucun id — et
+// c'est exactement le trou : si le refetch de l'agent A court en avance de
+// la propagation du claim de l'agent B (A ne voit encore aucun rival), A
+// gagne trivialement sans savoir qu'il y a conflit. Si le refetch de B,
+// juste après, voit bien le claim de A, B compare pour de vrai — et PEUT
+// gagner aussi si son id est le plus petit des deux. Résultat possible :
+// DOUBLE-RÉTENTION (les deux gardent), jamais fermée par cette fonction
+// seule. La garantie est donc best-effort, pas structurelle : elle réduit
+// la fenêtre du correctif précédent, elle ne l'annule pas. Fermer ça pour
+// de vrai demande l'atomicité sur le FICHIER côté coordinator, pas le
+// thread — hors périmètre client (documenté aussi en bas de fichier, sur le
+// refetch après course perdue).
 async function resolveFileConflict(
   coordinatorUrl: string,
   agentId: string,
@@ -351,7 +362,13 @@ export async function unclaimTask(
     thread_id: threadId,
     agent_id: agentId,
   }).catch((err) => {
-    log.warn("unclaimTask failed", { error: (err as Error).message });
+    // Swallowed on purpose (every caller fires this fire-and-forget), but the
+    // thread id has to be IN the warning: without it, a failed unclaim is a
+    // thread stuck claimed_by us forever — nobody, including us, ever picks
+    // it up again — and a bare "unclaimTask failed" gives no way to find
+    // which one. Cheapest fix that covers every call site, including the
+    // new cede-on-conflict path in claimNextTask (#140).
+    log.warn(`unclaimTask failed: thread=${threadId}`, { error: (err as Error).message });
   });
 }
 

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -167,3 +167,92 @@ describe('claimNextTask — refetch après course perdue (fenêtre TOCTOU rédui
     expect(claimed).toHaveLength(1); // t2 correctement écarté après le refetch
   });
 });
+
+// #140 — la fenêtre restante : au démarrage parallèle, les N instantanés
+// précèdent structurellement les N claims, donc computeBusyFiles() ne peut
+// rien voir au premier tour. Deux agents peuvent chacun réussir un claim
+// atomique (claim-task est atomique PAR THREAD, pas par fichier) sur deux
+// threads distincts qui ciblent le même fichier. Le départage doit être
+// déterministe et symétrique : les deux agents l'évaluent indépendamment,
+// sans se parler, et doivent converger vers EXACTEMENT un cédant.
+describe('claimNextTask — départage déterministe après double claim réussi sur un même fichier (#140)', () => {
+  it('cède le thread si un pair détient déjà un claim ouvert sur le même fichier avec un id de thread plus petit, puis enchaîne sur le candidat suivant', async () => {
+    let threadsActiveCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/threads-active')) {
+        threadsActiveCalls++;
+        if (threadsActiveCalls === 1) {
+          // Snapshot initial : les deux fichiers semblent libres — c'est
+          // structurellement le cas au démarrage parallèle, computeBusyFiles()
+          // ne peut rien voir ici.
+          return new Response(JSON.stringify([
+            { id: 't5', status: 'open', claimed_by: null, target_files: ['shared.ts'] },
+            { id: 't9', status: 'open', claimed_by: null, target_files: ['other.ts'] },
+          ]), { status: 200 });
+        }
+        if (threadsActiveCalls === 2) {
+          // Re-fetch juste après notre claim RÉUSSI sur t5 : un pair a claim
+          // t1 sur le même fichier entre notre snapshot et notre claim. 't1'
+          // < 't5' : le pair garde, nous cédons.
+          return new Response(JSON.stringify([
+            { id: 't1', status: 'open', claimed_by: 'autre-agent', target_files: ['shared.ts'] },
+            { id: 't5', status: 'open', claimed_by: 'hunter-2', target_files: ['shared.ts'] },
+            { id: 't9', status: 'open', claimed_by: null, target_files: ['other.ts'] },
+          ]), { status: 200 });
+        }
+        // Re-fetch après le claim du candidat suivant (t9) : aucun rival sur other.ts.
+        return new Response(JSON.stringify([
+          { id: 't1', status: 'open', claimed_by: 'autre-agent', target_files: ['shared.ts'] },
+          { id: 't9', status: 'open', claimed_by: 'hunter-2', target_files: ['other.ts'] },
+        ]), { status: 200 });
+      }
+      if (url.endsWith('/api/claim-task')) {
+        return new Response(JSON.stringify({ success: true, claimed_by: null }), { status: 200 });
+      }
+      if (url.endsWith('/api/unclaim-task')) {
+        return new Response('{}', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t9'); // a cédé t5 (t1 < t5), a enchaîné sur le candidat suivant
+    const unclaimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/unclaim-task'));
+    expect(unclaimed).toHaveLength(1);
+    expect(JSON.parse((unclaimed[0][1] as RequestInit).body as string).thread_id).toBe('t5');
+  });
+
+  it('cas symétrique : mêmes fichiers, identités inversées (notre id est maintenant le plus petit) — c\'est nous qui gardons, la conclusion suit l\'id et pas l\'ordre des appels', async () => {
+    let threadsActiveCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/threads-active')) {
+        threadsActiveCalls++;
+        if (threadsActiveCalls === 1) {
+          return new Response(JSON.stringify([
+            { id: 't5', status: 'open', claimed_by: null, target_files: ['shared.ts'] },
+          ]), { status: 200 });
+        }
+        // Re-fetch après notre claim réussi sur t5 : le pair détient t99 sur
+        // le même fichier. 't5' < 't99' cette fois : nous gardons, le pair
+        // cède (de son côté, avec le même calcul).
+        return new Response(JSON.stringify([
+          { id: 't5', status: 'open', claimed_by: 'hunter-2', target_files: ['shared.ts'] },
+          { id: 't99', status: 'open', claimed_by: 'autre-agent', target_files: ['shared.ts'] },
+        ]), { status: 200 });
+      }
+      if (url.endsWith('/api/claim-task')) {
+        return new Response(JSON.stringify({ success: true, claimed_by: null }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t5'); // id plus petit : nous gardons, pas de cession
+    const unclaimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/unclaim-task'));
+    expect(unclaimed).toHaveLength(0);
+  });
+});

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -252,6 +252,12 @@ describe('claimNextTask — départage déterministe après double claim réussi
     const task = await claimNextTask('https://c', 'hunter-2');
 
     expect(task?.id).toBe('t5'); // id plus petit : nous gardons, pas de cession
+    // Discriminant : sur 058ee3f, claimNextTask retourne dès success===true
+    // sans jamais rappeler threads-active — task?.id==='t5' et 0 unclaim
+    // seraient déjà vrais SANS le patch (aucun refetch post-claim n'existe).
+    // Le seul signal qui ne peut être vrai qu'AVEC resolveFileConflict() en
+    // jeu est ce second appel : le pré-patch en fait 1, le patché en fait 2.
+    expect(threadsActiveCalls).toBe(2);
     const unclaimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/unclaim-task'));
     expect(unclaimed).toHaveLength(0);
   });


### PR DESCRIPTION
Suite de #139. Le garde-fou « un agent par fichier » fonctionne maintenant, mais il ne suffisait pas : il travaille sur un **instantané pris avant le claim**. Au démarrage parallèle, les N instantanés précèdent les N claims — il ne pouvait structurellement pas se déclencher au premier tour.

Le rafraîchissement n'existait que dans la branche **course perdue**. Sur un claim **réussi**, l'agent repartait sans jamais vérifier qu'un pair venait de réclamer un thread partageant un de ses fichiers.

## Mesuré, sur charge identique

Deux runs de 4 agents, 4 défauts réels dans 4 fichiers distincts, même seed :

| | corrections tentées | redondance |
|---|---|---|
| garde-fou inerte (avant #139) | 11 | 2,75× |
| garde-fou actif (après #139) | 6 | **1,50×** |

Ce correctif attaque ce résidu de 1,50×.

## Le départage

Après un claim réussi, re-fetch ; si un pair détient un claim ouvert sur un de nos fichiers, on garde si notre `thread_id` est le plus petit de l'ensemble, sinon on dé-réclame et on continue vers le candidat suivant.

**Comparaison lexicographique des `thread_id`, pas d'horodatage** — les horloges dérivent et les latences sont asymétriques, deux agents peuvent chacun se croire premier. L'identifiant est une clé primaire côté coordinator : les deux agents en conflit calculent le même prédicat sur le même couple, et obtiennent des booléens complémentaires.

## Ce que le correctif ne fait PAS, et le commentaire le dit

La relecture a démoli la première version de cette affirmation, à juste titre. **Une double-rétention reste possible** : le chemin « aucun rival » gagne trivialement, sans comparer d'identifiant. Contre-exemple à deux agents — X claim, son refetch tourne avant que Y ait claim → aucun rival → X garde ; Y claim ensuite, voit X, son id est plus petit → Y garde aussi.

La double-**cession**, elle, reste structurellement impossible : l'agent au plus petit identifiant du conflit ne peut jamais perdre sa propre comparaison. Le travail n'est donc jamais perdu.

La garantie est **best-effort, pas structurelle**, et le commentaire le dit maintenant en nommant le chemin fautif. Fermer vraiment cette fenêtre demande l'atomicité sur le **fichier** côté coordinator — `claim-task` n'est atomique que sur le `thread_id`.

## Non-régression

- Aucun verrou, aucune sérialisation : le lancement reste parallèle.
- Coordinator injoignable au re-fetch → on garde le thread plutôt que de perdre le travail.
- Coût : un aller-retour de plus par claim réussi **ayant au moins un fichier cible** ; l'appel est sauté sinon.

## Vérification

- **782 tests au vert**, `tsc` propre
- Un premier test couvre la cession, un second le déterminisme. La relecture a rejeté la première version du second — **elle passait à l'identique sur le code d'avant** ; il compte désormais les appels réseau, ce que seul le nouveau chemin peut satisfaire.
- Le rouge a été vérifié en restaurant le fichier depuis la base : `expected 1 to be 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)