### PR TITLE
fix(security): un agent read-only ne peut plus ecrire l'arbre de travail (#1)

### DIFF
--- a/behaviors/read-only-mode.yaml
+++ b/behaviors/read-only-mode.yaml
@@ -7,8 +7,8 @@ sections:
     prompt: |
       ## Contrainte — mode lecture seule
 
-      Tu ne modifies AUCUN fichier du repo, et tu ne CRÉES aucun fichier non plus. Pas de Write, pas d'Edit, pas de NotebookEdit. Aucune exception.
+      Tu ne modifies AUCUN fichier du repo, et tu ne CRÉES aucun fichier non plus. Pas de Write, pas d'Edit, pas de NotebookEdit, pas de Bash. Aucune exception — l'outillage lui-même te refuse ces outils, ce n'est pas qu'une consigne.
 
-      Tu analyses (Read, Glob, Grep, Bash de lecture comme `wc -l` ou `find`), tu raisonnes, tu communiques tes findings dans la conversation et dans les threads MCP du coordinator (post_to_thread, propose_resolution, etc.). C'est tout.
+      Tu analyses (Read, Glob, Grep), tu raisonnes, tu communiques tes findings dans la conversation et dans les threads MCP du coordinator (post_to_thread, propose_resolution, etc.). C'est tout. (Glob remplace `find`, Grep remplace `grep -r`.)
 
       Si un autre behavior plus tard dans ce prompt te donne une exception explicite pour un chemin précis (voir `audit-output`), seule cette exception est valide — pas d'extension par analogie.

--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -26,12 +26,17 @@ export function buildSoloArgs(
   prompt: string,
   mcpTools: string[],
   mcpConfigPath: string | null,
+  readOnly = false,
 ): string[] {
   const args = ["-p", prompt];
   if (mcpConfigPath) {
     args.push("--mcp-config", mcpConfigPath);
   }
-  args.push("--allowedTools", buildAllowedTools({ tools: mcpTools } as AgentConfig));
+  // solo n'utilise PAS --dangerously-skip-permissions : en headless `-p`, un
+  // outil hors allowlist est refuse. L'allowlist EST donc le verrou ici, et
+  // read_only en retire Write/Edit/Bash (DF4). Le read_only vient du preset
+  // (buildSolo le derive de la presence du behavior read-only-mode).
+  args.push("--allowedTools", buildAllowedTools({ tools: mcpTools, read_only: readOnly } as AgentConfig));
   return args;
 }
 
