### PR TITLE
fix(falsifiability): la ligne de base appartient au thread, pas a la tentative

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -641,6 +641,30 @@ export async function runAgentLoop(
   // Track which threads this agent has claimed (for MQTT filtering)
   const claimedThreadIds = new Set<string>();
 
+  /**
+   * Ligne de base du garde-fou de falsifiabilité, UNE PAR THREAD.
+   *
+   * Clé = le thread, jamais l'agent. Une base unique par agent, relevée au
+   * démarrage de la boucle, serait plus courte et complaisante : le même
+   * worktree sert à toutes les tâches d'affilée, donc le test écrit pour la
+   * tâche 1 créditerait la tâche 2 qui n'en a produit aucun. Voir le cas
+   * « ne crédite PAS un thread du test écrit pour le thread précédent ».
+   *
+   * PURGÉE À LA COMPLÉTION (voir settleDone). Le cas « thread complété, puis
+   * un AUTRE thread sur le même fichier » se règle tout seul — l'autre thread
+   * a sa propre clé, donc sa propre base, qui inventorie le travail du premier
+   * comme préexistant, commité ou non. Ce qui reste à trancher est le thread
+   * ROUVERT par le coordinator : sans purge il rejouerait éternellement la
+   * base de sa toute première réclamation et se ferait créditer d'un test déjà
+   * livré. On purge donc — une reprise après complétion repart d'une base
+   * fraîche et doit prouver son propre travail. Le sens conservateur : le
+   * garde-fou peut trop demander, jamais trop peu.
+   *
+   * Portée du run, comme claimedThreadIds : un thread abandonné au cycle N
+   * peut être re-réclamé au cycle N+1, dans le même worktree.
+   */
+  const threadBaselines = new Map<string, { sha?: string; untracked: string[] }>();
+
   const mqtt: MqttListener = createMqttListener({
     url: config.mqttUrl,
     agentId: config.agentId,
@@ -1239,10 +1263,25 @@ export async function runAgentLoop(
               // compare contre ce SHA. Sans lui il n'inspecte que l'arbre de
               // travail, que le commit par tâche vide — 54 refus « aucun
               // fichier de test modifié » sur un banc de 6 runs.
+              //
+              // RELEVÉ UNE FOIS PAR THREAD, PAS PAR TENTATIVE. Une tâche peut
+              // être re-réclamée par le MÊME agent après un abandon sans DONE:
+              // (`error_max_turns`), et le travail de l'essai précédent est
+              // alors DÉJÀ dans l'arbre. Mesuré au run G3 : un refus sur douze,
+              // thread 2a2548b3 réclamé deux fois — l'essai 1 écrit source et
+              // test sans commiter, l'essai 2 n'a plus rien à écrire, lance les
+              // tests et dit DONE:. Une base relevée à la seconde réclamation
+              // inventorie le test de l'essai 1 comme non-suivi PRÉEXISTANT, le
+              // soustrait, et refuse « aucun fichier de test modifié » sur un
+              // travail réellement fait — qui part ensuite à la poubelle. La
+              // soustraction de #142 retournée contre le correctif qu'elle
+              // protège. L'unité de jugement est le THREAD.
               const falsifiabilityDeps = gitExec(config.workspacePath);
-              const taskBase = phase.requireFailingTest
-                ? await taskBaseline(falsifiabilityDeps)
-                : undefined;
+              let taskBase = threadBaselines.get(task.id);
+              if (phase.requireFailingTest && !taskBase) {
+                taskBase = await taskBaseline(falsifiabilityDeps);
+                threadBaselines.set(task.id, taskBase);
+              }
 
               /**
                * Un seul chemin « l'agent a dit DONE: », pour les DEUX envois.
@@ -1279,6 +1318,10 @@ export async function runAgentLoop(
                 }
                 logger.info(`Work-stealing: completed${after} — "${taskSummary.slice(0, 80)}"`);
                 await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
+                // La base ne survit PAS à la complétion : elle n'existe que
+                // pour recoller les tentatives d'un thread INACHEVÉ. Sur refus,
+                // au contraire, on la garde — c'est tout l'objet du correctif.
+                threadBaselines.delete(task.id);
                 tasksDone++;
               };
 

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -190,17 +190,20 @@ function gitExec(cwd: string): FalsifiabilityDeps {
  */
 async function taskBaseline(
   deps: FalsifiabilityDeps,
-): Promise<{ sha?: string; untracked: string[] }> {
+): Promise<{ sha: string; untracked: string[] } | undefined> {
   const r = await deps.exec("git", ["rev-parse", "HEAD"]);
   const sha = r.stdout.trim();
   // Les non-suivis DÉJÀ LÀ avant la tâche. Sans cet inventaire, `.mcp.json` —
   // que promptweave dépose dans chaque worktree à sa création — compte comme
   // « fichier de production changé » à chaque tâche.
   const st = await deps.exec("git", ["status", "--porcelain", "--untracked-files=all"]);
-  return {
-    sha: r.code === 0 && sha ? sha : undefined,
-    untracked: st.code === 0 ? parseUntrackedFiles(st.stdout) : [],
-  };
+  // Tout ou rien. Une base partielle est PIRE qu'aucune : sans `sha` le
+  // contrôle retombe sur l'arbre seul (le défaut aveugle de #142), et sans
+  // l'inventaire des non-suivis `.mcp.json` redevient un « fichier de
+  // production » et fait sauter le contrôle à chaque DONE:. L'appelant ne
+  // mémorise que ce qui est complet.
+  if (r.code !== 0 || !sha || st.code !== 0) return undefined;
+  return { sha, untracked: parseUntrackedFiles(st.stdout) };
 }
 
 /**
@@ -663,7 +666,25 @@ export async function runAgentLoop(
    * Portée du run, comme claimedThreadIds : un thread abandonné au cycle N
    * peut être re-réclamé au cycle N+1, dans le même worktree.
    */
-  const threadBaselines = new Map<string, { sha?: string; untracked: string[] }>();
+  // UN SEUL emplacement, pas une Map — et c'est le point du correctif.
+  //
+  // Une Map par thread paraissait plus juste : chaque thread garderait sa base
+  // et la retrouverait à la reprise. Deux relectures indépendantes l'ont cassée
+  // par exécution : l'entrée survit à l'abandon, mais aussi à TOUT ce qui se
+  // passe entre les deux tentatives. Ordonnancement mesuré — A réclamé (base
+  // S0), A abandonné, B réclamé, B écrit son test et COMMITE (ce que
+  // phase-execute.yaml:56 ordonne), B complété, puis A re-réclamé : `git diff
+  // S0 HEAD` remonte alors les fichiers de B, et A est ACCEPTÉ sur la preuve
+  // de B sans avoir rien écrit. Le garde-fou devenait complaisant là où main
+  // refusait correctement.
+  //
+  // Un emplacement unique rend la péremption impossible par construction :
+  // toute réclamation d'un AUTRE thread l'écrase, donc la base n'est réutilisée
+  // que sur des tentatives CONSÉCUTIVES du même thread — exactement le cas G3
+  // (thread 2a2548b3 déréclamé en error_max_turns puis re-réclamé dans la
+  // foulée, le test de la tentative 1 restant invisible et un travail réel
+  // jeté). Effacé aussi à la complétion : un thread rouvert doit reprouver.
+  let lastBaseline: { threadId: string; base: { sha: string; untracked: string[] } } | null = null;
 
   const mqtt: MqttListener = createMqttListener({
     url: config.mqttUrl,
@@ -1277,10 +1298,17 @@ export async function runAgentLoop(
               // soustraction de #142 retournée contre le correctif qu'elle
               // protège. L'unité de jugement est le THREAD.
               const falsifiabilityDeps = gitExec(config.workspacePath);
-              let taskBase = threadBaselines.get(task.id);
+              let taskBase: { sha: string; untracked: string[] } | undefined =
+                lastBaseline?.threadId === task.id ? lastBaseline.base : undefined;
               if (phase.requireFailingTest && !taskBase) {
                 taskBase = await taskBaseline(falsifiabilityDeps);
-                threadBaselines.set(task.id, taskBase);
+                // `taskBaseline` rend undefined si git a hoqueté — on ne
+                // mémorise QUE les relevés réussis. Mémoriser un échec le
+                // figerait pour toutes les tentatives suivantes du thread,
+                // alors qu'un `index.lock` (l'agent commite dans le même
+                // worktree) est une collision ordinaire dont la tentative
+                // suivante doit pouvoir se relever.
+                lastBaseline = taskBase ? { threadId: task.id, base: taskBase } : null;
               }
 
               /**
@@ -1321,7 +1349,7 @@ export async function runAgentLoop(
                 // La base ne survit PAS à la complétion : elle n'existe que
                 // pour recoller les tentatives d'un thread INACHEVÉ. Sur refus,
                 // au contraire, on la garde — c'est tout l'objet du correctif.
-                threadBaselines.delete(task.id);
+                lastBaseline = null;
                 tasksDone++;
               };
 

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1953,6 +1953,58 @@ describe("runAgentLoop — phased mode", () => {
       );
     });
 
+    // RÉGRESSION — LA BASE MÉMORISÉE NE DOIT PAS PÉRIMER.
+    //
+    // Première rédaction : une Map<threadId, base>. Deux relectures
+    // indépendantes l'ont cassée par exécution. L'entrée survit à l'abandon —
+    // c'est voulu — mais aussi à tout ce qui se passe ENTRE les deux
+    // tentatives. Ordonnancement mesuré : A réclamé (base S0), A abandonné,
+    // B réclamé, B écrit son test et COMMITE, B complété, puis A re-réclamé.
+    // `git diff S0 HEAD` remonte alors les fichiers de B, et A était ACCEPTÉ
+    // sur la preuve de B sans avoir rien écrit — là où main refusait
+    // correctement. Un emplacement UNIQUE rend ça impossible : la réclamation
+    // de B écrase celle de A.
+    it("ne crédite PAS un thread rouvert du travail commité entre-temps par un autre", async () => {
+      let claims = 0;
+      mockClaimNextTask.mockImplementation(async () => {
+        claims++;
+        if (claims === 1) return { id: "t-A", description: "defaut A", file: undefined, severity: undefined };
+        if (claims === 2) return { id: "t-B", description: "defaut B", file: undefined, severity: undefined };
+        if (claims === 3) return { id: "t-A", description: "defaut A", file: undefined, severity: undefined };
+        return null;
+      });
+
+      mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
+
+      mockSend
+        .mockResolvedValueOnce(discovery)
+        // A, essai 1 : rien produit, plafonne.
+        .mockResolvedValueOnce({ content: "je continue", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1", subtype: "error_max_turns" })
+        // B : écrit source + test et COMMITE, comme phase-execute l'ordonne.
+        .mockImplementationOnce(async () => {
+          writeFileSync(join(repo, "base.js"), "export const a = 2;\n");
+          writeFileSync(join(repo, "tests", "unit", "b.test.ts"), "// repro de B\n");
+          git(repo, "add", "--", "base.js", "tests/unit/b.test.ts");
+          git(repo, "commit", "-qm", "fix B + test");
+          return { content: "DONE: B corrige", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1" };
+        })
+        // A, essai 2 : n'écrit RIEN et prétend avoir fini.
+        .mockResolvedValueOnce({ content: "DONE: A corrige", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1" });
+
+      const verdicts = captureVerdicts();
+
+      await runAgentLoop(makeConfig({ workspacePath: repo, maxTurns: 4, phases: phases() }), silentLogger);
+
+      // Deux verdicts : celui de B, puis celui de A au second essai.
+      expect(verdicts).toHaveLength(2);
+      // LE POINT DU TEST : A ne doit rien voir du test de B.
+      expect(verdicts[1].testFiles).not.toContain("tests/unit/b.test.ts");
+      expect(verdicts[1].testFiles).toEqual([]);
+      expect(mockCompleteTask).not.toHaveBeenCalledWith(
+        "http://localhost:3100", "t-A", "test-agent", expect.any(String),
+      );
+    });
+
     // GARDE-FOU CONTRE LA SUR-CORRECTION. Une ligne de base « par AGENT »,
     // relevée une seule fois au démarrage de la boucle, serait plus simple et
     // FAUSSE : l'agent enchaîne plusieurs tâches dans le MÊME worktree, et le

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentLoopConfig, AgentLoopResult, AgentLoopLogger } from "../../src/agent-loop/agent-loop.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
@@ -102,14 +106,20 @@ vi.mock("../../src/agent-loop/work-stealing.js", () => ({
 // Mock falsifiability — le garde-fou est testé contre un vrai dépôt git dans
 // tests/unit/falsifiability.test.ts. Ici on vérifie uniquement que le loop
 // l'appelle sur TOUS les chemins où l'agent dit DONE:, et qu'il lui obéit.
-const mockVerifyFailingTest = vi.fn(async () => ({
+const mockVerifyFailingTest = vi.fn(async (..._args: unknown[]) => ({
   falsifiable: true,
   reason: "ok",
   testFiles: [] as string[],
   sourceFiles: [] as string[],
 }));
-vi.mock("../../src/agent-loop/falsifiability.js", () => ({
-  verifyFailingTest: (...args: unknown[]) => mockVerifyFailingTest(...(args as [])),
+// Le reste du module reste RÉEL (`importOriginal` + étalement). Deux raisons :
+// agent-loop importe aussi `parseUntrackedFiles` — qu'un mock ne rendant que
+// `verifyFailingTest` laissait `undefined`, sauvé par le seul court-circuit
+// `st.code === 0 ? ... : []` — et les cas « ligne de base par THREAD » plus bas
+// font tourner le VRAI garde-fou sur un VRAI dépôt git.
+vi.mock("../../src/agent-loop/falsifiability.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/agent-loop/falsifiability.js")>()),
+  verifyFailingTest: (...args: unknown[]) => mockVerifyFailingTest(...args),
 }));
 
 // Mock fetch for coordinator REST
@@ -1831,6 +1841,157 @@ describe("runAgentLoop — phased mode", () => {
     const reviewPrompt = mockSend.mock.calls[1][0] as string;
     expect(reviewPrompt).toContain("DISCOVERY:\nsrc/auth.ts | 42 | Missing null check | critical");
     expect(reviewPrompt).toContain("- [t-existing] Vieux bug dans auth.ts");
+  });
+
+  // ── L'UNITÉ DE JUGEMENT EST LE THREAD, PAS LA TENTATIVE ──────────────────
+  //
+  // Run G3, après #142 et #143 : refus tombés de 29 à 1. Le dernier, ligne par
+  // ligne dans le log réel :
+  //
+  //   l.77   [work-stealing] claimed thread=2a2548b3 : critical: preflight.ts
+  //   essai 1  l'agent écrit src/orchestrator/preflight.ts ET
+  //            tests/unit/preflight-auth.test.ts, sans jamais commiter
+  //   l.196  WARN aborting task (no DONE: marker) subtype=error_max_turns
+  //   l.197  [work-stealing] claimed thread=2a2548b3   <- MÊME thread, MÊME agent
+  //   essai 2  le travail est déjà là : l'agent n'écrit RIEN, lance vitest, DONE:
+  //   l.268  WARN DONE refusé — aucun fichier de test modifié {"testFiles":[]}
+  //
+  // Vérifié : la branche de l'agent ne portait AUCUN commit au-delà de la base.
+  // Le travail de l'essai 1 n'existait donc que NON SUIVI, dans l'arbre.
+  //
+  // Cause : `taskBaseline()` était relevé à CHAQUE réclamation. Au second essai
+  // son inventaire des non-suivis contenait DÉJÀ le test écrit au premier, qui
+  // se faisait alors soustraire comme « préexistant » — la soustraction de #142
+  // retournée contre le correctif qu'elle protégeait, sur un chemin plus étroit.
+  // Un travail RÉELLEMENT FAIT était refusé puis jeté.
+  describe("ligne de base par THREAD", () => {
+    const git = (cwd: string, ...args: string[]) =>
+      spawnSync("git", args, { cwd, encoding: "utf8" });
+
+    type Verdict = { falsifiable: boolean; reason: string; testFiles: string[]; sourceFiles: string[] };
+    let repo: string;
+    let realVerify: (...args: never[]) => Promise<Verdict>;
+
+    beforeEach(async () => {
+      repo = mkdtempSync(join(tmpdir(), "essaim-thread-base-"));
+      git(repo, "init", "-q");
+      git(repo, "config", "user.email", "t@t");
+      git(repo, "config", "user.name", "t");
+      writeFileSync(join(repo, "base.js"), "export const a = 1;\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-qm", "base");
+      // promptweave dépose `.mcp.json` dans CHAQUE worktree d'agent à sa
+      // création, et il y reste NON SUIVI : c'est lui qui rend l'inventaire
+      // des non-suivis indispensable (#142), et lui qu'on reproduit ici.
+      writeFileSync(join(repo, ".mcp.json"), "{}\n");
+      mkdirSync(join(repo, "tests", "unit"), { recursive: true });
+
+      // Le VRAI garde-fou, sur ce VRAI dépôt : c'est son verdict qu'on mesure,
+      // pas un mock qui dirait ce qu'on veut entendre.
+      const actual = await vi.importActual<typeof import("../../src/agent-loop/falsifiability.js")>(
+        "../../src/agent-loop/falsifiability.js",
+      );
+      realVerify = actual.verifyFailingTest as unknown as (...args: never[]) => Promise<Verdict>;
+    });
+
+    afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+    /** Branche le vrai garde-fou et collecte ses verdicts, dans l'ordre. */
+    function captureVerdicts(): Verdict[] {
+      const verdicts: Verdict[] = [];
+      mockVerifyFailingTest.mockImplementation(async (...args: unknown[]) => {
+        const v = await realVerify(...(args as never[]));
+        verdicts.push(v);
+        return v;
+      });
+      return verdicts;
+    }
+
+    const discovery = { content: "DISCOVERY:\nitem", toolCalls: [], costUsd: 0.01, durationMs: 100, sessionId: "s1" };
+
+    // `maxTurns` = le nombre EXACT d'envois scénarisés (1 découverte + 2
+    // exécutions) : la boucle sort alors sur son propre gardien plutôt que
+    // d'aller dormir MAX_EMPTY_RETRIES x 10 s sur un pool vide. Pas de faux
+    // minuteurs, donc les `spawn` de git réels ne risquent pas d'être affamés.
+    const phases = () => [
+      { name: "discover", prompt: "Scan", toolsMode: "read_only" as const, loop: false, effort: "low" as const },
+      { name: "execute", prompt: "Fix", toolsMode: "full" as const, loop: true, effort: "high" as const, requireFailingTest: true },
+    ];
+
+    it("voit le test de l'essai 1 quand le MÊME thread est réclamé une seconde fois", async () => {
+      let claims = 0;
+      mockClaimNextTask.mockImplementation(async () => {
+        claims++;
+        return claims <= 2
+          ? { id: "t-2a2548b3", description: "critical: orchestrator/preflight.ts", file: undefined, severity: "critical" }
+          : null;
+      });
+
+      mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
+
+      mockSend
+        .mockResolvedValueOnce(discovery)
+        // Essai 1 : l'agent écrit son test de régression… et manque de tours.
+        // Rien n'est commité — exactement l'état constaté sur la branche G3.
+        .mockImplementationOnce(async () => {
+          writeFileSync(join(repo, "tests", "unit", "preflight-auth.test.ts"), "// repro\n");
+          return { content: "je continue", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1", subtype: "error_max_turns" };
+        })
+        // Essai 2 : le travail est déjà là, l'agent n'écrit RIEN et conclut.
+        .mockResolvedValueOnce({ content: "DONE: preflight corrigé + test", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1" });
+
+      const verdicts = captureVerdicts();
+
+      await runAgentLoop(makeConfig({ workspacePath: repo, maxTurns: 3, phases: phases() }), silentLogger);
+
+      expect(verdicts).toHaveLength(1);
+      // LE POINT DU TEST : le test de l'essai 1 est VU au second essai.
+      expect(verdicts[0].testFiles).toEqual(["tests/unit/preflight-auth.test.ts"]);
+      expect(verdicts[0].falsifiable).toBe(true);
+      expect(mockCompleteTask).toHaveBeenCalledWith(
+        "http://localhost:3100", "t-2a2548b3", "test-agent", expect.any(String),
+      );
+    });
+
+    // GARDE-FOU CONTRE LA SUR-CORRECTION. Une ligne de base « par AGENT »,
+    // relevée une seule fois au démarrage de la boucle, serait plus simple et
+    // FAUSSE : l'agent enchaîne plusieurs tâches dans le MÊME worktree, et le
+    // test écrit pour la tâche 1 créditerait la tâche 2 qui n'en a produit
+    // aucun. Le garde-fou deviendrait complaisant — le défaut exact qu'il
+    // existe pour attraper. La clé DOIT être le thread : ce cas échoue si on
+    // la remplace par une base globale.
+    it("ne crédite PAS un thread du test écrit pour le thread précédent", async () => {
+      let claims = 0;
+      mockClaimNextTask.mockImplementation(async () => {
+        claims++;
+        if (claims === 1) return { id: "t-un", description: "premier défaut", file: undefined, severity: undefined };
+        if (claims === 2) return { id: "t-deux", description: "second défaut", file: undefined, severity: undefined };
+        return null;
+      });
+
+      mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
+
+      mockSend
+        .mockResolvedValueOnce(discovery)
+        // Thread 1 : test écrit, DONE: — accepté.
+        .mockImplementationOnce(async () => {
+          writeFileSync(join(repo, "tests", "unit", "un.test.ts"), "// repro\n");
+          return { content: "DONE: premier corrigé", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1" };
+        })
+        // Thread 2 : rien d'écrit, DONE: quand même — doit être REFUSÉ.
+        .mockResolvedValueOnce({ content: "DONE: second corrigé", toolCalls: [], costUsd: 0.02, durationMs: 100, sessionId: "s1" });
+
+      const verdicts = captureVerdicts();
+
+      await runAgentLoop(makeConfig({ workspacePath: repo, maxTurns: 3, phases: phases() }), silentLogger);
+
+      expect(verdicts).toHaveLength(2);
+      expect(verdicts[0].falsifiable).toBe(true);
+      expect(verdicts[0].testFiles).toEqual(["tests/unit/un.test.ts"]);
+      expect(verdicts[1].falsifiable).toBe(false);
+      expect(verdicts[1].testFiles).toEqual([]);
+      expect(mockCompleteTask).toHaveBeenCalledTimes(1);
+    });
   });
 });
 


### PR DESCRIPTION
Dernier trou laissé par #142 : sur les 3 runs de validation, **un refus sur douze** portait encore le motif d'origine. Diagnostiqué sur le log réel du run G3, pas supposé.

## Le défaut

```
l.77   claimed thread=2a2548b3 : critical: orchestrator/preflight.ts
       l'agent écrit preflight.ts, orchestrator.ts ET tests/unit/preflight-auth.test.ts
l.196  aborting task (no DONE: marker) — unclaiming ... subtype=error_max_turns
l.197  claimed thread=2a2548b3          <- MÊME thread, MÊME agent, re-réclamé
       l'agent n'écrit RIEN (le travail est déjà là), lance vitest, dit DONE:
l.268  DONE refusé — aucun fichier de test modifié {"testFiles":[]}
```

La branche `mini-project-bench-G3-agent-sentinelle-2` ne porte **aucun commit** : le travail de la première tentative vivait uniquement dans l'arbre, non suivi. Il a donc été capturé par le `baseUntracked` de la **seconde** tentative et soustrait comme préalable.

`taskBaseline()` était appelé à chaque réclamation. L'unité de jugement doit être **le thread**, pas la tentative.

## Un seul emplacement, pas une Map — et c'est le cœur du correctif

La première rédaction utilisait `Map<threadId, baseline>`. **Deux relectures adversariales indépendantes l'ont cassée par exécution :** l'entrée survit à l'abandon — c'est voulu — mais aussi à tout ce qui se passe **entre** les deux tentatives.

```
A réclamé (base S0) → A abandonné → B réclamé → B écrit son test et COMMITE
→ B complété → A re-réclamé avec S0, antérieur au commit de B
→ git diff S0 HEAD remonte les fichiers de B → A ACCEPTÉ sur la preuve de B
```

Mesuré sur un vrai dépôt avec le vrai garde-fou :

```
avec la Map (base S0) -> {"falsifiable":true,  "testFiles":["tests/unit/b.test.js"]}
sur main   (base S1)  -> {"falsifiable":false, "testFiles":[]}
```

Le thread A était accepté avec **zéro travail**, là où `main` refusait correctement. Le garde-fou devenait complaisant — le défaut exact qu'il existe pour attraper.

**Un emplacement unique rend la péremption impossible par construction** : toute réclamation d'un autre thread l'écrase, donc la base n'est réutilisée que sur des tentatives **consécutives** du même thread. Effacé aussi à la complétion, pour qu'un thread rouvert doive reprouver.

## Second défaut, même relecture

`taskBaseline` dégradait sans jeter et rendait un objet **toujours truthy**, même quand git avait échoué. Mémorisé, ce relevé raté se figeait pour toutes les tentatives suivantes du thread — alors que sur `main` la tentative suivante se rattrapait. Le déclencheur n'est pas théorique : l'agent lance ses propres `git commit` dans le **même worktree** que celui où la base est relevée, et `index.lock` est la collision ordinaire de cette configuration.

Conséquence mesurée quand seul `git status` hoquetait : `.mcp.json` n'était plus soustrait, devenait « fichier de production », et le contrôle était **sauté à chaque DONE:** de ce thread — le trou n°2 de #142 rouvert par mémorisation.

Corrigé : `taskBaseline` rend `undefined` en cas d'échec, et seuls les relevés complets sont mémorisés.

## Tests

Trois cas contre un **vrai dépôt git** avec le **vrai** `verifyFailingTest` (pas un simulacre), `.mcp.json` non suivi comme dans les worktrees réels :

1. le scénario G3 — le test de la tentative 1 est vu à la tentative 2 (échoue contre `main` : `expected [] to deeply equal ['tests/unit/preflight-auth.test.ts']`)
2. non-complaisance entre deux threads successifs (échoue si la clé devient globale)
3. **non-péremption** — un thread rouvert n'est pas crédité du travail commité entre-temps par un autre (échoue si on remet la Map : `expected ['tests/unit/b.test.ts'] to not include 'tests/unit/b.test.ts'`)

Les trois mutations ont été **exécutées**, pas raisonnées.

## Vérification

`npx tsc --noEmit` vert. `pnpm test` : 765 passés.

Quatre fichiers ne collectent pas sur cette machine (`Cannot find package '...jose/index.js'`, store pnpm local incomplet) plus les deux cas `shell-scripts` — **reproduits à l'identique sur `main` non modifié**, donc sans rapport avec ce diff. La CI installe à neuf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
