### PR TITLE
fix(falsifiability): le garde-fou inspectait l'arbre, le prompt ordonne de commiter

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -11,8 +11,11 @@ import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, unclaim
 import { createLogger } from "../logger.js";
 import { resolveEffort, upgradeEffort, parseSeverity, EFFORT_PROFILES, isThinkingLevel, type EffortLevel, type ConcreteEffortLevel, type ThinkingLevel } from "./effort.js";
 import { authHeaders } from "../coordinator-auth.js";
-import { verifyFailingTest, type FalsifiabilityDeps } from "./falsifiability.js";
+import { verifyFailingTest, parseUntrackedFiles, type FalsifiabilityDeps } from "./falsifiability.js";
 import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { detectLanguage } from "../orchestrator/scanner.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -151,7 +154,16 @@ function gitExec(cwd: string): FalsifiabilityDeps {
   return {
     exec(cmd, args) {
       return new Promise((resolve) => {
-        const child = spawn(cmd, args, { cwd, shell: process.platform === "win32" });
+        // `shell` UNIQUEMENT pour le lanceur de tests. Sur Windows `pnpm`/`npx`
+        // sont des .cmd et exigent un shell ; `git` est un vrai .exe et n'en a
+        // pas besoin. Or sous `shell: true` Node NE CITE PAS les arguments :
+        // un chemin contenant une espace (« my src.ts », ou un tmpdir sous
+        // `C:\Users\Jean Dupont\...`) se scindait en deux pathspecs et le
+        // fichier n'était jamais neutralisé — un bon correctif se faisait alors
+        // refuser par « le test passe SANS le patch », le pire des verdicts
+        // puisqu'il a l'air d'un vrai. Le contrôle d'effet ne le rattrapait pas :
+        // il rejouait le même pathspec cassé.
+        const child = spawn(cmd, args, { cwd, shell: process.platform === "win32" && cmd !== "git" });
         let stdout = "";
         child.stdout?.on("data", (d) => { stdout += String(d); });
         child.stderr?.on("data", (d) => { stdout += String(d); });
@@ -159,6 +171,35 @@ function gitExec(cwd: string): FalsifiabilityDeps {
         child.on("close", (code) => resolve({ code: code ?? -1, stdout }));
       });
     },
+    // HORS du worktree : un patch déposé dedans apparaîtrait dans le
+    // `git status` du contrôle suivant et serait compté comme fichier source.
+    async writeTemp(content) {
+      const file = join(mkdtempSync(join(tmpdir(), "essaim-falsifiability-")), "neutralize.patch");
+      writeFileSync(file, content);
+      return file;
+    },
+  };
+}
+
+/**
+ * HEAD relevé AVANT que l'agent touche à la tâche : la base contre laquelle le
+ * garde-fou mesure ce qui a été produit. Sans elle il n'inspectait que l'arbre
+ * de travail, que le commit par tâche (behaviors/phase-execute.yaml:56) vide.
+ * Rendre `undefined` si git ne répond pas — le contrôle retombe alors sur son
+ * comportement historique plutôt que de bloquer une tâche légitime.
+ */
+async function taskBaseline(
+  deps: FalsifiabilityDeps,
+): Promise<{ sha?: string; untracked: string[] }> {
+  const r = await deps.exec("git", ["rev-parse", "HEAD"]);
+  const sha = r.stdout.trim();
+  // Les non-suivis DÉJÀ LÀ avant la tâche. Sans cet inventaire, `.mcp.json` —
+  // que promptweave dépose dans chaque worktree à sa création — compte comme
+  // « fichier de production changé » à chaque tâche.
+  const st = await deps.exec("git", ["status", "--porcelain", "--untracked-files=all"]);
+  return {
+    sha: r.code === 0 && sha ? sha : undefined,
+    untracked: st.code === 0 ? parseUntrackedFiles(st.stdout) : [],
   };
 }
 
