### PR TITLE
fix(coordination): completeTask auto-approuve — les threads atteignent 'resolved' (#2)

### DIFF
--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -396,7 +396,24 @@ export async function claimNextTask(
 }
 
 /**
- * Mark a task complete by proposing resolution.
+ * Termine une tache : propose la resolution PUIS auto-approuve (#2).
+ *
+ * `propose-resolution` fait passer le thread en `resolving` — le coordinator
+ * attend alors une approbation. Cette approbation n'etait JAMAIS emise :
+ * `approveResolution` cote coordinator existait, l'appel cote essaim aussi
+ * (approveResolutionViaRest), mais rien ne l'appelait. Mesure : sur 6 runs,
+ * TOUS les threads « resolus » finissaient `resolving`, jamais `resolved` — la
+ * couche de consensus ne concluait jamais.
+ *
+ * L'agent qui a fait le travail auto-approuve sa propre proposition. Cote
+ * coordinator, `allRespondentsApproved` rend true des que `expected_respondents`
+ * est vide (verifie sur les bases du banc : les threads bloques avaient tous
+ * exp=[]), donc une seule approbation resout le thread. Un thread AVEC des
+ * repondants attendus (chevauchement de module) n'est PAS resolu par cette
+ * auto-approbation seule — il attend le vrai consensus, comportement correct.
+ *
+ * L'approbation est resiliente (catch) : si propose a echoue, le thread n'est
+ * pas `resolving` et approveResolution jetterait — on avale, comme propose.
  */
 export async function completeTask(
   coordinatorUrl: string,
@@ -405,12 +422,22 @@ export async function completeTask(
   summary: string,
 ): Promise<void> {
   log.debug(`completeTask: thread=${threadId}`, { summary: summary.slice(0, 80) });
-  await coordinatorPost(`${coordinatorUrl}/api/propose-resolution`, {
+  const proposed = await coordinatorPost(`${coordinatorUrl}/api/propose-resolution`, {
     thread_id: threadId,
     agent_id: agentId,
     summary,
+  }).then(() => true).catch((err) => {
+    log.warn("completeTask: propose-resolution failed", { error: (err as Error).message });
+    return false;
+  });
+  if (!proposed) return;
+  await coordinatorPost(`${coordinatorUrl}/api/approve-resolution`, {
+    thread_id: threadId,
+    agent_id: agentId,
   }).catch((err) => {
-    log.warn("completeTask failed", { error: (err as Error).message });
+    // Un thread avec expected_respondents non vide n'est pas resolu ici : ce
+    // n'est pas une erreur. On journalise en debug, pas en warn.
+    log.debug("completeTask: approve-resolution non concluante (repondants attendus ?)", { error: (err as Error).message });
   });
 }
 

--- a/tests/unit/work-stealing.test.ts
+++ b/tests/unit/work-stealing.test.ts
@@ -304,23 +304,31 @@ describe("completeTask", () => {
     vi.unstubAllGlobals();
   });
 
-  it("calls propose-resolution endpoint with correct body", async () => {
-    const capturedBodies: Record<string, unknown>[] = [];
-    const mockFetch = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
-      capturedBodies.push(JSON.parse(init.body as string));
+  it("propose PUIS auto-approuve — sinon le thread reste bloque en 'resolving'", async () => {
+    // #2 — propose-resolution seul laisse le thread en 'resolving' : le
+    // coordinator attend une approbation, qui n'etait JAMAIS emise. Mesure :
+    // sur 6 runs, TOUS les threads resolus finissaient 'resolving', jamais
+    // 'resolved' — la couche de consensus ne concluait pas. L'agent qui a fait
+    // le travail auto-approuve : pour un thread sans expected_respondents (le
+    // cas mesure, exp=[]), une seule approbation suffit -> resolved.
+    const calls: { url: string; body: Record<string, unknown> }[] = [];
+    const mockFetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      calls.push({ url: url as string, body: JSON.parse(init.body as string) });
       return { ok: true, json: async () => ({ status: "resolving" }) };
     });
     vi.stubGlobal("fetch", mockFetch);
 
     await completeTask("http://localhost:3100", "t-42", "agent-1", "Fixed the null check");
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0][0]).toBe("http://localhost:3100/api/propose-resolution");
-    expect(capturedBodies[0]).toEqual({
+    expect(calls[0].url).toBe("http://localhost:3100/api/propose-resolution");
+    expect(calls[0].body).toEqual({
       thread_id: "t-42",
       agent_id: "agent-1",
       summary: "Fixed the null check",
     });
+    // L'auto-approbation, meme agent, meme thread.
+    expect(calls[1].url).toBe("http://localhost:3100/api/approve-resolution");
+    expect(calls[1].body).toMatchObject({ thread_id: "t-42", agent_id: "agent-1" });
   });
 
   it("doesn't throw on network failure", async () => {


### PR DESCRIPTION
Ferme #2 (partie work-stealing de la boucle de consensus).

## Le défaut, mesuré

Sur 6 runs, **tous** les threads « résolus » finissaient `status=resolving`, jamais `resolved`. `completeTask` appelait `/api/propose-resolution` (thread → `resolving`), mais **rien** n'appelait `/api/approve-resolution` (→ `resolved`). `approveResolution` existait des deux côtés (coordinator + `approveResolutionViaRest`), jamais déclenché. La couche de consensus ne concluait jamais.

## Le correctif

`completeTask` propose **puis** auto-approuve (même agent), résilient. Côté coordinator, `allRespondentsApproved` rend `true` dès que `expected_respondents` est vide — et **tous** les producteurs de threads réclamables codent `target_modules: []` (postDiscoveries, review NOUVEAU, security/ingest), donc `exp=[]` : une seule approbation résout. Un thread avec des répondants attendus n'est **pas** résolu par cette auto-approbation seule (il attend le vrai consensus) — comportement correct.

## Preuve

- **Unitaire** falsifiable : le test exige propose **puis** approve (RED prouvé — l'ancien test figeait « propose seul »).
- **Intégration, contre un vrai coordinator local** : un thread semé passe de `resolving` à `resolved` (`threads-summary {resolved:1, resolving:0}`).
- **Adversariale** : 20 assertions exécutées contre la logique réelle du coordinator (better-sqlite3, DB jetable). Aucune résolution à tort : un approbateur pirate ne résout pas un thread à répondants réels ; un non-propriétaire ne peut pas proposer ; `completeTask` ne touche structurellement jamais un thread de décision (`isWorkItem` + `timeout_seconds=600` l'excluent).

## Portée honnête

Ceci résout le chemin **work-stealing** — ce que le banc a mesuré. Le chemin de **décision multi-agents** (propose_resolution via le protocole d'annonce) n'auto-approuve **pas** : c'est du vrai vote de pairs, qui reste conclu par le sweeper de timeout du coordinator. C'est cohérent avec la direction « consensus à relabeler » du cadrage (section 1), pas une régression.

Un invariant non-assuré subsiste (relevé par la revue) : la sûreté repose sur le fait qu'aucun producteur réclamable ne porte de modules. Aucun chemin essaim ne le viole aujourd'hui ; un futur producteur qui posterait un thread `keep_open` ou `assigned_to` avec modules le laisserait bloqué en `resolving`. Documenté dans le code.

`pnpm test` : 822 passés, 1 ignoré. `pnpm build` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
