### PR TITLE
feat(cli): essaim doctor — preflight des dependances (#148)

### DIFF
--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import { spawnSync } from "node:child_process";
+import { runDoctor, formatDoctorReport, type DoctorDeps } from "../src/orchestrator/doctor.js";
+import { resolveClaudeBin } from "../src/agent-loop/claude-stream.js";
+import { getCatalogRoots } from "./bce-resolver.js";
+
+/** Test de port bloquant et synchrone : un mini-serveur via un sous-processus
+ *  node (`node -e`). Synchrone parce que runDoctor l'est ; le bind local resout
+ *  en quelques ms. Exit 0 = port libre, 1 = occupe. */
+function probePortSync(port: number): boolean {
+  const code = `const net=require('net');const s=net.createServer();s.once('error',()=>process.exit(1));s.once('listening',()=>s.close(()=>process.exit(0)));s.listen(${port},'127.0.0.1');`;
+  const r = spawnSync(process.execPath, ["-e", code], { stdio: "ignore", timeout: 5_000 });
+  return r.status === 0;
+}
+
+/** DoctorDeps câblées sur le vrai système. Séparées de runDoctor pour que la
+ *  logique de diagnostic reste testable sans toucher au systeme. */
+export function realDoctorDeps(projectPath?: string): DoctorDeps {
+  return {
+    // shell:true seulement sous win32 (claude/jq/curl peuvent etre des .cmd) ;
+    // ailleurs on evite le shell. On SONDE vraiment le binaire (--version), on
+    // ne se contente pas de le trouver : un binaire present mais casse est un
+    // faux OK — exactement ce que doctor doit attraper.
+    probe(bin, versionArg) {
+      try {
+        const r = spawnSync(bin, [versionArg], {
+          stdio: "ignore",
+          timeout: 10_000,
+          shell: process.platform === "win32",
+        });
+        return r.status === 0;
+      } catch {
+        return false;
+      }
+    },
+    resolveClaudeBin,
+    portFree: probePortSync,
+    catalogOk() {
+      try {
+        getCatalogRoots({ projectPath });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    platform: process.platform,
+    coordinatorUrl: process.env.COORDINATOR_URL,
+  };
+}
+
+export function createDoctorCommand(): Command {
+  return new Command("doctor")
+    .description("Vérifie les dépendances (Claude Code, catalogue, ports, jq/curl) avant un run")
+    .option("-p, --project <path>", "Chemin du projet (pour localiser un catalogue de .essaim/)")
+    .action((opts: { project?: string }) => {
+      const report = runDoctor(realDoctorDeps(opts.project));
+      console.log(formatDoctorReport(report));
+      // Code de sortie non nul si un critique echoue : cablable dans un script.
+      process.exit(report.ok ? 0 : 1);
+    });
+}

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { runDoctor, formatDoctorReport, type DoctorDeps } from "../src/orchestrator/doctor.js";
 import { resolveClaudeBin } from "../src/agent-loop/claude-stream.js";
-import { getCatalogRoots } from "./bce-resolver.js";
+import { getCatalogRoots, getBundledRoot } from "./bce-resolver.js";
 
 /** Test de port bloquant et synchrone : un mini-serveur via un sous-processus
  *  node (`node -e`). Synchrone parce que runDoctor l'est ; le bind local resout
@@ -17,16 +19,19 @@ function probePortSync(port: number): boolean {
  *  logique de diagnostic reste testable sans toucher au systeme. */
 export function realDoctorDeps(projectPath?: string): DoctorDeps {
   return {
-    // shell:true seulement sous win32 (claude/jq/curl peuvent etre des .cmd) ;
-    // ailleurs on evite le shell. On SONDE vraiment le binaire (--version), on
-    // ne se contente pas de le trouver : un binaire present mais casse est un
-    // faux OK — exactement ce que doctor doit attraper.
-    probe(bin, versionArg) {
+    // `useShell` DOIT refléter comment le binaire tourne au run, sinon la sonde
+    // ment : claude est spawné SANS shell (claude-stream.ts) — le sonder avec
+    // shell ferait passer un `.cmd` shim npm qui casse au run, et échouerait sur
+    // un chemin CLAUDE_BIN à espace (le shell scinde à l'espace) que le run
+    // lancerait sans souci. jq/curl passent par des hooks shell → shell:true.
+    // On SONDE vraiment (--version) : un binaire présent mais cassé est un faux
+    // OK, exactement ce que doctor doit attraper.
+    probe(bin, versionArg, useShell) {
       try {
         const r = spawnSync(bin, [versionArg], {
           stdio: "ignore",
           timeout: 10_000,
-          shell: process.platform === "win32",
+          shell: useShell,
         });
         return r.status === 0;
       } catch {
@@ -38,7 +43,10 @@ export function realDoctorDeps(projectPath?: string): DoctorDeps {
     catalogOk() {
       try {
         getCatalogRoots({ projectPath });
-        return true;
+        // getBundledRoot ne vérifie que behaviors/presets/compositions ; on
+        // confirme aussi templates/ — sans lui, un run échoue plus loin sur un
+        // « Unknown template » opaque, pas ici. (Le message annonce templates/.)
+        return existsSync(resolve(getBundledRoot(), "templates"));
       } catch {
         return false;
       }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@ import { createSecurityCommand } from "./security.js";
 import { createInitCommand } from "./init.js";
 import { createListCommand } from "./list.js";
 import { createSelfUpdateCommand } from "./self-update.js";
+import { createDoctorCommand } from "./doctor.js";
 import { getVersion } from "./version.js";
 
 const program = new Command();
@@ -24,5 +25,6 @@ program.addCommand(createSecurityCommand());
 program.addCommand(createInitCommand());
 program.addCommand(createListCommand());
 program.addCommand(createSelfUpdateCommand());
+program.addCommand(createDoctorCommand());
 
 program.parse();

--- a/cli/run-core.ts
+++ b/cli/run-core.ts
@@ -5,6 +5,8 @@ import { getCatalogRoots } from "./bce-resolver.js";
 import { runProject } from "../src/orchestrator/orchestrator.js";
 import { writeReport } from "../src/orchestrator/reporter.js";
 import { loadConfig } from "./config.js";
+import { runDoctor, formatDoctorReport } from "../src/orchestrator/doctor.js";
+import { realDoctorDeps } from "./doctor.js";
 import type { RunResult } from "../src/orchestrator/types.js";
 
 /**
@@ -89,6 +91,20 @@ Catalogues consultés : ${roots}`,
   // When none is set, runProject starts an in-process coordinator (Strategy A).
   loadConfig(); // ensure config warning is shown (side-effect only)
   const resolvedCoordinatorUrl = opts.coordinatorUrl ?? process.env.COORDINATOR_URL;
+
+  // #148 — préflight AVANT que le coordinator ne démarre. Une dépendance
+  // critique manquante (Claude Code, catalogue) doit produire un diagnostic
+  // lisible + une commande d'installation, pas un stack trace en plein run ni un
+  // « 0 findings » trompeur. On respecte un COORDINATOR_URL explicite pour le
+  // test des ports. ESSAIM_SKIP_DOCTOR=1 court-circuite (CI, cas limites).
+  if (process.env.ESSAIM_SKIP_DOCTOR !== "1") {
+    const deps = realDoctorDeps(projectPath);
+    const report = runDoctor({ ...deps, coordinatorUrl: resolvedCoordinatorUrl });
+    if (!report.ok) {
+      console.error(formatDoctorReport(report));
+      throw new Error("essaim doctor: une dépendance critique manque — corrigez les points ✗ ci-dessus (ou ESSAIM_SKIP_DOCTOR=1 pour forcer).");
+    }
+  }
 
   // Build project — pass projectPath so .essaim/templates/ overrides apply
   const project = buildProject(

--- a/cli/security.ts
+++ b/cli/security.ts
@@ -114,19 +114,28 @@ export function createSecurityCommand(): Command {
     .action(async (opts: SecurityCliOpts) => {
       const projectPath = resolve(opts.project);
       const { security, triageOnly } = assembleSecurity(opts, projectPath);
-      const result = await executeRun({
-        template: "sentinelle",
-        project: opts.project,
-        agentCount: opts.agents ? parseInt(opts.agents, 10) : undefined,
-        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
-        cleanup: opts.cleanup,
-        dryRun: opts.dryRun,
-        setParams: {},
-        coordinatorUrl: opts.coordinatorUrl,
-        catalogs: [],
-        security,
-        triageOnly,
-      });
+      // Comme cli/run.ts : les échecs de préflight (doctor, template inconnu,
+      // pas un dépôt git) sont des `throw` — on imprime e.message et on sort en
+      // 1, jamais un stack trace nu (l'anti-but même de #148).
+      let result;
+      try {
+        result = await executeRun({
+          template: "sentinelle",
+          project: opts.project,
+          agentCount: opts.agents ? parseInt(opts.agents, 10) : undefined,
+          timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+          cleanup: opts.cleanup,
+          dryRun: opts.dryRun,
+          setParams: {},
+          coordinatorUrl: opts.coordinatorUrl,
+          catalogs: [],
+          security,
+          triageOnly,
+        });
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exit(1);
+      }
       if (!result) process.exit(0); // --dry-run: executeRun returns undefined, nothing ran
       const code = result.security ? securityExitCode(result.security) : 0;
       process.exit(code);

--- a/src/orchestrator/doctor.ts
+++ b/src/orchestrator/doctor.ts
@@ -1,0 +1,120 @@
+// essaim doctor — préflight de dépendances. #148.
+//
+// Raison d'être : aujourd'hui, une dépendance manquante (Claude Code absent du
+// PATH, catalogue introuvable, port occupé) se manifeste par un stack trace Node
+// en pleine exécution, ou par un run qui « réussit » avec 0 finding. `doctor`
+// transforme ça en un diagnostic lisible AVANT que le coordinator ne démarre :
+// chaque échec porte un message et une commande d'installation, jamais une trace.
+//
+// La fonction est PURE et à dépendances injectables : les tests l'exécutent sans
+// toucher au systeme (pas de vrai spawn, pas de vrai bind de port). Le seul
+// verdict qui compte est `ok` (aucune verification critique en echec).
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface DoctorCheck {
+  name: string;
+  status: CheckStatus;
+  /** Ce qui a été constaté (une ligne). */
+  detail: string;
+  /** Comment réparer — commande d'installation. Présent des que status !== "ok". */
+  hint?: string;
+  /** Un échec critique empêche un run de démarrer. */
+  critical: boolean;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  /** false si une verification CRITIQUE est en echec. Un `warn` ne bloque pas. */
+  ok: boolean;
+}
+
+export interface DoctorDeps {
+  /** Sonde un binaire : lance `<bin> <versionArg>` et rend true si code 0. */
+  probe(bin: string, versionArg: string): boolean;
+  /** Résout le binaire Claude Code (respecte CLAUDE_BIN / PATH / .cmd Windows). */
+  resolveClaudeBin(): string;
+  /** true si le port est LIBRE (bindable), false s'il est occupé. */
+  portFree(port: number): boolean;
+  /** true si behaviors/ presets/ templates/ sont localisables. */
+  catalogOk(): boolean;
+  /** Plateforme, pour des hints d'installation adaptés. */
+  platform: NodeJS.Platform;
+  /** COORDINATOR_URL de l'environnement : si defini, essaim ne demarre PAS le
+   *  coordinator local, donc les ports 3100/1883 n'ont pas a etre libres. */
+  coordinatorUrl?: string;
+}
+
+/** Commande d'installation d'un outil selon la plateforme. */
+function installHint(tool: string, platform: NodeJS.Platform): string {
+  const table: Record<string, { win32: string; darwin: string; linux: string }> = {
+    jq: { win32: "winget install jqlang.jq", darwin: "brew install jq", linux: "sudo apt install jq" },
+    curl: { win32: "winget install curl.curl", darwin: "brew install curl", linux: "sudo apt install curl" },
+  };
+  const t = table[tool];
+  if (!t) return `installez ${tool}`;
+  return platform === "win32" ? t.win32 : platform === "darwin" ? t.darwin : t.linux;
+}
+
+const CLAUDE_INSTALL = "npm install -g @anthropic-ai/claude-code (ou voir claude.com/claude-code)";
+
+export function runDoctor(deps: DoctorDeps): DoctorReport {
+  const checks: DoctorCheck[] = [];
+
+  // 1. Claude Code — CRITIQUE. Sans lui, aucun agent ne peut se lancer. On SONDE
+  //    (lance --version), on ne se contente pas de trouver le chemin : un binaire
+  //    present mais non executable est un faux OK.
+  const claudeBin = deps.resolveClaudeBin();
+  const claudeOk = deps.probe(claudeBin, "--version");
+  checks.push(claudeOk
+    ? { name: "claude", status: "ok", detail: `Claude Code répond (${claudeBin})`, critical: true }
+    : { name: "claude", status: "fail", detail: `Claude Code introuvable ou muet (${claudeBin})`, hint: CLAUDE_INSTALL, critical: true });
+
+  // 2. Catalogue — CRITIQUE. Sans behaviors/presets/templates, aucun prompt
+  //    ne s'assemble. Message deja clair cote getCatalogRoots ; ici on le
+  //    transforme en verdict avant l'execution.
+  const catOk = deps.catalogOk();
+  checks.push(catOk
+    ? { name: "catalog", status: "ok", detail: "behaviors/ presets/ templates/ localisés", critical: true }
+    : { name: "catalog", status: "fail", detail: "catalogue introuvable (behaviors/ presets/ templates/)", hint: "réinstallez essaim (npm i -g essaim) ou lancez depuis le dépôt", critical: true });
+
+  // 3 & 4. Ports 3100 (coordinator) et 1883 (MQTT). Non critiques : si
+  //    COORDINATOR_URL est defini, essaim ne demarre PAS le coordinator local,
+  //    donc les ports n'ont pas a etre libres. Sinon, un port occupe est un warn
+  //    (un autre coordinator tourne peut-etre deja) — pas un blocage, mais a dire.
+  if (deps.coordinatorUrl) {
+    checks.push({ name: "port-3100", status: "ok", detail: `COORDINATOR_URL défini (${deps.coordinatorUrl}) — coordinator local non requis`, critical: false });
+  } else {
+    for (const port of [3100, 1883]) {
+      const free = deps.portFree(port);
+      checks.push(free
+        ? { name: `port-${port}`, status: "ok", detail: `port ${port} libre`, critical: false }
+        : { name: `port-${port}`, status: "warn", detail: `port ${port} occupé`, hint: `un processus écoute déjà sur ${port} — arrêtez-le, ou pointez COORDINATOR_URL vers lui`, critical: false });
+    }
+  }
+
+  // 5 & 6. jq et curl — utilises par les hooks/scripts. Warn : un run peut
+  //    demarrer sans, mais certains hooks echoueront en silence.
+  for (const tool of ["jq", "curl"]) {
+    const ok = deps.probe(tool, "--version");
+    checks.push(ok
+      ? { name: tool, status: "ok", detail: `${tool} présent`, critical: false }
+      : { name: tool, status: "warn", detail: `${tool} absent — certains hooks en dépendent`, hint: installHint(tool, deps.platform), critical: false });
+  }
+
+  const ok = !checks.some((c) => c.critical && c.status === "fail");
+  return { checks, ok };
+}
+
+/** Rendu texte pour la CLI. stdout, pas du JSON — un humain le lit. */
+export function formatDoctorReport(report: DoctorReport): string {
+  const icon = (s: CheckStatus) => (s === "ok" ? "✓" : s === "warn" ? "!" : "✗");
+  const lines = report.checks.map((c) => {
+    const head = `  ${icon(c.status)} ${c.name.padEnd(11)} ${c.detail}`;
+    return c.hint ? `${head}\n      → ${c.hint}` : head;
+  });
+  const verdict = report.ok
+    ? "\nDiagnostic OK — un run peut démarrer."
+    : "\nDiagnostic ÉCHOUÉ — corrigez les points critiques (✗) avant de lancer un run.";
+  return lines.join("\n") + "\n" + verdict;
+}

--- a/src/orchestrator/doctor.ts
+++ b/src/orchestrator/doctor.ts
@@ -30,8 +30,15 @@ export interface DoctorReport {
 }
 
 export interface DoctorDeps {
-  /** Sonde un binaire : lance `<bin> <versionArg>` et rend true si code 0. */
-  probe(bin: string, versionArg: string): boolean;
+  /**
+   * Sonde un binaire : lance `<bin> <versionArg>` et rend true si code 0.
+   * `useShell` DOIT refléter comment le binaire est réellement lancé : claude
+   * est spawné SANS shell (claude-stream.ts), donc sa sonde aussi — sinon un
+   * `.cmd` shim npm passe la sonde (shell) mais casse au run (no-shell), et un
+   * chemin a espace echoue a la sonde (shell ne cite pas) mais marche au run.
+   * jq/curl sont invoques par des hooks shell : leur sonde utilise un shell.
+   */
+  probe(bin: string, versionArg: string, useShell: boolean): boolean;
   /** Résout le binaire Claude Code (respecte CLAUDE_BIN / PATH / .cmd Windows). */
   resolveClaudeBin(): string;
   /** true si le port est LIBRE (bindable), false s'il est occupé. */
@@ -64,11 +71,15 @@ export function runDoctor(deps: DoctorDeps): DoctorReport {
   // 1. Claude Code — CRITIQUE. Sans lui, aucun agent ne peut se lancer. On SONDE
   //    (lance --version), on ne se contente pas de trouver le chemin : un binaire
   //    present mais non executable est un faux OK.
+  // SANS shell : on imite exactement le vrai lanceur (claude-stream.ts spawn
+  // sans shell). --version qui repond ne garantit PAS que `-p` marche (auth,
+  // version) — la sonde attrape « introuvable / non lançable comme au run »,
+  // pas « ne peut pas vraiment travailler ». C'est la limite honnete du check.
   const claudeBin = deps.resolveClaudeBin();
-  const claudeOk = deps.probe(claudeBin, "--version");
+  const claudeOk = deps.probe(claudeBin, "--version", false);
   checks.push(claudeOk
-    ? { name: "claude", status: "ok", detail: `Claude Code répond (${claudeBin})`, critical: true }
-    : { name: "claude", status: "fail", detail: `Claude Code introuvable ou muet (${claudeBin})`, hint: CLAUDE_INSTALL, critical: true });
+    ? { name: "claude", status: "ok", detail: `Claude Code lançable (${claudeBin})`, critical: true }
+    : { name: "claude", status: "fail", detail: `Claude Code non lançable comme au run (${claudeBin})`, hint: CLAUDE_INSTALL, critical: true });
 
   // 2. Catalogue — CRITIQUE. Sans behaviors/presets/templates, aucun prompt
   //    ne s'assemble. Message deja clair cote getCatalogRoots ; ici on le
@@ -93,10 +104,11 @@ export function runDoctor(deps: DoctorDeps): DoctorReport {
     }
   }
 
-  // 5 & 6. jq et curl — utilises par les hooks/scripts. Warn : un run peut
-  //    demarrer sans, mais certains hooks echoueront en silence.
+  // 5 & 6. jq et curl — utilises par les hooks/scripts SHELL, donc sonde AVEC
+  //    shell (contrairement a claude). Warn : un run peut demarrer sans, mais
+  //    certains hooks echoueront en silence.
   for (const tool of ["jq", "curl"]) {
-    const ok = deps.probe(tool, "--version");
+    const ok = deps.probe(tool, "--version", true);
     checks.push(ok
       ? { name: tool, status: "ok", detail: `${tool} présent`, critical: false }
       : { name: tool, status: "warn", detail: `${tool} absent — certains hooks en dépendent`, hint: installHint(tool, deps.platform), critical: false });

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -69,6 +69,25 @@ describe("runDoctor", () => {
     expect(r.ok).toBe(true);
   });
 
+  it("claude est sondé SANS shell, jq/curl AVEC shell (fidèle au vrai lanceur)", () => {
+    // Verrou anti-régression pour #148 : le vrai lanceur spawn claude sans
+    // shell (claude-stream.ts) ; le sonder avec shell ferait passer un .cmd
+    // shim npm (faux OK) et casserait sur un chemin à espace (faux échec).
+    // jq/curl passent par des hooks shell → shell attendu.
+    const calls: Array<{ bin: string; useShell: boolean }> = [];
+    runDoctor(
+      healthyDeps({
+        probe: (bin, _v, useShell) => {
+          calls.push({ bin, useShell });
+          return true;
+        },
+      }),
+    );
+    expect(calls.find((c) => c.bin === "claude")!.useShell).toBe(false);
+    expect(calls.find((c) => c.bin === "jq")!.useShell).toBe(true);
+    expect(calls.find((c) => c.bin === "curl")!.useShell).toBe(true);
+  });
+
   it("formatDoctorReport imprime le hint sous une ligne en echec, et le verdict", () => {
     const r = runDoctor(healthyDeps({ probe: (b) => b !== "claude" }));
     const txt = formatDoctorReport(r);

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { runDoctor, formatDoctorReport, type DoctorDeps } from "../../src/orchestrator/doctor.js";
+
+// Un jeu de deps « tout va bien », qu'on degrade cas par cas.
+function healthyDeps(over: Partial<DoctorDeps> = {}): DoctorDeps {
+  return {
+    probe: () => true,
+    resolveClaudeBin: () => "claude",
+    portFree: () => true,
+    catalogOk: () => true,
+    platform: "linux",
+    coordinatorUrl: undefined,
+    ...over,
+  };
+}
+
+describe("runDoctor", () => {
+  it("tout present -> ok, aucun fail", () => {
+    const r = runDoctor(healthyDeps());
+    expect(r.ok).toBe(true);
+    expect(r.checks.some((c) => c.status === "fail")).toBe(false);
+  });
+
+  it("Claude Code absent -> fail CRITIQUE avec une commande d'installation, ok=false", () => {
+    // probe rend false pour le bin claude (present mais muet, ou introuvable).
+    const r = runDoctor(healthyDeps({ probe: (bin) => bin !== "claude" }));
+    expect(r.ok).toBe(false);
+    const claude = r.checks.find((c) => c.name === "claude")!;
+    expect(claude.status).toBe("fail");
+    expect(claude.critical).toBe(true);
+    // Le hint DOIT contenir une commande d'installation — pas juste « erreur ».
+    expect(claude.hint).toMatch(/install/i);
+  });
+
+  it("catalogue introuvable -> fail critique, ok=false", () => {
+    const r = runDoctor(healthyDeps({ catalogOk: () => false }));
+    expect(r.ok).toBe(false);
+    const cat = r.checks.find((c) => c.name === "catalog")!;
+    expect(cat.status).toBe("fail");
+    expect(cat.hint).toBeTruthy();
+  });
+
+  it("jq/curl absents -> WARN, pas fail : ok reste true (un warn ne bloque pas)", () => {
+    const r = runDoctor(healthyDeps({ probe: (bin) => bin === "claude" }));
+    expect(r.ok).toBe(true); // jq/curl manquants ne sont pas critiques
+    const jq = r.checks.find((c) => c.name === "jq")!;
+    expect(jq.status).toBe("warn");
+    expect(jq.hint).toBeTruthy();
+  });
+
+  it("hint jq adapte a la plateforme", () => {
+    const win = runDoctor(healthyDeps({ probe: (b) => b === "claude", platform: "win32" }));
+    expect(win.checks.find((c) => c.name === "jq")!.hint).toContain("winget");
+    const mac = runDoctor(healthyDeps({ probe: (b) => b === "claude", platform: "darwin" }));
+    expect(mac.checks.find((c) => c.name === "jq")!.hint).toContain("brew");
+  });
+
+  it("port 3100 occupe -> WARN (pas critique), ok reste true", () => {
+    const r = runDoctor(healthyDeps({ portFree: (p) => p !== 3100 }));
+    expect(r.ok).toBe(true);
+    expect(r.checks.find((c) => c.name === "port-3100")!.status).toBe("warn");
+  });
+
+  it("COORDINATOR_URL defini -> les ports locaux ne sont pas testes", () => {
+    const r = runDoctor(healthyDeps({ coordinatorUrl: "https://c.example", portFree: () => false }));
+    // portFree rend false partout, mais comme COORDINATOR_URL est defini, aucun
+    // warn de port : le coordinator local n'est pas requis.
+    expect(r.checks.some((c) => c.name === "port-1883")).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  it("formatDoctorReport imprime le hint sous une ligne en echec, et le verdict", () => {
+    const r = runDoctor(healthyDeps({ probe: (b) => b !== "claude" }));
+    const txt = formatDoctorReport(r);
+    expect(txt).toMatch(/install/i);
+    expect(txt).toContain("ÉCHOUÉ");
+  });
+});


### PR DESCRIPTION
Ferme #148. Ajoute `essaim doctor` : un preflight des dependances (Claude Code, catalogue, ports 3100/1883, jq/curl) qui transforme une dependance manquante en **diagnostic lisible + commande d'installation** AVANT que le coordinator ne demarre — au lieu d'un stack trace en plein run ou d'un run qui "reussit" avec 0 finding.

## Ce qui est cable
- Commande autonome `essaim doctor` (exit 0/1, cablable en script).
- Preflight automatique dans les trois entrees `run` / `pipeline` / `security`. `ESSAIM_SKIP_DOCTOR=1` court-circuite. Un `COORDINATOR_URL` explicite dispense du test des ports locaux.
- Fonction `runDoctor` pure a dependances injectables -> testee sans toucher au systeme.

## Fidelite prouvee par une revue adverse
La sonde claude imite **exactement** le vrai lanceur (`claude-stream.ts` spawn **sans** shell). Sonder avec shell mentait dans les deux sens, verifie par execution :

| Cas | sonde shell (naif) | sonde no-shell (fidele) | vrai run |
|-----|-----|-----|-----|
| `.cmd` shim npm, PATH minimal | OK ✗ (faux OK) | ENOENT ✓ | casse |
| `CLAUDE_BIN` a espace | echec ✗ (faux echec) | lance ✓ | lance |

jq/curl passent par des hooks shell -> sonde **avec** shell. Un test falsifiable verrouille l'asymetrie.

## Autres correctifs de la revue
- `catalogOk` verifie aussi `templates/` (sinon un catalogue partiel ressortait en "Unknown template" opaque plus loin).
- `cli/security.ts` enveloppe `executeRun` d'un try/catch (comme `run.ts`) : l'abort du doctor imprime `e.message` + exit 1, jamais une trace nue — l'anti-but meme de #148.

## Tests
831 pass / 1 skip, build vert. 9 tests unitaires sur `runDoctor` (claude absent -> fail+hint, jq/curl -> warn, hints par plateforme, port occupe -> warn, `COORDINATOR_URL` -> ports ignores, sonde claude sans shell / jq-curl avec). Les deux faux verdicts et l'abort propre verifies bout-en-bout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