@@ -1163,6 +1204,54 @@ export async function runAgentLoop(
               const execTools = toolsForMode(phase.toolsMode, config.allowedTools);
               const execBlocked = disallowedForMode(phase.toolsMode);
               const freshExec = config.freshSessionPerTask === true;
+
+              // Relevé AVANT le premier envoi : le garde-fou de falsifiabilité
+              // compare contre ce SHA. Sans lui il n'inspecte que l'arbre de
+              // travail, que le commit par tâche vide — 54 refus « aucun
+              // fichier de test modifié » sur un banc de 6 runs.
+              const falsifiabilityDeps = gitExec(config.workspacePath);
+              const taskBase = phase.requireFailingTest
+                ? await taskBaseline(falsifiabilityDeps)
+                : undefined;
+
+              /**
+               * Un seul chemin « l'agent a dit DONE: », pour les DEUX envois.
+               * Celui de reprise après rate limit appelait completeTask sans
+               * passer par le garde-fou : un DONE arraché après la pause était
+               * accepté sans preuve, `requireFailingTest` ou non.
+               *
+               * Le DONE: ne suffit pas quand le behavior exige une preuve.
+               * Mesuré : un agent a « corrigé » deux champs non contrôlables
+               * par le moteur, avec un test qui passait avant comme après.
+               * Un FALSE_POSITIVE n'a ni patch ni test : c'est une issue que
+               * la mission de sentinelle autorise explicitement. Mesuré sur un
+               * vrai swarm — un agent a correctement identifié le faux positif
+               * et s'est fait refuser sa résolution, faute de test à montrer.
+               */
+              const settleDone = async (content: string, after: string): Promise<void> => {
+                const taskSummary = extractDoneSummary(content, "Done");
+                const verdict =
+                  phase.requireFailingTest && !FALSE_POSITIVE_PATTERN.test(taskSummary)
+                    ? await verifyFailingTest(falsifiabilityDeps, testCommandFor(config.workspacePath), taskBase?.sha, taskBase?.untracked)
+                    : null;
+                if (verdict && !verdict.falsifiable) {
+                  logger.warn(`Work-stealing: DONE refusé — ${verdict.reason}`, {
+                    taskId: task.id,
+                    testFiles: verdict.testFiles,
+                  });
+                  // Dire POURQUOI dans le thread. Sans ça le prochain agent
+                  // reprend la tâche sans savoir ce qui a été refusé et refait
+                  // la même chose : mesuré, trois refus d'affilée pour « aucun
+                  // test » sur des tâches reprises en boucle.
+                  await postRefusal(config, task.id, verdict.reason);
+                  await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
+                  return;
+                }
+                logger.info(`Work-stealing: completed${after} — "${taskSummary.slice(0, 80)}"`);
+                await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
+                tasksDone++;
+              };
+
               const resp = await send(taskPrompt, { model: execProfile.model, thinking: execProfile.thinking, maxTurns: execProfile.maxTurns, allowedTools: execTools, disallowedTools: execBlocked, freshSession: freshExec });
 
               // Detect rate limit — pause and wait for reset instead of wasting turns.
@@ -1211,10 +1300,7 @@ export async function runAgentLoop(
                 const retryResp = await send(taskPrompt, { model: execProfile.model, thinking: execProfile.thinking, maxTurns: execProfile.maxTurns, allowedTools: execTools, disallowedTools: execBlocked, freshSession: freshExec });
                 if (!retryResp.rateLimited) {
                   if (hasDoneMarker(retryResp.content)) {
-                    const taskSummary = extractDoneSummary(retryResp.content, "Done");
-                    logger.info(`Work-stealing: completed after retry — "${taskSummary.slice(0, 80)}"`);
-                    await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
-                    tasksDone++;
+                    await settleDone(retryResp.content, " after retry");
                   } else {
                     logger.warn(`Work-stealing: aborting task after retry (no DONE:) — unclaiming thread=${task.id} subtype=${retryResp.subtype ?? "?"}`);
                     await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
@@ -1236,34 +1322,7 @@ export async function runAgentLoop(
               // with partial/unrelated content (e.g. "Je vais explorer..."),
               // blocking the real work from ever happening.
               if (hasDoneMarker(resp.content)) {
-                const taskSummary = extractDoneSummary(resp.content, "Done");
-                // Le DONE: ne suffit pas quand le behavior exige une preuve.
-                // Mesuré : un agent a « corrigé » deux champs non contrôlables
-                // par le moteur, avec un test qui passait avant comme après.
-                // Un FALSE_POSITIVE n'a ni patch ni test : c'est une issue que
-                // la mission de sentinelle autorise explicitement. Mesuré sur un
-                // vrai swarm — un agent a correctement identifié le faux positif
-                // et s'est fait refuser sa résolution, faute de test à montrer.
-                const verdict =
-                  phase.requireFailingTest && !FALSE_POSITIVE_PATTERN.test(taskSummary)
-                    ? await verifyFailingTest(gitExec(config.workspacePath), testCommandFor(config.workspacePath))
-                    : null;
-                if (verdict && !verdict.falsifiable) {
-                  logger.warn(`Work-stealing: DONE refusé — ${verdict.reason}`, {
-                    taskId: task.id,
-                    testFiles: verdict.testFiles,
-                  });
-                  // Dire POURQUOI dans le thread. Sans ça le prochain agent
-                  // reprend la tâche sans savoir ce qui a été refusé et refait
-                  // la même chose : mesuré, trois refus d'affilée pour « aucun
-                  // test » sur des tâches reprises en boucle.
-                  await postRefusal(config, task.id, verdict.reason);
-                  await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
-                } else {
-                  logger.info(`Work-stealing: completed — "${taskSummary.slice(0, 80)}"`);
-                  await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
-                  tasksDone++;
-                }
+                await settleDone(resp.content, "");
               } else {
                 // subtype distingue « l'agent a divagué » (success) de « il a
                 // manqué de tours » (error_max_turns). On le JOURNALISE sans

--- a/src/agent-loop/falsifiability.ts
+++ b/src/agent-loop/falsifiability.ts
@@ -11,7 +11,7 @@ const log = createLogger("falsifiability");
  * calculé localement et une valeur passée par une allowlist stricte — avec un
  * test qui passait dans les deux cas, et a conclu DONE.
  *
- * Le principe : remiser les fichiers NON-test modifiés, relancer les tests
+ * Le principe : NEUTRALISER les fichiers non-test modifiés, relancer les tests
  * touchés, et exiger un échec. Si le test passe sans le patch, il ne prouve
  * rien — la tâche n'est pas terminée.
  */
@@ -24,6 +24,13 @@ export interface ExecResult {
 export interface FalsifiabilityDeps {
   /** Exécute une commande dans le worktree. Ne doit jamais jeter. */
   exec(cmd: string, args: string[]): Promise<ExecResult>;
+  /**
+   * Écrit un patch dans un fichier temporaire HORS du worktree et rend son
+   * chemin. Séparé d'`exec` pour une raison mécanique : `exec` n'a pas d'entrée
+   * standard, et `git apply` ne lit un patch que depuis un fichier ou stdin.
+   * Injectable pour que les tests puissent le simuler.
+   */
+  writeTemp?(content: string): Promise<string>;
 }
 
 export interface FalsifiabilityVerdict {
@@ -32,7 +39,7 @@ export interface FalsifiabilityVerdict {
   reason: string;
   /** Fichiers de test détectés dans le diff. */
   testFiles: string[];
-  /** Fichiers de production remisés le temps du contrôle. */
+  /** Fichiers de production neutralisés le temps du contrôle. */
   sourceFiles: string[];
 }
 
@@ -41,27 +48,215 @@ export function isTestFile(path: string): boolean {
   return /(^|\/)tests\/.*\.test\.(ts|js)$/.test(path.replace(/\\/g, "/"));
 }
 
-/** `git status --porcelain` → chemins modifiés ou ajoutés. */
+/**
+ * `git status --porcelain` → chemins modifiés ou ajoutés.
+ *
+ * Un RENOMMAGE se présente `R  ancien -> nouveau` : sans le décoder, le chemin
+ * retenu devenait la CHAÎNE ENTIÈRE, flèche comprise. Passée telle quelle à
+ * `git diff` sous `shell: true`, cmd.exe interprétait le `>` comme une
+ * REDIRECTION et ÉCRASAIT le fichier de l'agent avec la sortie de git. Le
+ * `shell: true` a disparu côté git (voir gitExec dans agent-loop.ts), mais un
+ * pathspec portant une flèche ne désignerait toujours aucun fichier — on garde
+ * donc le décodage.
+ */
 export function parseChangedFiles(porcelain: string): string[] {
   return porcelain
     .split("\n")
     .map((l) => l.trimEnd())
     .filter((l) => l.length > 3)
     .map((l) => l.slice(3).trim())
+    .map((p) => {
+      const arrow = p.indexOf(" -> ");
+      return arrow === -1 ? p : p.slice(arrow + 4).trim();
+    })
     .filter(Boolean);
+}
+
+/** `git status --porcelain` → chemins SUIVIS seulement (tout sauf `??`). */
+export function parseTrackedChanges(porcelain: string): string[] {
+  const tracked = porcelain.split("\n").filter((l) => l.length > 3 && !l.startsWith("??"));
+  return parseChangedFiles(tracked.join("\n"));
+}
+
+/** `git status --porcelain` → chemins NON SUIVIS seulement (préfixe `??`). */
+export function parseUntrackedFiles(porcelain: string): string[] {
+  const untracked = porcelain.split("\n").filter((l) => l.startsWith("??"));
+  return parseChangedFiles(untracked.join("\n"));
+}
+
+/** `git diff --name-only` → un chemin par ligne, sans code d'état. */
+export function parseNameOnly(out: string): string[] {
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Retire le patch de production du worktree, et sait le remettre.
+ * Deux mécanismes, parce que `git stash` ne peut pas retirer un COMMIT.
+ */
+type Neutralization =
+  | { ok: true; restore: () => Promise<void> }
+  | { ok: false; reason: string };
+
+/** Voie historique : suffisante tant que le patch est resté dans l'arbre. */
+async function neutralizeByStash(
+  deps: FalsifiabilityDeps,
+  sourceFiles: string[],
+): Promise<Neutralization> {
+  // `--include-untracked` : un patch qui CRÉE un fichier source ne serait pas
+  // remisé sans lui, la remise échouerait, et le contrôle s'ouvrirait en grand
+  // sur exactement le cas qu'il doit surveiller.
+  const stash = await deps.exec("git", ["stash", "push", "--quiet", "--include-untracked", "--", ...sourceFiles]);
+  if (stash.code !== 0) return { ok: false, reason: "remise impossible — contrôle sauté" };
+  return {
+    ok: true,
+    restore: async () => {
+      const pop = await deps.exec("git", ["stash", "pop", "--quiet"]);
+      if (pop.code !== 0) {
+        // Laisser un worktree amputé de son patch serait pire que tout.
+        log.error("git stash pop a échoué — le patch est resté remisé", { sourceFiles });
+      }
+    },
+  };
+}
+
+/**
+ * PATCH INVERSE : le seul primitif symétrique quand le patch est COMMITÉ.
+ *
+ * `git stash push` sur des chemins propres-parce-que-commités sort 0 SANS RIEN
+ * REMISER — vérifié sur un dépôt jetable, patch et test commités, arbre propre :
+ * `git status:[]`, `git stash push --include-untracked -- src.ts` → exit 0, rien
+ * de remisé, src.ts contenait toujours « patched ». Le contrôle rejouait alors
+ * le test AVEC le patch en place, il passait, et le verdict devenait « le test
+ * passe SANS le patch ». Réparer la base de diff sans réparer la neutralisation
+ * aurait transformé 54 refus MUETS en 54 refus MENSONGERS : les deux ou aucun.
+ *
+ * `git diff <baseSha> -- <fichiers>` diffe baseSha contre l'ARBRE DE TRAVAIL :
+ * il couvre donc le commité ET le non commité en une seule passe, et `git apply
+ * -R` puis `git apply` forment un aller-retour exact (vérifié aussi sur un
+ * worktree CRLF, où le patch émis par git est en LF).
+ */
+async function neutralizeByReversePatch(
+  deps: FalsifiabilityDeps,
+  baseSha: string,
+  sourceFiles: string[],
+  untracked: Set<string>,
+): Promise<Neutralization> {
+  if (!deps.writeTemp) return { ok: false, reason: "écriture de patch indisponible — contrôle sauté" };
+
+  // ON NE TOUCHE JAMAIS À UN FICHIER NON SUIVI. La rédaction précédente les
+  // faisait entrer dans le patch via `git add --intent-to-add`, pour que le
+  // patch inverse les supprime. Deux conséquences mesurées, toutes deux pires
+  // que le défaut réparé :
+  //
+  //  1. `.mcp.json` est non suivi dans TOUS les worktrees d'agent (promptweave
+  //     l'y dépose à la création). Il devenait donc « fichier de production »
+  //     à chaque tâche, et se faisait supprimer par la neutralisation.
+  //  2. La restauration est un `git apply` unique, donc ATOMIQUE : si le seul
+  //     lancement des tests recrée un artefact non suivi, `git apply` refuse
+  //     le patch ENTIER (« already exists in working directory »), et le
+  //     correctif de l'agent n'est PAS restauré — pendant que le verdict reste
+  //     `falsifiable: true` et que la tâche part en `completeTask`. La remise
+  //     historique, elle, laissait au moins une entrée récupérable dans
+  //     `git stash list`.
+  //
+  // Un fichier non suivi APPARU pendant la tâche est traité en amont (il fait
+  // fail-open explicite) ; un fichier non suivi préexistant n'est simplement
+  // pas de notre ressort.
+  const stillUntracked = sourceFiles.filter((f) => untracked.has(f));
+  if (stillUntracked.length) {
+    return { ok: false, reason: "fichier source non suivi — contrôle sauté" };
+  }
+
+  // `--binary` : sans lui, git rend « Binary files ... differ », un en-tête que
+  // `git apply` REFUSE (« cannot apply binary patch without full index line »).
+  // Un seul binaire non suivi dans le lot — capture, .db, fixture PNG —
+  // désarmait donc tout le contrôle par fail-open.
+  const patch = await deps.exec("git", ["diff", "--binary", baseSha, "--", ...sourceFiles]);
+  if (patch.code !== 0 || !patch.stdout.trim()) {
+    return { ok: false, reason: "aucun patch de production à neutraliser — contrôle sauté" };
+  }
+
+  const patchFile = await deps.writeTemp(patch.stdout);
+  const reverted = await deps.exec("git", ["apply", "-R", patchFile]);
+  if (reverted.code !== 0) {
+    return { ok: false, reason: "patch inverse inapplicable — contrôle sauté" };
+  }
+
+  const restore = async () => {
+    const back = await deps.exec("git", ["apply", patchFile]);
+    if (back.code === 0) return;
+    // `git apply` est ATOMIQUE : il refuse le patch ENTIER dès qu'un seul
+    // fichier gêne — typiquement « already exists in working directory » quand
+    // le lancement des tests a recréé un fichier que la neutralisation venait
+    // de supprimer. Sans rattrapage, le correctif de l'agent est PERDU alors
+    // que le verdict reste positif et que la tâche part en completeTask.
+    // `git checkout HEAD --` rend leur contenu commité à tous les chemins
+    // concernés : c'est exactement l'état d'avant le contrôle, puisque le
+    // commit par tâche est ce que phase-execute.yaml:56 exige.
+    const hard = await deps.exec("git", ["checkout", "HEAD", "--", ...sourceFiles]);
+    if (hard.code !== 0) {
+      log.error("restauration impossible — le worktree est resté sans son patch", { patchFile, sourceFiles });
+      return;
+    }
+    log.warn("git apply a échoué — patch restauré depuis HEAD", { patchFile, sourceFiles });
+  };
+
+  // LE GARDE-FOU DU GARDE-FOU. `git apply -R` peut sortir 0 sans avoir rien
+  // changé, comme `git stash push` le faisait. Un refus ne doit JAMAIS reposer
+  // sur une neutralisation qui n'a pas eu lieu : si le patch est toujours là on
+  // ne sait rien, et on le DIT. Le seul verdict négatif légitime reste « le
+  // test est complaisant ».
+  const effect = await deps.exec("git", ["diff", "--name-only", baseSha, "--", ...sourceFiles]);
+  if (effect.code !== 0 || effect.stdout.trim()) {
+    await restore();
+    return { ok: false, reason: "neutralisation sans effet — contrôle sauté" };
+  }
+
+  return { ok: true, restore };
 }
 
 /**
  * Rejoue les tests sans les modifications de production.
  *
- * Fail-open sur toute anomalie d'outillage (git indisponible, remise
- * impossible) : ce garde-fou doit attraper un test complaisant, pas bloquer
- * une tâche légitime parce que git a hoqueté. Le seul verdict négatif est
- * « le test passe sans le patch ».
+ * `baseSha` est le HEAD relevé AVANT que l'agent travaille sur la tâche. Sans
+ * lui, le comportement historique est conservé (arbre de travail + remise).
+ *
+ * Fail-open sur toute anomalie d'outillage (git indisponible, neutralisation
+ * impossible ou sans effet) : ce garde-fou doit attraper un test complaisant,
+ * pas bloquer une tâche légitime parce que git a hoqueté. Le seul verdict
+ * négatif est « le test passe sans le patch ».
  */
 export async function verifyFailingTest(
   deps: FalsifiabilityDeps,
   testCommand: { cmd: string; args: string[] },
+  baseSha?: string,
+  baseUntracked?: string[],
+): Promise<FalsifiabilityVerdict> {
+  // CONTRAT : ne jette JAMAIS. La docstring le promet depuis toujours et
+  // l'appelant ne l'entoure d'aucun try — une exception ici remonte au catch
+  // global d'agent-loop.ts et arrête la boucle de travail ENTIÈRE, pas le seul
+  // contrôle. Mesuré : 900 fichiers non suivis sous dist/ suffisaient à faire
+  // sortir `spawn` en ENAMETOOLONG et à tuer l'agent.
+  try {
+    return await runVerification(deps, testCommand, baseSha, baseUntracked);
+  } catch (err) {
+    return {
+      falsifiable: true,
+      reason: `contrôle impossible (${(err as Error).message}) — contrôle sauté`,
+      testFiles: [],
+      sourceFiles: [],
+    };
+  }
+}
+
+async function runVerification(
+  deps: FalsifiabilityDeps,
+  testCommand: { cmd: string; args: string[] },
+  baseSha?: string,
+  baseUntracked?: string[],
 ): Promise<FalsifiabilityVerdict> {
   // `--untracked-files=all` est obligatoire : sans lui, git REPLIE un
   // répertoire entièrement non suivi en une seule entrée (`?? tests/`) et le
@@ -72,7 +267,43 @@ export async function verifyFailingTest(
     return { falsifiable: true, reason: "git status indisponible — contrôle sauté", testFiles: [], sourceFiles: [] };
   }
 
-  const changed = parseChangedFiles(status.stdout);
+  const worktreeChanges = parseChangedFiles(status.stdout);
+  const untracked = new Set(parseUntrackedFiles(status.stdout));
+
+  // LE COMMIT PAR TÂCHE EST VOULU — c'est le garde-fou qui doit s'y adapter.
+  // behaviors/phase-execute.yaml:56 ordonne « chaque tâche nécessite son PROPRE
+  // commit », :59 « puis dis DONE: », et falsifiability.ts:70 n'interrogeait que
+  // `git status` : l'ARBRE, que le commit vient précisément de vider. Le
+  // garde-fou n'était pas trop strict, il était AVEUGLE. Mesuré : 54 refus sur
+  // un banc de 6 runs, TOUS « aucun fichier de test modifié — rien ne prouve le
+  // défaut », 3 des 4 vrais défauts finissant `poisoned` par run. Sur un
+  // worktree réel du banc, status ne montrait que `?? .mcp.json` pendant que
+  // `git show --name-only HEAD` listait bien la source ET le test. D'où
+  // l'UNION : ce qui a été COMMITÉ depuis baseSha + ce qui reste dans l'ARBRE.
+  let changed = worktreeChanges;
+  if (baseSha) {
+    const committed = await deps.exec("git", ["diff", "--name-only", baseSha, "HEAD"]);
+    if (committed.code !== 0) {
+      return {
+        falsifiable: true,
+        reason: "diff depuis la base indisponible — contrôle sauté",
+        testFiles: [],
+        sourceFiles: [],
+      };
+    }
+    // NON SUIVIS PRÉEXISTANTS : hors périmètre, et il FAUT les exclure.
+    // `.mcp.json` est déposé dans chaque worktree AVANT que l'agent travaille ;
+    // le compter comme « fichier de production changé » le faisait entrer dans
+    // la neutralisation à chaque tâche, avec le risque de perte décrit plus
+    // haut. La base de comparaison n'est donc pas seulement un SHA : c'est le
+    // SHA **plus** l'ensemble des non-suivis déjà là au départ.
+    const before = new Set(baseUntracked ?? []);
+    const appeared = parseUntrackedFiles(status.stdout).filter((f) => !before.has(f));
+    changed = [
+      ...new Set([...parseNameOnly(committed.stdout), ...parseTrackedChanges(status.stdout), ...appeared]),
+    ];
+  }
+
   const testFiles = changed.filter(isTestFile);
   const sourceFiles = changed.filter((f) => !isTestFile(f));
 
@@ -85,15 +316,13 @@ export async function verifyFailingTest(
     return { falsifiable: true, reason: "test ajouté sans patch de production", testFiles, sourceFiles };
   }
 
-  // `--include-untracked` : un patch qui CRÉE un fichier source ne serait pas
-  // remisé sans lui, la remise échouerait, et le contrôle s'ouvrirait en grand
-  // sur exactement le cas qu'il doit surveiller.
   // MESURE DE RÉFÉRENCE, patch en place. Sans elle, un lanceur qui ne démarre
   // pas — mauvaise commande pour ce dépôt, dépendance absente, config cassée —
-  // sort non-zéro APRÈS la remise et se lit comme « le test échoue sans le
-  // patch » : le garde-fou accepte, en silence, exactement ce qu'il surveille.
-  // Mesuré : sur un dépôt sans vitest, `pnpm exec vitest run` produisait un
-  // faux ACCEPT sur un test dont le verdict correct était « ne prouve rien ».
+  // sort non-zéro APRÈS la neutralisation et se lit comme « le test échoue sans
+  // le patch » : le garde-fou accepte, en silence, exactement ce qu'il
+  // surveille. Mesuré : sur un dépôt sans vitest, `pnpm exec vitest run`
+  // produisait un faux ACCEPT sur un test dont le verdict correct était
+  // « ne prouve rien ».
   const baseline = await deps.exec(testCommand.cmd, [...testCommand.args, ...testFiles]);
   if (baseline.code !== 0) {
     return {
@@ -104,9 +333,11 @@ export async function verifyFailingTest(
     };
   }
 
-  const stash = await deps.exec("git", ["stash", "push", "--quiet", "--include-untracked", "--", ...sourceFiles]);
-  if (stash.code !== 0) {
-    return { falsifiable: true, reason: "remise impossible — contrôle sauté", testFiles, sourceFiles };
+  const neutral = baseSha
+    ? await neutralizeByReversePatch(deps, baseSha, sourceFiles, untracked)
+    : await neutralizeByStash(deps, sourceFiles);
+  if (!neutral.ok) {
+    return { falsifiable: true, reason: neutral.reason, testFiles, sourceFiles };
   }
 
   try {
@@ -121,10 +352,6 @@ export async function verifyFailingTest(
     }
     return { falsifiable: true, reason: "le test échoue sans le patch", testFiles, sourceFiles };
   } finally {
-    const pop = await deps.exec("git", ["stash", "pop", "--quiet"]);
-    if (pop.code !== 0) {
-      // Laisser un worktree amputé de son patch serait pire que tout.
-      log.error("git stash pop a échoué — le patch est resté remisé", { sourceFiles });
-    }
+    await neutral.restore();
   }
 }

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -99,6 +99,19 @@ vi.mock("../../src/agent-loop/work-stealing.js", () => ({
   processReviewActions: (url: string, agentId: string, agentName: string, actions: unknown[]) => mockProcessReviewActions(url, agentId, agentName, actions),
 }));
 
+// Mock falsifiability — le garde-fou est testé contre un vrai dépôt git dans
+// tests/unit/falsifiability.test.ts. Ici on vérifie uniquement que le loop
+// l'appelle sur TOUS les chemins où l'agent dit DONE:, et qu'il lui obéit.
+const mockVerifyFailingTest = vi.fn(async () => ({
+  falsifiable: true,
+  reason: "ok",
+  testFiles: [] as string[],
+  sourceFiles: [] as string[],
+}));
+vi.mock("../../src/agent-loop/falsifiability.js", () => ({
+  verifyFailingTest: (...args: unknown[]) => mockVerifyFailingTest(...(args as [])),
+}));
+
 // Mock fetch for coordinator REST
 const mockFetch = vi.fn(async () => ({
   ok: true,
@@ -1612,6 +1625,54 @@ describe("runAgentLoop — phased mode", () => {
     expect(mockCompleteTask).not.toHaveBeenCalled();
     // A run that never got past a rate limit must not be stamped as a success.
     expect(result.exitReason).not.toBe("done");
+  });
+
+  it("passe par le garde-fou de falsifiabilité AUSSI après une reprise de rate limit", async () => {
+    // Le chemin de reprise appelait completeTask directement : un DONE: arraché
+    // après la pause était accepté sans preuve, `requireFailingTest` ou non.
+    // Même cécité que celle qui a produit les 54 refus, dans l'autre sens —
+    // là le garde-fou refusait à tort, ici il ne regardait pas du tout.
+    vi.useFakeTimers();
+
+    let claimCall = 0;
+    mockClaimNextTask.mockImplementation(async () => {
+      claimCall++;
+      if (claimCall === 1) return { id: "t-retry", description: "tâche reprise après rate limit", file: undefined, severity: undefined };
+      return null;
+    });
+
+    mockSend.mockResolvedValueOnce({ content: "DISCOVERY:\nitem", toolCalls: [], costUsd: 0.01, durationMs: 100, sessionId: "s1" });
+    mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
+
+    // Execute: rate limited, puis DONE: à la reprise.
+    mockSend.mockResolvedValueOnce({ content: "", toolCalls: [], costUsd: 0, durationMs: 100, sessionId: "s1", rateLimited: true, rateLimitResetsAt: undefined });
+    mockSend.mockResolvedValueOnce({ content: "DONE: patch livré", toolCalls: [], costUsd: 0.02, durationMs: 300, sessionId: "s1" });
+
+    mockVerifyFailingTest.mockResolvedValue({
+      falsifiable: false,
+      reason: "aucun fichier de test modifié — rien ne prouve le défaut",
+      testFiles: [],
+      sourceFiles: [],
+    });
+
+    const config = makeConfig({
+      phases: [
+        { name: "discover", prompt: "Scan", toolsMode: "read_only", loop: false, effort: "low" },
+        { name: "execute",  prompt: "Fix",  toolsMode: "full",      loop: true,  effort: "high", requireFailingTest: true },
+      ],
+    });
+
+    const loopPromise = runAgentLoop(config, silentLogger);
+    for (let i = 0; i < 40; i++) await vi.advanceTimersByTimeAsync(10_000);
+    await loopPromise;
+
+    expect(mockVerifyFailingTest).toHaveBeenCalled();
+    expect(mockCompleteTask).not.toHaveBeenCalled();
+    expect(mockUnclaimTask).toHaveBeenCalledWith(
+      "http://localhost:3100",
+      "t-retry",
+      "test-agent",
+    );
   });
 
   it("does NOT cycle when maxDiscoverCycles is absent (default)", async () => {

--- a/tests/unit/falsifiability.test.ts
+++ b/tests/unit/falsifiability.test.ts
@@ -7,6 +7,7 @@ import {
   verifyFailingTest,
   isTestFile,
   parseChangedFiles,
+  parseUntrackedFiles,
   type ExecResult,
 } from "../../src/agent-loop/falsifiability.js";
 
@@ -199,4 +200,232 @@ describe("verifyFailingTest contre un vrai dépôt git", () => {
     expect(existsSync(join(repo, "tests", "z.test.js"))).toBe(true);
     expect(git(repo, "stash", "list").stdout.trim()).toBe("");
   });
+});
+
+// ── Le défaut mesuré : l'agent COMMITE, le garde-fou regarde ailleurs ───
+//
+// 54 refus sur un banc de 6 runs, TOUS avec le même motif « aucun fichier de
+// test modifié — rien ne prouve le défaut », et 3 des 4 vrais défauts finissant
+// `poisoned` par run. Le garde-fou n'était pas trop strict, il était AVEUGLE :
+// behaviors/phase-execute.yaml:56 ordonne « chaque tâche nécessite son PROPRE
+// commit », falsifiability.ts:70 n'interrogeait que `git status` — l'arbre que
+// le commit vient précisément de vider. Relevé sur un worktree réel du banc :
+// `git status --porcelain --untracked-files=all` ne montrait que `?? .mcp.json`
+// pendant que `git show --name-only HEAD` listait bien src ET tests.
+describe("verifyFailingTest quand l'agent a COMMITÉ (arbre propre)", () => {
+  const git = (cwd: string, ...args: string[]) =>
+    spawnSync("git", args, { cwd, encoding: "utf8" });
+
+  const realExec = (cwd: string) => ({
+    async exec(cmd: string, args: string[]): Promise<ExecResult> {
+      const r = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+      return { code: r.status ?? -1, stdout: (r.stdout ?? "") + (r.stderr ?? "") };
+    },
+    // HORS du worktree : un patch déposé dedans se retrouverait dans le
+    // `git status` du contrôle suivant, compté comme fichier source.
+    async writeTemp(content: string): Promise<string> {
+      const p = join(mkdtempSync(join(tmpdir(), "essaim-patch-")), "p.patch");
+      writeFileSync(p, content);
+      return p;
+    },
+  });
+
+  let repo: string;
+  let base: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "essaim-fals-commit-"));
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "t@t");
+    git(repo, "config", "user.name", "t");
+    writeFileSync(join(repo, "src.js"), "module.exports = 'buggy';\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "base");
+    base = git(repo, "rev-parse", "HEAD").stdout.trim();
+  });
+
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  /** Ce que phase-execute EXIGE : patch + test, dans un commit, arbre vidé. */
+  const commitPatchAndTest = () => {
+    writeFileSync(join(repo, "src.js"), "module.exports = 'patched';\n");
+    mkdirSync(join(repo, "tests"), { recursive: true });
+    writeFileSync(join(repo, "tests", "a.test.js"), "// repro\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "fix(scanner): repro + patch");
+  };
+
+  /** Sonde HONNÊTE : elle échoue dès que le patch n'est plus là. */
+  const honestProbe = {
+    cmd: process.execPath,
+    args: [
+      "-e",
+      "const fs=require('fs');" +
+        "process.exit(fs.readFileSync('src.js','utf8').includes('patched')?0:1);",
+    ],
+  };
+
+  it("voit le patch commité et accepte un test qui échoue sans lui", async () => {
+    commitPatchAndTest();
+    // L'arbre est propre : c'est tout ce que voyait le garde-fou.
+    expect(git(repo, "status", "--porcelain", "--untracked-files=all").stdout.trim()).toBe("");
+
+    const v = await verifyFailingTest(realExec(repo), honestProbe, base);
+
+    expect(v.testFiles).toEqual(["tests/a.test.js"]);
+    expect(v.sourceFiles).toEqual(["src.js"]);
+    expect(v.falsifiable).toBe(true);
+    expect(v.reason).toContain("échoue sans le patch");
+  });
+
+  it("refuse un test complaisant commité, et rend le worktree intact", async () => {
+    commitPatchAndTest();
+    // Sonde COMPLAISANTE : elle sort 0 quel que soit l'état du worktree.
+    const v = await verifyFailingTest(
+      realExec(repo),
+      { cmd: process.execPath, args: ["-e", "process.exit(0)"] },
+      base,
+    );
+
+    expect(v.falsifiable).toBe(false);
+    expect(v.reason).toContain("passe SANS le patch");
+    // Ne JAMAIS laisser un worktree amputé de son patch.
+    expect(readFileSync(join(repo, "src.js"), "utf8")).toContain("patched");
+    expect(git(repo, "stash", "list").stdout.trim()).toBe("");
+  });
+
+  it("neutralise aussi un fichier source NON SUIVI quand le test est commité", async () => {
+    // Mixte : le test part au commit, le patch reste un fichier neuf non suivi.
+    // `git diff` ignore les non-suivis — sans traitement explicite, le patch
+    // serait invisible et le contrôle s'ouvrirait en grand.
+    mkdirSync(join(repo, "tests"), { recursive: true });
+    writeFileSync(join(repo, "tests", "b.test.js"), "// repro\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "test only");
+    writeFileSync(join(repo, "newsrc.js"), "module.exports = 1;\n");
+
+    const v = await verifyFailingTest(
+      realExec(repo),
+      {
+        cmd: process.execPath,
+        args: ["-e", "process.exit(require('fs').existsSync('newsrc.js')?0:1);"],
+      },
+      base,
+    );
+
+    // CONTRAT CHANGÉ, et c'est délibéré. La rédaction précédente faisait entrer
+    // ce fichier non suivi dans le patch via `git add --intent-to-add` pour que
+    // la neutralisation le supprime. Mesuré : ça mettait AUSSI `.mcp.json` — non
+    // suivi dans tous les worktrees d'agent — dans le « patch de production »,
+    // et comme la restauration est un `git apply` unique donc ATOMIQUE, un
+    // artefact recréé par le lancement des tests faisait échouer le patch
+    // ENTIER : le correctif de l'agent disparaissait pendant que la tâche
+    // partait en completeTask. On préfère désormais ne rien conclure.
+    expect(v.sourceFiles).toEqual(["newsrc.js"]);
+    expect(v.falsifiable).toBe(true);
+    expect(v.reason).toContain("non suivi");
+    expect(v.reason).not.toContain("passe SANS le patch");
+    // Et surtout : le fichier de l'agent n'a pas bougé d'un octet.
+    expect(existsSync(join(repo, "newsrc.js"))).toBe(true);
+    expect(git(repo, "status", "--porcelain", "--untracked-files=all").stdout).toContain("?? newsrc.js");
+  });
+
+  // RÉGRESSION — le garde-fou ne doit JAMAIS faire perdre le correctif.
+  //
+  // La première rédaction du patch inverse faisait entrer tout fichier NON
+  // SUIVI non-test dans le « patch de production » via `git add
+  // --intent-to-add`, pour que la neutralisation le supprime. Or `.mcp.json`
+  // est non suivi dans TOUS les worktrees d'agent (promptweave l'y dépose à la
+  // création), et la restauration est un `git apply` unique, donc ATOMIQUE :
+  // il suffisait que le lancement des tests recrée l'artefact pour que git
+  // refuse le patch ENTIER (« already exists in working directory ») et que le
+  // correctif de l'agent disparaisse — pendant que le verdict restait
+  // `falsifiable: true` et que la tâche partait en completeTask.
+  //
+  // La base de comparaison n'est donc pas un simple SHA : c'est le SHA PLUS
+  // l'inventaire des non-suivis déjà présents. Ce test échoue si on le retire.
+  it("ne touche pas à un artefact non suivi préexistant, et garde le patch intact", async () => {
+    const mcp = join(repo, ".mcp.json");
+    writeFileSync(mcp, "{}\n");
+    const baseUntracked = parseUntrackedFiles(
+      git(repo, "status", "--porcelain", "--untracked-files=all").stdout,
+    );
+    expect(baseUntracked).toContain(".mcp.json");
+
+    // L'agent corrige la source ET écrit le test, puis COMMITE LES DEUX —
+    // nommément, sans `git add -A` : dans les vrais worktrees du banc,
+    // `.mcp.json` est resté NON SUIVI (`?? .mcp.json` dans status).
+    writeFileSync(join(repo, "src.js"), "module.exports = 'patched';\n");
+    mkdirSync(join(repo, "tests"), { recursive: true });
+    writeFileSync(join(repo, "tests", "a.test.js"), "// repro\n");
+    git(repo, "add", "--", "src.js", "tests/a.test.js");
+    git(repo, "commit", "-qm", "fix + test");
+
+    // Lanceur : recrée l'artefact (le cas qui faisait échouer la restauration
+    // atomique), puis échoue si le patch est absent — un vrai test de régression.
+    const runner = {
+      cmd: process.execPath,
+      args: [
+        "-e",
+        `const fs=require("fs");fs.writeFileSync(${JSON.stringify(mcp)},"{}");`
+          + `process.exit(fs.readFileSync(${JSON.stringify(join(repo, "src.js"))},"utf8").includes("patched")?0:1)`,
+      ],
+    };
+
+    const v = await verifyFailingTest(realExec(repo), runner, base, baseUntracked);
+
+    expect(v.falsifiable).toBe(true);
+    expect(v.sourceFiles).not.toContain(".mcp.json");
+    // LE POINT DU TEST : le correctif de l'agent est toujours là.
+    expect(readFileSync(join(repo, "src.js"), "utf8")).toContain("patched");
+  });
+});
+
+// ── Second étage : une neutralisation sans effet ne doit RIEN conclure ──
+//
+// Réparer la base de diff sans réparer la neutralisation aurait été PIRE que le
+// défaut d'origine : `git stash push` sur des chemins propres-parce-que-commités
+// sort 0 SANS RIEN REMISER (vérifié sur un dépôt jetable), le test était alors
+// rejoué AVEC le patch encore en place, il passait, et le garde-fou concluait
+// « le test passe SANS le patch ». 54 refus muets seraient devenus 54 refus
+// MENSONGERS. D'où ce contrôle de l'effet de la neutralisation.
+describe("verifyFailingTest — garde-fou du garde-fou", () => {
+  /** Faux exécuteur qui matche la ligne de commande COMPLÈTE. */
+  function scriptedExec(reply: (line: string) => ExecResult | undefined) {
+    const calls: string[] = [];
+    return {
+      calls,
+      deps: {
+        async exec(cmd: string, args: string[]): Promise<ExecResult> {
+          const line = `${cmd} ${args.join(" ")}`;
+          calls.push(line);
+          return reply(line) ?? { code: 0, stdout: "" };
+        },
+        async writeTemp(_content: string): Promise<string> {
+          return "/tmp/essaim.patch";
+        },
+      },
+    };
+  }
+
+  it("fail-open explicite quand la neutralisation n'a rien changé", async () => {
+    const { deps } = scriptedExec((line) => {
+      if (line.startsWith("git status")) return { code: 0, stdout: "" }; // arbre propre
+      if (line === "git diff --name-only BASE HEAD") return { code: 0, stdout: "src/a.ts\ntests/unit/x.test.ts\n" };
+      if (line === "git diff --binary BASE -- src/a.ts") return { code: 0, stdout: "--- a/src/a.ts\n+++ b/src/a.ts\n" };
+      if (line.startsWith("git apply -R")) return { code: 0, stdout: "" }; // ment : sort 0 sans agir
+      // Le contrôle d'effet : le fichier est TOUJOURS modifié après « neutralisation ».
+      if (line === "git diff --name-only BASE -- src/a.ts") return { code: 0, stdout: "src/a.ts\n" };
+      return { code: 0, stdout: "" }; // le lanceur de tests passe, patch en place
+    });
+
+    const v = await verifyFailingTest(deps, TEST_CMD, "BASE");
+
+    // Le seul verdict négatif légitime est « test complaisant ». Ici on ne sait
+    // rien : il faut le dire, pas accuser.
+    expect(v.falsifiable).toBe(true);
+    expect(v.reason).toContain("sans effet");
+    expect(v.reason).not.toContain("passe SANS le patch");
+  });
+
 });


### PR DESCRIPTION
## Le défaut

Deux lignes qui se contredisent :

- `behaviors/phase-execute.yaml:56` — « Chaque tâche nécessite son PROPRE commit », `:59` « puis dis DONE: »
- `src/agent-loop/falsifiability.ts` — n'interrogeait que `git status`, c'est-à-dire **l'arbre de travail que le commit vient de vider**

Le garde-fou n'était pas trop strict : il était **aveugle**. Relevé sur un worktree réel du banc :

```
$ git status --porcelain --untracked-files=all
?? .mcp.json                          <- tout ce que le garde-fou voyait

$ git show --name-only HEAD
src/orchestrator/scanner.ts
tests/unit/scanner.test.ts            <- source ET test, exactement l'exigence
```

## La mesure

Banc de 6 runs sur charge identique (4 défauts réels dans 4 fichiers, même semis), puis 3 runs après correctif.

| | avant | après |
|---|---|---|
| `DONE refusé` | 54 (tous du même motif) | **1** |
| threads empoisonnés (base SQLite) | 2,0 / 4 en moyenne | **0,33 / 4** |
| tâches complétées | 5 sur 3 runs | **11 sur 3 runs** |
| fail-open (`contrôle sauté`) | — | **0** |

Zéro fail-open est le chiffre qui compte : chaque verdict rendu est un vrai verdict — neutralisation faite, test rejoué — et non un contournement silencieux.

## Pourquoi le changement devait être atomique

Réparer la base de diff **sans** réparer la neutralisation aurait été pire que le défaut. Vérifié sur un dépôt jetable, patch et test commités, arbre propre :

```
git status:[]
git stash push --quiet --include-untracked -- src.ts
  -> exit 0, rien remisé, src.ts contient toujours "patched"
```

`git stash push` sur des chemins propres-parce-que-commités sort 0 **sans rien remiser**. Le test aurait été rejoué avec le patch en place, il passe, et le verdict devient « le test passe SANS le patch » : 54 refus muets transformés en 54 refus **mensongers**.

## Ce que fait ce PR

- la base de comparaison devient le SHA relevé avant la tâche **plus** l'inventaire des non-suivis déjà présents
- neutralisation par patch inverse (`git diff <base>` puis `git apply -R`), seul primitif symétrique face à un commit
- **garde-fou du garde-fou** : si la neutralisation n'a rien changé, le verdict est un fail-open explicite, jamais une accusation

## Défauts trouvés par relecture adversariale, tous corrigés

- un artefact non suivi entrant dans le patch pouvait faire **perdre le correctif de l'agent** — `git apply` est atomique, et `.mcp.json` est non suivi dans tous les worktrees ; repli sur `git checkout HEAD --`, et les non-suivis ne sont plus jamais touchés
- `--binary` : un seul binaire désarmait tout le contrôle
- les renommages sont décodés ; sous `shell: true` le chevron était interprété comme une redirection et écrasait un fichier source
- `shell: true` réservé au lanceur de tests : `git` est un `.exe`, et sous shell Node ne cite pas les arguments — un chemin à espace produisait un refus mensonger
- `verifyFailingTest` ne jette plus jamais : `ENAMETOOLONG` tuait la boucle entière

## Vérification

`pnpm test` : 75 fichiers, 788 passés, 1 ignoré. `pnpm build` vert.

Le test de régression sur la perte du correctif est falsifié par mutation exécutée : retirer la soustraction des non-suivis préexistants le fait échouer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
