### PR TITLE
fix(work-stealing): une annonce de coordination n'est pas un item de travail

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -407,7 +407,7 @@ async function coordinatorPost(
   return (await resp.json()) as Record<string, unknown>;
 }
 
-async function announceViaRest(
+export async function announceViaRest(
   coordinatorUrl: string,
   agentId: string,
   work: WorkDescription,
@@ -421,6 +421,25 @@ async function announceViaRest(
     target_files: work.targetFiles,
     depends_on_files: work.dependsOnFiles,
     exports_affected: work.exportsAffected,
+    // PAS d'estampille run_id ici — et c'est DÉLIBÉRÉ, contrairement aux deux
+    // autres chemins d'annonce (postDiscoveries et le NOUVEAU groupé, qui la
+    // passent tous deux depuis #32).
+    //
+    // Elle ne fermerait qu'une fuite INTER-runs, dont le banc de 6 runs n'a
+    // mesuré aucune occurrence, et dont le vrai dommage — être réclamée comme
+    // tâche — est déjà fermé par isWorkItem() dans work-stealing.ts. En face,
+    // elle régresserait une ligne de rapport rendue honnête exprès :
+    // /api/threads-summary filtre en ÉGALITÉ STRICTE sur run_id (voir le
+    // commentaire de fetchThreadsSummary dans orchestrator/metrics.ts), donc
+    // les annonces en sont aujourd'hui exclues et la note « État final
+    // (coordinator, faisant autorité) » ne compte que du vrai travail.
+    // Estampillées, les N annonces de boot entreraient dans le total : un raid
+    // à 4 agents qui corrige 4 bugs afficherait 8 threads au lieu de 4.
+    // Vérifié sur un rapport réel du banc : threads_opened=9, threads_final
+    // {total:4, poisoned:4} — l'égalité stricte est prouvée par artefact.
+    //
+    // À rouvrir seulement si /api/threads-summary apprend à ne compter que les
+    // items de travail (`AND timeout_seconds = 0`), côté mcp-coordinator.
   });
 
   const threadId = (data.thread_id as string) || "";
@@ -1042,6 +1061,17 @@ export async function runAgentLoop(
             // Work-stealing loop with grace period for late discoveries
             let tasksDone = 0;
             let emptyRetries = 0;
+            // Laissé à 3, contre mon intuition — et c'est la mesure qui a
+            // tranché. Le garde-fou isWorkItem() supprime une temporisation
+            // ACCIDENTELLE : avant, un agent arrivé en execute avant ses pairs
+            // réclamait une annonce et y brûlait des minutes, pendant
+            // lesquelles les découvertes des pairs plus lents atterrissaient.
+            // La crainte était qu'un agent rapide sorte désormais en 30 s sans
+            // rien faire. Sur les 3 runs de validation, ça ne s'est produit
+            // AUCUNE fois : les 4 agents de chaque run ont pris leur tâche
+            // (« 1 tasks done » x4), et le second cycle seul trouve le pool
+            // vide. Porter le budget à 6 aurait ajouté 30 s d'attente par
+            // agent et par cycle pour un problème qui ne se manifeste pas.
             const MAX_EMPTY_RETRIES = 3;
             const EMPTY_WAIT_MS = 10_000;  // 10s between retries
 

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -41,6 +41,50 @@ function safeParseArray(raw: string): unknown[] {
   }
 }
 
+// Une ANNONCE de coordination n'est pas un item de travail (#142).
+//
+// Mesuré sur un banc de 6 runs à charge identique : 22 des 23 threads
+// abandonnés étaient des annonces d'intention. claimNextTask réclamait
+// n'importe quel thread ouvert non réclamé ; comme une annonce porte
+// target_files vide, computeBusyFiles() ne la voyait jamais en conflit et
+// rien ne l'écartait. L'agent la réclamait, cherchait 20 tours ce qu'il
+// devait faire, plafonnait en error_max_turns, la déréclamait — et elle
+// repartait au pool pour le suivant. 15 tours sur 59 (25 %) finissaient
+// ainsi, brûlant 16,4 M des 32,9 M de jetons cache-read : LA MOITIÉ de la
+// dépense du banc.
+//
+// Le discriminant est keep_open, que le coordinator persiste dans
+// timeout_seconds : `keepOpen ? 0 : 600` à l'INSERT (consultation.ts, avec
+// `keepOpen = params.keep_open || assignedTo !== null`), et listThreads fait
+// `SELECT * FROM threads` — la colonne arrive donc telle quelle dans
+// /api/threads-active. Le balayeur confirme le sens : il ne périme que
+// `timeout_seconds > 0`. Un 0 veut dire « ne se périme jamais », c'est-à-dire
+// un item qui ATTEND UN PRENEUR. Les trois chemins qui postent du vrai
+// travail (postDiscoveries et le NOUVEAU groupé ci-dessous, findingToAnnounce
+// dans security/ingest.ts) envoient tous keep_open: true ; announceViaRest
+// est le seul à ne pas l'envoyer. Le dispatch dirigé est couvert gratuitement
+// (assigned_to implique keepOpen côté coordinator).
+//
+// Discriminant ÉCARTÉ — « target_files vide ⇒ pas une tâche » : il sépare
+// bien les familles observées, mais il casse trois producteurs de vrai
+// travail sans fichier, dont security/ingest.ts qui poste target_files: []
+// pour tout finding sans code_location (documenté tel quel dans
+// security/types.ts). La vuln serait sortie du pool en silence, exit 0,
+// rapport vert — du gaspillage transformé en PERTE, ce qui est pire.
+// Également écarté : expected_respondents (vaut "[]" pour l'annonce COMME
+// pour l'item semé — hypothèse testée sur coordinator réel et réfutée).
+//
+// Même prudence de lecture que threadFiles ci-dessus (#139) : la valeur
+// arrive d'une ligne SQLite brute, elle peut être un nombre, une chaîne, ou
+// manquer. Absente ou illisible, on dégrade vers RÉCLAMABLE — jamais vers
+// l'exclusion, sinon un pool de vrais items tous écartés fait sortir l'agent
+// par « pool empty », proprement, sans avoir rien fait.
+function isWorkItem(thread: Record<string, unknown>): boolean {
+  const raw = thread.timeout_seconds;
+  const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+  return !Number.isFinite(n) || n === 0;
+}
+
 const DISCOVERY_MARKER = "DISCOVERY:";
 
 /**
@@ -248,6 +292,16 @@ export async function claimNextTask(
 
   let busyFiles = computeBusyFiles(open, agentId);
 
+  // COMPTEUR D'ÉCARTÉS — en info, pas en debug, et c'est le point.
+  // La dégradation d'isWorkItem() est « réclamable » : un thread dont
+  // timeout_seconds est illisible passe. Un garde-fou qui dégrade en silence ne
+  // peut pas être distingué d'un garde-fou INERTE — c'est exactement ce qui
+  // s'est passé avec le départage post-claim de #141, dont le compteur de
+  // cessions valait 0 sur trois runs sans que personne le voie. Une valeur nulle
+  // ici, alors que des tours finissent en error_max_turns, veut dire que le
+  // mécanisme ne sert à rien : il faut pouvoir le lire dans le log du run.
+  let skippedAnnounces = 0;
+
   // What has already LANDED on each file this run, so the executing agent can
   // recognise a duplicate rather than re-committing it.
   const doneByFile = new Map<string, string[]>();
@@ -264,6 +318,12 @@ export async function claimNextTask(
   for (const thread of threads) {
     if (thread.status !== "open") continue;
     if (thread.claimed_by) continue;
+    // Le garde-fou de #142.
+    if (!isWorkItem(thread)) {
+      skippedAnnounces++;
+      log.debug(`skipping thread=${thread.id} — annonce de coordination (timeout_seconds=${String(thread.timeout_seconds)}), pas un item de travail`);
+      continue;
+    }
 
     const files = threadFiles(thread);
     const conflict = files.find((f) => busyFiles.has(f));
@@ -299,6 +359,9 @@ export async function claimNextTask(
         if (relatedDone.length > 0) {
           log.info(`thread=${threadId}: ${relatedDone.length} résolution(s) déjà livrée(s) sur ${files.join(", ")} — contexte injecté`);
         }
+        if (skippedAnnounces > 0) {
+          log.info(`claimNextTask: ${skippedAnnounces} annonce(s) de coordination écartée(s) — pas des items de travail`);
+        }
         return {
           id: threadId,
           description: subject,
@@ -325,6 +388,9 @@ export async function claimNextTask(
     }
   }
 
+  if (skippedAnnounces > 0) {
+    log.info(`claimNextTask: ${skippedAnnounces} annonce(s) de coordination écartée(s) — pas des items de travail`);
+  }
   log.debug("claimNextTask: nothing to claim");
   return null;
 }

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -262,3 +262,127 @@ describe('claimNextTask — départage déterministe après double claim réussi
     expect(unclaimed).toHaveLength(0);
   });
 });
+
+// #142 — une annonce de coordination n'est pas un item de travail.
+//
+// Mesure (banc de 6 runs, charge identique de 4 vrais défauts) : 22 des 23
+// threads abandonnés étaient des ANNONCES d'intention, jamais du travail. Un
+// agent en réclamait une, cherchait 20 tours ce qu'il devait faire, plafonnait
+// en error_max_turns, la déréclamait — et elle repartait au pool pour le
+// suivant. 15 tours sur 59 (25 %) finissaient ainsi, brûlant 16,4 M des 32,9 M
+// de jetons cache-read : LA MOITIÉ de la dépense du banc.
+//
+// Discriminant RETENU : timeout_seconds === 0, c'est-à-dire keep_open.
+// Le coordinator écrit `keepOpen ? 0 : 600` (consultation.ts:229, avec
+// `keepOpen = params.keep_open || assignedTo !== null` ligne 210) et listThreads
+// fait `SELECT * FROM threads` — la colonne arrive donc telle quelle dans
+// /api/threads-active. Un `0` signifie « ne se périme jamais » : le balayeur
+// l'ignore (`AND timeout_seconds > 0`), c'est un item qui ATTEND UN PRENEUR.
+//
+// Discriminant ÉCARTÉ : « target_files vide ⇒ pas une tâche ». Réfuté sur
+// quatre chemins livrés, dont src/security/ingest.ts qui poste `target_files:
+// []` avec `keep_open: true` pour tout finding sans code_location (documenté
+// tel quel dans src/security/types.ts) — il serait devenu invisible au swarm de
+// remédiation, en silence, exit 0. Les cas ci-dessous verrouillent ça.
+describe("claimNextTask — une annonce de coordination n'est pas une tâche (#142)", () => {
+  it("n'essaie même pas de claim une annonce d'intention (timeout_seconds=600)", async () => {
+    // La forme exacte de la ligne SQLite du run A1 : target_files vide, des
+    // modules, run_id NULL, timeout 600. Elle reste `open` dès que le scorer
+    // d'impact a trouvé un pair concerné (sinon le coordinator l'auto-résout).
+    const fetchMock = mockCoordinator([
+      { id: 't1', status: 'open', claimed_by: null, target_files: '[]', target_modules: '["agent-loop","orchestrator"]', expected_respondents: '[]', run_id: null, timeout_seconds: 600, subject: 'agent-sentinelle-1 starting work on agent-loop, orchestrator' },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task).toBeNull();
+    const claimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/claim-task'));
+    expect(claimed).toHaveLength(0);
+  });
+
+  it("claim un item de travail semé SANS fichier cible (timeout_seconds=0) — le discriminant n'est PAS target_files", async () => {
+    // C'est le cas que « target_files vide ⇒ pas une tâche » aurait cassé :
+    // un finding de sécurité sans code_location (src/security/ingest.ts:81,
+    // keep_open: true) est du travail légitime, et il doit rester réclamable.
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't2', status: 'open', claimed_by: null, target_files: '[]', target_modules: '[]', run_id: 'bench-A1', timeout_seconds: 0, subject: 'high: secret en clair dans la config' },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('t2');
+  });
+
+  it("les trois familles réelles du run A1 côte à côte : seul l'item semé est réclamé", async () => {
+    const fetchMock = mockCoordinator([
+      // ANNONCE — agent-loop.ts n'envoie pas keep_open → 600 → écartée.
+      { id: 'a1', status: 'open', claimed_by: null, target_files: '[]', target_modules: '["agent-loop","orchestrator","pipeline","security"]', expected_respondents: '[]', run_id: null, timeout_seconds: 600, subject: 'agent-sentinelle-3 starting work on agent-loop' },
+      // TRAVAIL semé — ingest.ts envoie keep_open: true → 0 → réclamable.
+      { id: 'w1', status: 'open', claimed_by: null, target_files: '["src/orchestrator/preflight.ts"]', target_modules: '[]', expected_respondents: '[]', run_id: 'bench-A1', timeout_seconds: 0, subject: 'major: pas de garde sur le chemin destructif' },
+      // ANNONCE announce-before-write postée par un agent via le MCP
+      // announce_work, avec ses fichiers : elle doit alimenter busyFiles mais
+      // ne JAMAIS être réclamée. expected_respondents "[]" ne discrimine rien
+      // ici — hypothèse testée sur coordinator réel et réfutée.
+      { id: 'a2', status: 'open', claimed_by: null, target_files: '["src/orchestrator/preflight.ts","tests/unit/preflight.test.ts"]', target_modules: '["orchestrator"]', expected_respondents: '["agent-sentinelle-3","seeder"]', run_id: null, timeout_seconds: 600, subject: 'je vais toucher preflight.ts' },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('w1');
+    const claimed = fetchMock.mock.calls
+      .filter((c) => String(c[0]).endsWith('/api/claim-task'))
+      .map((c) => JSON.parse((c[1] as RequestInit).body as string).thread_id);
+    expect(claimed).toEqual(['w1']); // a1 et a2 jamais tentés
+  });
+
+  it('timeout_seconds absent dégrade vers RÉCLAMABLE, jamais vers l\'exclusion', async () => {
+    // Même prudence que threadFiles : une colonne manquante ou illisible ne
+    // doit pas transformer du gaspillage en PERTE SILENCIEUSE (un pool de
+    // vrais items tous écartés sort par « pool empty », exit 0, rapport vert).
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't3', status: 'open', claimed_by: null, target_files: '["src/a.ts"]' },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+    expect(task?.id).toBe('t3');
+  });
+
+  it('timeout_seconds illisible dégrade aussi vers réclamable', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't4', status: 'open', claimed_by: null, target_files: '["src/a.ts"]', timeout_seconds: 'jamais' },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+    expect(task?.id).toBe('t4');
+  });
+
+  it('tolérance de forme : timeout_seconds en chaîne, target_files en TABLEAU déjà décodé', async () => {
+    // Le coordinator livre des chaînes ; un appelant (ou un futur coordinator
+    // qui désérialiserait) peut livrer des types natifs. Les deux formes
+    // doivent conclure pareil, sinon on rejoue le bug de classe de #139.
+    const fetchMock = mockCoordinator([
+      { id: 'a1', status: 'open', claimed_by: null, target_files: [], timeout_seconds: '600' },
+      { id: 'w1', status: 'open', claimed_by: null, target_files: ['src/a.ts'], timeout_seconds: '0' },
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+
+    expect(task?.id).toBe('w1');
+    const claimed = fetchMock.mock.calls
+      .filter((c) => String(c[0]).endsWith('/api/claim-task'))
+      .map((c) => JSON.parse((c[1] as RequestInit).body as string).thread_id);
+    expect(claimed).toEqual(['w1']);
+  });
+
+  it('le dispatch dirigé reste réclamable par son destinataire (assigned_to implique keep_open côté coordinator)', async () => {
+    vi.stubGlobal('fetch', mockCoordinator([
+      { id: 't5', status: 'open', claimed_by: null, assigned_to: 'hunter-2', target_files: '[]', timeout_seconds: 0, subject: 'lead → worker' },
+    ]));
+
+    const task = await claimNextTask('https://c', 'hunter-2');
+    expect(task?.id).toBe('t5');
+  });
+});

--- a/tests/unit/run-id.test.ts
+++ b/tests/unit/run-id.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { currentRunId, ensureRunId } from '../../src/run-id.js';
 import { claimNextTask, postDiscoveries } from '../../src/agent-loop/work-stealing.js';
+import { announceViaRest } from '../../src/agent-loop/agent-loop.js';
 
 beforeEach(() => { delete process.env.ESSAIM_RUN_ID; });
 afterEach(() => { vi.unstubAllGlobals(); delete process.env.ESSAIM_RUN_ID; });
@@ -57,6 +58,38 @@ describe('work-stealing — estampillage du run (#32)', () => {
     await claimNextTask('https://c', 'a1');
 
     const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.run_id).toBeUndefined();
+  });
+});
+
+// #142 — l'annonce de coordination reste DÉLIBÉRÉMENT non estampillée.
+//
+// Ces deux cas verrouillent le corps que `announceViaRest` envoie, parce que le
+// garde-fou `isWorkItem()` de work-stealing.ts repose entièrement dessus :
+//
+//  - PAS de `keep_open` : c'est ce qui fait écrire `timeout_seconds = 600` au
+//    coordinator, donc ce qui distingue une annonce d'un item de travail. Sans
+//    ce verrou la régression était INVISIBLE — vérifié par mutation exécutée :
+//    ajouter `keep_open: true` laissait la suite entière verte tout en rendant
+//    le garde-fou totalement inerte.
+//  - PAS de `run_id` : les deux autres chemins d'annonce le passent (#32), et
+//    l'ajouter ici est le réflexe évident. Ce serait une régression du rapport :
+//    /api/threads-summary filtre en égalité stricte, donc les annonces en sont
+//    aujourd'hui exclues et la note « faisant autorité » ne compte que du vrai
+//    travail. Estampillées, un raid à 4 agents qui corrige 4 bugs afficherait
+//    8 threads. Mesuré sur un rapport réel : threads_opened=9, threads_final
+//    {total:4, poisoned:4}.
+describe("agent-loop — le corps de l’annonce de coordination (#142)", () => {
+  it("n’envoie ni keep_open ni run_id — les deux verrous dont isWorkItem() dépend", async () => {
+    process.env.ESSAIM_RUN_ID = 'run-42';
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(JSON.stringify({ thread_id: 't1', status: 'open' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await announceViaRest('https://c', 'a1', { subject: 'a1 starting work', targetModules: ['agent-loop'], targetFiles: [] });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.keep_open).toBeUndefined();
+    // Même avec ESSAIM_RUN_ID posé dans l'environnement.
     expect(body.run_id).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Le défaut

Chaque agent publie au démarrage une annonce d'intention (« Sentinelle Bravo starting work on agent-loop, orchestrator… »). Elle atterrit dans le **même pool** que `claimNextTask` utilise comme file de travail, et `claimNextTask` réclamait n'importe quel thread ouvert non réclamé.

Une annonce porte `target_files` vide, donc `computeBusyFiles` ne la voyait jamais en conflit : rien ne l'écartait. Un agent la réclamait, cherchait 20 tours ce qu'il devait faire, plafonnait en `error_max_turns`, la déréclamait — et elle repartait au pool pour le suivant.

## La mesure

Banc de 6 runs à charge identique (4 défauts réels dans 4 fichiers, même semis), puis 3 runs après correctif.

| | avant | après |
|---|---|---|
| threads abandonnés qui sont des annonces | **22 sur 23** | — |
| annonces réclamées | 19 sur 3 runs | **0** |
| `error_max_turns` | 33 sur 3 runs | **5** |
| tâches complétées | 5 sur 3 runs | **11 sur 3 runs** |

Les tours plafonnés brûlaient 16,4 M des 32,9 M de jetons cache-read du banc — la moitié de la dépense, pour zéro travail accepté. La frontière était exacte : tous les tours à 20 outils et plus plafonnaient, tous ceux à 19 et moins réussissaient (`high` = opus / `maxTurns: 20`).

## Le discriminant, et les deux écartés

Retenu : **`keep_open`**, que le coordinator persiste dans `timeout_seconds` (`keepOpen ? 0 : 600`). Un `0` signifie « ne se périme jamais », c'est-à-dire un item qui attend un preneur. Les trois chemins qui postent du vrai travail passent `keep_open: true` ; l'annonce de coordination est la seule à ne pas le passer. Vérifié présent sur le fil dans les deux générations de coordinator.

Écartés après vérification :

- **`target_files` vide** — cassait `src/security/ingest.ts`, qui poste `target_files: []` pour tout finding sans `code_location` (comportement documenté dans `security/types.ts`). La vulnérabilité serait sortie du pool en silence, sortie 0, rapport vert. Du gaspillage transformé en perte, ce qui est pire.
- **`expected_respondents`** — vaut `"[]"` pour l'annonce **comme** pour l'item de travail. Hypothèse testée sur un coordinator réel et réfutée.

Toute forme dégénérée de `timeout_seconds` (absent, nul, chaîne vide, illisible) dégrade vers **réclamable**, jamais vers l'exclusion : un pool de vrais items tous écartés ferait sortir l'agent proprement, sans rien avoir fait.

## Le compteur d'écartés est en `info`, pas en `debug`

C'est délibéré. La dégradation est silencieuse, donc un garde-fou **inerte** serait indistinguable d'un garde-fou qui marche. C'est exactement ce qui est arrivé au départage post-claim de #141, dont le compteur de cessions valait 0 sur trois runs sans que personne le voie. Une valeur nulle ici, alors que des tours finissent en `error_max_turns`, veut dire que le mécanisme ne sert à rien — il faut pouvoir le lire.

## Ce que ce PR ne fait PAS, volontairement

`announceViaRest` **ne passe pas** `run_id`, contrairement aux deux autres chemins d'annonce. L'estampille ne fermerait qu'une fuite inter-runs, dont le banc n'a mesuré aucune occurrence, et dont le vrai dommage — être réclamée comme tâche — est déjà fermé ici.

En face, elle régresserait une ligne de rapport rendue honnête exprès : `/api/threads-summary` filtre en **égalité stricte** sur `run_id`, donc les annonces en sont aujourd'hui exclues. Estampillées, un raid à 4 agents qui corrige 4 bugs afficherait « 8 threads » au lieu de 4. Vérifié sur un rapport réel du banc : `threads_opened=9`, `threads_final {total:4, poisoned:4}`.

Un test verrouille les **deux** champs absents (`keep_open` et `run_id`), avec la raison en commentaire. Sans ce verrou la régression était invisible : vérifié par mutation exécutée, ajouter `keep_open: true` laissait la suite entière verte tout en rendant le garde-fou totalement inerte.

## Vérification

`pnpm test` : 75 fichiers, 790 passés, 1 ignoré. `pnpm build` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