@@ -94,13 +99,14 @@ export function createSoloCommand(): Command {
         for (const [behavior, values] of Object.entries(setFileParams)) {
           setParams[behavior] = { ...setParams[behavior], ...values };
         }
-        const { prompt, mcpTools } = buildSolo(template, context, setParams, projectPath, opts.catalog);
+        const { prompt, mcpTools, read_only } = buildSolo(template, context, setParams, projectPath, opts.catalog);
 
         const mcpConfigPath = resolve(projectPath, ".mcp.json");
         const args = buildSoloArgs(
           prompt,
           mcpTools,
           existsSync(mcpConfigPath) ? mcpConfigPath : null,
+          read_only,
         );
 
         console.log(`\nSolo mode: ${template}`);

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -34,6 +34,11 @@ export interface AgentLoopConfig {
   maxBudgetUsd?: number;
   maxTurns?: number;
   dangerouslySkipPermissions?: boolean;
+  // DF4 — l'agent est declare lecture seule (behavior read-only-mode). Sous
+  // --dangerously-skip-permissions l'allowlist ne protege rien : le mode
+  // one-shot passe alors disallowedForMode("read_only") pour bloquer dur toute
+  // ecriture (Write/Edit/NotebookEdit/Bash). Cable depuis agent.read_only.
+  readOnly?: boolean;
   // Max times the phased sequence (discover → review → execute) is re-run
   // when execute exits with an empty pool while real work was done.
   // Default 1 (no re-discover). Raise this for raids that need extra pool refills.
@@ -343,14 +348,17 @@ function toolsForMode(
   return [...mcpTools, ...readUserTools];
 }
 
-function disallowedForMode(
+export function disallowedForMode(
   toolsMode: "read_only" | "full" | "none",
 ): string[] {
   // Nested agents are blocked in every mode — see NESTED_AGENT_TOOLS comment.
   if (toolsMode === "full") return [...NESTED_AGENT_TOOLS];
   if (toolsMode === "none") return [...ALL_USER_TOOLS];
-  // read_only: block write tools explicitly + nested agents
-  return [...WRITE_USER_TOOLS, ...NESTED_AGENT_TOOLS];
+  // read_only: block write tools + Bash + nested agents. Bash EST un vecteur
+  // d'ecriture (`echo > f`, `rm`, `sed -i`) ; l'omettre laissait un agent
+  // read-only ecrire l'arbre sous --dangerously-skip-permissions, ou seul
+  // --disallowedTools bloque vraiment (l'allowlist y est ignoree). DF4.
+  return [...WRITE_USER_TOOLS, "Bash", ...NESTED_AGENT_TOOLS];
 }
 
 // ── Prompt injections ──────────────────────────────────────────────────
@@ -727,6 +735,13 @@ export async function runAgentLoop(
     // (ask_llm_decide / ask_llm_respond / propose_resolution) et mode one-shot.
     const blocked = new Set(opts?.disallowedTools ?? []);
     for (const tool of ALWAYS_BLOCKED) blocked.add(tool);
+    // DF4 — verrou lecture seule au niveau SESSION. Un agent read-only (preset
+    // avec read-only-mode) ne doit ecrire sous AUCUN envoi : ni le one-shot, ni
+    // les envois de coordination (ask_llm_*, propose_resolution) qui ne passent
+    // aucune option. Sous --dangerously-skip-permissions, seul --disallowedTools
+    // bloque dur ; le poser ici couvre TOUS les envois d'un coup. Les phases
+    // (phased mode) passent deja leur propre disallow, superset compatible.
+    if (config.readOnly) for (const tool of disallowedForMode("read_only")) blocked.add(tool);
     const resp = await claude.send(content, { ...opts, disallowedTools: [...blocked] });
 
     totalCost += resp.costUsd;
@@ -868,7 +883,15 @@ export async function runAgentLoop(
     // Fix 5: send to separate session to avoid polluting main context
     logger.info("Processing important MQTT interrupts", { count: important.length, skipped: interrupts.length - important.length });
     const formatted = formatInterrupts(important);
-    await interruptClaude.send(formatted, { maxTurns: 1, disallowedTools: [...ALWAYS_BLOCKED] });
+    // interruptClaude est une session SEPAREE : elle ne passe pas par le wrapper
+    // `send`, donc le verrou read_only doit etre applique ici aussi (DF4). Le
+    // contenu d'une interruption vient d'un pair — un agent read-only ne doit
+    // pas pouvoir ecrire l'arbre sur injection.
+    const interruptBlocked = [
+      ...ALWAYS_BLOCKED,
+      ...(config.readOnly ? disallowedForMode("read_only") : []),
+    ];
+    await interruptClaude.send(formatted, { maxTurns: 1, disallowedTools: interruptBlocked });
     return true;
   }
 
@@ -1463,6 +1486,9 @@ export async function runAgentLoop(
         // ③ WORK LOOP — send initial prompt, then iterate
         logger.info(`Phase 3: work loop (protocol.phase=${protocol.phase})`);
         currentPhase = "main";
+        // DF4 : le verrou read_only est applique par le wrapper `send` (voir
+        // `if (config.readOnly)` plus haut), donc les envois one-shot ci-dessous
+        // heritent du blocage d'ecriture sans traitement special ici.
         const initialResp = await send(config.prompt);
         if (hasDoneMarker(initialResp.content)) {
           summary = extractDoneSummary(initialResp.content, "Complete");

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,7 +1,41 @@
 // bce/engine/bridge.ts
 import { resolve } from 'path';
-import { runPipeline } from '@swoofer/promptweave';
+import { runPipeline, Registry, resolveBehaviors } from '@swoofer/promptweave';
 import type { PipelineResult } from '@swoofer/promptweave';
+
+// DF4 — SÛRETÉ PAR CONSTRUCTION. Un preset dont les behaviors resolus incluent
+// `read-only-mode` produit un agent SANS aucun outil d'ecriture. Le signal est
+// la liste de behaviors resolue par promptweave (gere heritage + composition),
+// PAS le type de workspace : migrate-phase2 est `shared` et ECRIT
+// deliberement — il n'inclut simplement pas read-only-mode. Mesure : sans ce
+// cablage, `essaim run gardien -p .` donnait Write+Edit+Bash sur l'arbre REEL,
+// parce que `read_only` n'etait jamais positionne et buildAllowedTools retombait
+// sur CODE_TOOLS. Le behavior read-only-mode etait du texte de prompt sans verrou.
+const READ_ONLY_BEHAVIOR = 'read-only-mode';
+// audit-output « decoupe un droit d'ecriture pour une liste fixe de chemins
+// d'artefacts » (behaviors/audit-output.yaml). Un preset qui l'inclut (gardien
+// -> AUDIT.md, phare-* -> tmp/audit/*) N'EST donc PAS lecture seule : il DOIT
+// ecrire son livrable. Le bloquer entierement regresse #34 (« solo gardien a
+// produit son audit sur stdout mais aucun AUDIT.md »). L'ecriture path-scopee
+// de ces presets sous --dangerously-skip-permissions demande un hook PreToolUse
+// que le verrou d'outils ne sait pas exprimer — c'est un chantier distinct
+// (#1b). Ici, read_only ne couvre donc QUE les lecteurs purs.
+const AUDIT_WRITE_BEHAVIOR = 'audit-output';
+
+function presetIsReadOnly(registry: Registry, preset: string): boolean {
+  try {
+    const behaviors = resolveBehaviors(
+      { name: 'x', preset, add: [], remove: [], params: {} } as never,
+      registry,
+    ).behaviors;
+    return behaviors.includes(READ_ONLY_BEHAVIOR) && !behaviors.includes(AUDIT_WRITE_BEHAVIOR);
+  } catch {
+    // Preset introuvable / registry incomplet : runPipeline jettera plus loin
+    // avec un message clair. Ici on ne DECIDE rien — on laisse read_only a false
+    // et le vrai chemin echoue, plutot que de relacher la contrainte en silence.
+    return false;
+  }
+}
 
 // Import the orchestrator types for MiniProject compatibility
 // We define a minimal interface here to avoid circular deps
@@ -56,6 +90,10 @@ export function buildProjectFromBce(
     const available = Object.keys(templates).join(', ');
     throw new Error(`Unknown BCE template: "${templateId}". Available: ${available}`);
   }
+
+  // Registry charge UNE fois pour tout le template : presetIsReadOnly le
+  // reinterroge par agent, mais sans relire le catalogue a chaque agent.
+  const registry = Registry.load(getCatalogRoots(catalogOpts));
 
   if (options?.agentCount !== undefined) {
     const hasDynamic = def.agents.some((a) => a.count === "dynamic");
@@ -147,6 +185,7 @@ export function buildProjectFromBce(
         prompt: result.output.prompt,
         profile: agentDef.profile,
         role: agentDef.idPrefix,
+        read_only: presetIsReadOnly(registry, agentDef.preset),
         modules: registeredModules,
         launch_delay: agentDef.launch_delay,
         hooks: result.output.hooks,
@@ -190,7 +229,7 @@ export function buildSolo(
   setParams?: Record<string, Record<string, unknown>>,
   projectPath?: string,
   catalogs?: string[],
-): { prompt: string; mcpTools: string[] } {
+): { prompt: string; mcpTools: string[]; read_only: boolean } {
   // catalogs en DERNIER argument, jamais réordonné : c'est de la surface publique.
   const catalogOpts: CatalogOptions = { catalogs, projectPath };
   const templates = loadTemplates(projectPath, catalogOpts);
@@ -222,7 +261,12 @@ export function buildSolo(
     params: {} as Record<string, Record<string, unknown>>,
   };
   const result = runPipeline(agent, getCatalogRoots(catalogOpts), launchParams);
-  return { prompt: result.output.prompt, mcpTools: result.output.mcpTools };
+  // Meme verrou DF4 que le chemin parallele : un preset read-only lance en solo
+  // ne doit pas non plus exposer d'outil d'ecriture. L'appelant (cli/solo.ts)
+  // transmet ce flag a buildAllowedTools.
+  const registry = Registry.load(getCatalogRoots(catalogOpts));
+  const read_only = presetIsReadOnly(registry, agentDef.preset);
+  return { prompt: result.output.prompt, mcpTools: result.output.mcpTools, read_only };
 }
 
 /** @deprecated Prefer buildSolo() — this drops the tool allowlist (see #34). */

--- a/src/orchestrator/agent-launcher.ts
+++ b/src/orchestrator/agent-launcher.ts
@@ -37,7 +37,13 @@ const DEFAULT_MCP_TOOLS = [
 ];
 
 const CODE_TOOLS = ["Edit", "Read", "Write", "Bash", "Glob", "Grep"];
-const READ_ONLY_TOOLS = ["Read", "Bash", "Glob", "Grep"];
+// Bash EXCLU : Claude Code n'a pas de « Bash en lecture seule » — `echo > f`,
+// `rm`, `sed -i` ecrivent l'arbre autant que Write. Tant que Bash figurait ici,
+// le mode lecture-seule etait une promesse de prompt, pas un verrou. Read/Glob/
+// Grep couvrent les besoins de lecture (Grep = ripgrep, Glob = find). Perte
+// assumee : `git log`, `wc -l` — un auditeur ne peut plus les lancer, mais il
+// ne peut plus rien ecrire non plus, ce qui est le point (DF4).
+const READ_ONLY_TOOLS = ["Read", "Glob", "Grep"];
 
 function prefixMcpTools(names: string[]): string[] {
   return names.map((n) => (n.startsWith(MCP_COORDINATOR_PREFIX) ? n : `${MCP_COORDINATOR_PREFIX}${n}`));
@@ -163,6 +169,7 @@ export async function launchAgentLoop(
     mcpConfigPath: mcpConfigPath || "",
     prompt: fullPrompt,
     allowedTools: buildAgentLoopAllowedTools(agent),
+    readOnly: agent.read_only,
     model: agent.model,
     phases: agent.phases,
     maxTurns: 50,

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1449,13 +1449,16 @@ describe("runAgentLoop — phased mode", () => {
     for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
     await loopPromise;
 
-    // discover (read_only): block write tools
+    // discover (read_only): block write tools — Bash COMPRIS (DF4). L'ancienne
+    // version de ce test affirmait `not.toContain("Bash")`, ce qui enshrinait
+    // le trou : `echo > f` sous --dangerously-skip-permissions ecrivait l'arbre
+    // malgre le mode « lecture seule ». Bash est desormais bloque dur.
     const discoverBlocked = mockSend.mock.calls[0][1].disallowedTools;
     expect(discoverBlocked).toContain("Write");
     expect(discoverBlocked).toContain("Edit");
     expect(discoverBlocked).toContain("NotebookEdit");
+    expect(discoverBlocked).toContain("Bash");
     expect(discoverBlocked).not.toContain("Read");
-    expect(discoverBlocked).not.toContain("Bash");
     // AskUserQuestion attend une réponse humaine qu'un run headless n'a pas,
     // et --dangerously-skip-permissions ne l'auto-approuve pas : seule une
     // règle de deny empêche l'agent de rester suspendu, tâche réclamée.
@@ -1470,6 +1473,45 @@ describe("runAgentLoop — phased mode", () => {
     expect(reviewBlocked).toContain("Write");
     expect(reviewBlocked).toContain("Skill");  // meta tool also blocked
     expect(reviewBlocked).toContain("AskUserQuestion");
+  });
+
+  // DF4 / Defect 1 — un agent read-only NON phase (gardien, phare) tombe en
+  // one-shot, dont les sends ne passent aucune option. Le verrou vit dans le
+  // wrapper `send` : TOUT envoi d'un run read_only doit bloquer l'ecriture, y
+  // compris les envois nus (one-shot, coordination). Sans le wrapper, l'agent
+  // ecrivait l'arbre reel sous --dangerously-skip-permissions.
+  it("un run read-only bloque l'ecriture sur un envoi one-shot nu", async () => {
+    mockSend.mockResolvedValue({
+      content: "DONE: audit termine",
+      toolCalls: [],
+      costUsd: 0.01,
+      durationMs: 100,
+      sessionId: "s1",
+    });
+
+    // Pas de phases -> mode one-shot ; readOnly:true -> le wrapper doit bloquer.
+    await runAgentLoop(makeConfig({ readOnly: true }), silentLogger);
+
+    const oneShotBlocked = mockSend.mock.calls[0][1].disallowedTools;
+    for (const t of ["Write", "Edit", "NotebookEdit", "Bash"]) {
+      expect(oneShotBlocked, `${t} doit etre bloque sur l'envoi one-shot read-only`).toContain(t);
+    }
+  });
+
+  it("un run NON read-only ne bloque PAS l'ecriture en one-shot", async () => {
+    mockSend.mockResolvedValue({
+      content: "DONE: corrige",
+      toolCalls: [],
+      costUsd: 0.01,
+      durationMs: 100,
+      sessionId: "s1",
+    });
+
+    await runAgentLoop(makeConfig({ readOnly: false }), silentLogger);
+
+    const oneShotBlocked = mockSend.mock.calls[0][1].disallowedTools;
+    expect(oneShotBlocked).not.toContain("Write");
+    expect(oneShotBlocked).not.toContain("Bash");
   });
 
   it("disallowedTools blocks nested-agent and human-interaction tools in full mode", async () => {

--- a/tests/unit/read-only-enforcement.test.ts
+++ b/tests/unit/read-only-enforcement.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { buildProjectFromBce, buildSolo } from "../../src/bridge.js";
+import { buildAllowedTools } from "../../src/orchestrator/agent-launcher.js";
+import { disallowedForMode } from "../../src/agent-loop/agent-loop.js";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// DF4 — SÛRETÉ PAR CONSTRUCTION. Aucun agent dont l'intention declaree est
+// « lecture seule » ne peut ecrire dans l'arbre de travail de l'utilisateur.
+//
+// Le danger, mesure : `essaim run gardien -p .` donne Write+Edit+Bash a un agent
+// dont le cwd est l'arbre REEL (gardien est `workspace: shared`, pas de worktree).
+// Cause racine, verifiee : `bridge.ts` ne positionnait JAMAIS `read_only`, donc
+// `buildAllowedTools` retombait toujours sur CODE_TOOLS. Le behavior
+// `read-only-mode` etait du texte de prompt sans aucun verrou d'outil.
+//
+// L'invariant N'EST PAS « workspace: shared => lecture seule » : migrate-phase2
+// est `shared` et ECRIT deliberement (il n'inclut pas read-only-mode). Le signal
+// correct est la presence du behavior read-only-mode, resolue par promptweave en
+// `tools_mode: read_only`.
+
+const REPO = join(__dirname, "..", "..");
+const WRITE_TOOLS = ["Write", "Edit", "Bash", "NotebookEdit"];
+
+const ctx = {
+  path: REPO,
+  language: "typescript",
+  test_command: "pnpm test",
+  modules: ["orchestrator", "security"],
+  source_files: [],
+};
+
+/**
+ * Presets LECTEURS PURS : read-only-mode ET PAS audit-output. Eux ne doivent
+ * ecrire AUCUN fichier. Un preset avec audit-output (gardien, phare-*) ecrit son
+ * livrable (AUDIT.md, tmp/audit/*) et n'est donc PAS ici — son ecriture
+ * path-scopee est un chantier distinct (#1b), pas un leak.
+ */
+const readOnlyPresets = new Set(
+  readdirSync(join(REPO, "presets"))
+    .filter((f) => f.endsWith(".yaml"))
+    .map((f) => ({ name: f.replace(/\.yaml$/, ""), body: readFileSync(join(REPO, "presets", f), "utf8") }))
+    .filter((p) => p.body.includes("read-only-mode") && !p.body.includes("audit-output"))
+    .map((p) => p.name),
+);
+
+/**
+ * Map idPrefix -> preset depuis le template. On NE mappe PAS par index :
+ * `count: dynamic`/`per-module` produit N agents par definition, donc l'index
+ * d'agent ne suit pas l'ordre des presets (revue = N auteurs puis N reviewers).
+ * L'agent porte `role = idPrefix` (bridge.ts), c'est la cle fiable.
+ */
+function presetByRole(templateId: string): Map<string, string> {
+  const raw = readFileSync(join(REPO, "templates", `${templateId}.yaml`), "utf8");
+  const map = new Map<string, string>();
+  const blocks = raw.split(/\n\s*-\s*(?=idPrefix:)/);
+  for (const b of blocks) {
+    const id = b.match(/idPrefix:\s*(\S+)/)?.[1];
+    const preset = b.match(/preset:\s*(\S+)/)?.[1];
+    if (id && preset) map.set(id, preset);
+  }
+  return map;
+}
+
+const templates = readdirSync(join(REPO, "templates"))
+  .filter((f) => f.endsWith(".yaml"))
+  .map((f) => f.replace(/\.yaml$/, ""));
+
+describe("DF4 — un agent read-only ne peut pas ecrire l'arbre de travail", () => {
+  it("le catalogue declare bien des lecteurs purs (sinon le test ne prouve rien)", () => {
+    expect(readOnlyPresets.size).toBeGreaterThan(0);
+    expect(readOnlyPresets.has("debat")).toBe(true);
+    // FRONTIERE #1b : gardien a read-only-mode MAIS audit-output — il ecrit son
+    // AUDIT.md, donc il n'est PAS un lecteur pur. Le classer read_only casserait
+    // son livrable (regression #34). Le verrou path-scope est un autre chantier.
+    expect(readOnlyPresets.has("gardien")).toBe(false);
+  });
+
+  for (const tid of templates) {
+    it(`${tid} : chaque agent d'un preset read-only n'a aucun outil d'ecriture`, () => {
+      let project;
+      try {
+        project = buildProjectFromBce(tid, ctx, {}, REPO);
+      } catch {
+        // per-module sans modules, etc. — non pertinent pour cet invariant.
+        return;
+      }
+      const roleToPreset = presetByRole(tid);
+      project.agents.forEach((agent) => {
+        const preset = roleToPreset.get(agent.role ?? "") ?? "";
+        if (!readOnlyPresets.has(preset)) return;
+        // WIRING : un preset read-only doit produire un agent read_only.
+        expect(agent.read_only, `${tid}/${preset}: read_only devrait etre vrai`).toBe(true);
+        // ENFORCEMENT : et donc aucun outil d'ecriture dans l'allowlist.
+        const allowed = buildAllowedTools(agent).split(",");
+        const leaks = WRITE_TOOLS.filter((t) => allowed.includes(t));
+        expect(leaks, `${tid}/${preset} laisse fuir ${leaks.join(",")}`).toEqual([]);
+      });
+    });
+  }
+
+  it("migrate-phase2 (shared MAIS pas read-only) garde le droit d'ecrire", () => {
+    const p = buildProjectFromBce("migrate-phase2", ctx, {}, REPO);
+    // au moins un agent ecrit — sinon on aurait casse la migration
+    const anyWriter = p.agents.some((a) => !a.read_only);
+    expect(anyWriter).toBe(true);
+  });
+
+  it("solo d'un lecteur pur (debat) n'expose aucun outil d'ecriture", () => {
+    const solo = buildSolo("debat", ctx, undefined, REPO);
+    expect(solo.read_only).toBe(true);
+    const allowed = buildAllowedTools({ tools: solo.mcpTools, read_only: solo.read_only } as never).split(",");
+    expect(WRITE_TOOLS.filter((t) => allowed.includes(t))).toEqual([]);
+  });
+
+  it("solo d'un preset audit-output (gardien) GARDE l'ecriture — c'est son livrable (#34)", () => {
+    const solo = buildSolo("gardien", ctx, undefined, REPO);
+    expect(solo.read_only).toBe(false);
+    const allowed = buildAllowedTools({ tools: solo.mcpTools, read_only: solo.read_only } as never).split(",");
+    expect(allowed).toContain("Write");
+  });
+
+  // LE VRAI VERROU sous --dangerously-skip-permissions (chemin agent-loop) :
+  // l'allowlist y est IGNOREE, seul --disallowedTools bloque. Un agent read_only
+  // doit donc voir chaque outil d'ecriture dans son disallow, Bash COMPRIS —
+  // sinon le mode one-shot de gardien pouvait ecrire l'arbre reel malgre une
+  // allowlist propre. C'est l'artefact, pas le proxy.
+  it("le mode read_only bloque DUR chaque outil d'ecriture (disallowedTools)", () => {
+    const blocked = disallowedForMode("read_only");
+    for (const t of WRITE_TOOLS) {
+      expect(blocked, `${t} doit etre bloque dur en read_only`).toContain(t);
+    }
+  });
+
+  it("le mode full ne bloque PAS l'ecriture (sinon on aurait casse les writers)", () => {
+    const blocked = disallowedForMode("full");
+    expect(blocked).not.toContain("Write");
+    expect(blocked).not.toContain("Bash");
+  });
+});


### PR DESCRIPTION
Ferme #1 (DF4 — sûreté par construction).

## Le défaut, mesuré

`essaim run gardien -p .` donnait `Write+Edit+Bash` à un agent dont le cwd est l'arbre de travail **réel** (preset `shared`, pas de worktree). Cause racine, vérifiée : `bridge.ts` ne positionnait **jamais** `read_only`, donc `buildAllowedTools` retombait toujours sur `CODE_TOOLS`. Le behavior `read-only-mode` était du texte de prompt sans aucun verrou d'outil. Ce n'était pas « 4 templates » — c'était **tout agent** de tout preset read-only.

## L'invariant correct

`read_only` est dérivé de `resolveBehaviors(preset)` (le résolveur de promptweave, gère héritage/composition) : **`read-only-mode` présent ET `audit-output` absent**.

Ce n'est **pas** « workspace shared → lecture seule » : `migrate-phase2` est `shared` et écrit délibérément (il n'inclut pas `read-only-mode`). La règle du cadrage aurait cassé la migration.

## Le piège trouvé par relecture adversariale

L'agent-loop passe `--dangerously-skip-permissions`, sous lequel `--allowedTools` est **ignoré** — seul `--disallowedTools` par envoi bloque dur. **La mesure du cadrage (« buildAllowedTools ne contient pas Write ») était donc un proxy** : l'allowlist est du théâtre sur ce chemin. Deux trous prouvés par exécution :

- le mode one-shot (où tombent gardien/phare, non phasés) n'imposait aucun disallow ;
- les envois de coordination (`ask_llm_*`, `propose_resolution`) et d'interruption passaient nus — un contenu de pair (injection) pouvait écrire l'arbre.

**Le vrai verrou vit désormais dans le wrapper `send()`** et couvre **tous** les envois, plus le send d'interruption (session séparée). `disallowedForMode("read_only")` bloque Write+Edit+NotebookEdit+**Bash**.

Bash retiré des ensembles read-only : Claude Code n'a pas de « Bash lecture seule » — `echo > f` écrit autant que Write. Read/Glob/Grep couvrent la lecture.

## La frontière, honnête : #1b

Les presets **`audit-output`** (gardien → `AUDIT.md`, phare-* → `tmp/audit/*`) écrivent leur livrable. Les bloquer régresse #34. Ils **gardent l'écriture** dans cette PR. Leur écriture path-scopée sous skip-permissions demande un hook PreToolUse — **chantier distinct #1b**. Cette PR verrouille les lecteurs purs (arène, débat, chaine-review, revue-reviewer) qui aujourd'hui fuient l'écriture complète ; elle ne prétend pas encore fermer gardien/phare.

## Vérification

Test paramétré sur les 15 templates, **falsifiable** (mutations exécutées : retirer le câblage → 6 échecs ; retirer le verrou du wrapper → le test one-shot échoue) : lecteurs purs verrouillés, presets audit-output conservés, `disallowedForMode` prouvé, `migrate-phase2` garde le droit d'écrire.

`pnpm test` : 822 passés, 1 ignoré. `pnpm build` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
