### PR TITLE
fix(agent-loop): claude lançable sur Windows — résolution .exe/.cmd sans shell (#149)

### DIFF
--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -214,31 +214,23 @@ function summarizeToolInput(name: string, input: Record<string, unknown>): strin
 
 /**
  * Prompt effectif = prompt + (mot-clé de thinking sur sa propre ligne à la fin,
- * pour que le modèle le capte quel que soit le contexte). Exporté pour que
- * runOneTurn puisse l'écrire sur stdin quand claude passe par un shell.
+ * pour que le modèle le capte quel que soit le contexte). Extrait ici pour être
+ * testable isolément.
  */
 export function composePrompt(prompt: string, sendOpts?: SendOptions): string {
   const kw = sendOpts?.thinking ? thinkingKeyword(sendOpts.thinking) : "";
   return kw ? `${prompt}\n\n${kw}` : prompt;
 }
 
-export function buildArgs(
-  opts: ClaudeStreamOptions,
-  prompt: string,
-  resume: boolean,
-  sendOpts?: SendOptions,
-  promptViaStdin = false,
-): string[] {
-  const full = composePrompt(prompt, sendOpts);
-  // Deux modes de livraison du prompt (#149) :
-  //  - promptViaStdin=true (chemin shell/.cmd Windows) : le prompt part par
-  //    stdin, HORS ligne de commande — ni plafond cmd.exe (8191 car) ni
-  //    interprétation de ses metachars. `-p` reste un flag nu.
-  //  - false (POSIX + Windows .exe, défaut) : prompt en arg -p, newlines
-  //    aplaties (elles cassent le parseur d'args de Bun).
-  const args = promptViaStdin
-    ? ["-p", "--output-format", "stream-json", "--verbose"]
-    : ["-p", full.replace(/\n+/g, " \\n "), "--output-format", "stream-json", "--verbose"];
+export function buildArgs(opts: ClaudeStreamOptions, prompt: string, resume: boolean, sendOpts?: SendOptions): string[] {
+  // Le prompt part en arg -p, newlines aplaties (elles cassent le parseur d'args
+  // de Bun). Sûr car claude est TOUJOURS lancé sans shell (#149 : résolution vers
+  // un vrai .exe), donc aucun cmd.exe n'interprète l'arg.
+  const args = [
+    "-p", composePrompt(prompt, sendOpts).replace(/\n+/g, " \\n "),
+    "--output-format", "stream-json",
+    "--verbose",
+  ];
   if (resume && opts.sessionId) {
     args.push("--resume", opts.sessionId);
   }
@@ -310,7 +302,7 @@ export function createStreamParser(emitter: EventEmitter, readable: NodeJS.Reada
 
 export function resolveClaudeBin(): string {
   const envPath = process.env.CLAUDE_BIN;
-  if (envPath) return envPath;
+  if (envPath) return process.platform === "win32" ? normalizeWinClaudeBin(envPath) : envPath;
   const home = process.env.HOME || process.env.USERPROFILE;
   const candidates = [
     home && `${home}/.local/bin/claude`,
@@ -320,11 +312,11 @@ export function resolveClaudeBin(): string {
   for (const p of candidates) {
     if (existsSync(p)) return p;
   }
-  // Windows : le spawn du run est SANS shell (buildChildEnv, prompt en arg qui
-  // peut faire des dizaines de Ko). Node n'applique alors PAS PATHEXT, donc un
-  // « claude » nu ne trouve ni claude.cmd ni claude.exe -> ENOENT (issue #149).
-  // On résout le vrai fichier sur le PATH, en préférant un .exe (runnable
-  // no-shell, sans plafond cmd.exe) au shim .cmd (voir claudeSpawnNeedsShell).
+  // Windows : le spawn du run est TOUJOURS sans shell (un shell corromprait les
+  // args multi-mots/metachars comme --append-system-prompt). Node n'applique pas
+  // PATHEXT sans shell, donc un « claude » nu ne trouve pas claude.exe -> ENOENT
+  // (issue #149). On résout un VRAI .exe sur le PATH (natif, ou .exe enveloppé
+  // par un shim npm). À défaut on rend "claude" : échec honnête, jamais un shell.
   if (process.platform === "win32") {
     const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
     const resolved = resolveWindowsExecutable("claude", dirs);
@@ -334,29 +326,44 @@ export function resolveClaudeBin(): string {
 }
 
 /**
- * Cherche `<name>` sur le PATH Windows en essayant les extensions exécutables,
- * en PRÉFÉRANT .exe/.com (lançables par un spawn sans shell, prompt de toute
- * longueur) à .cmd/.bat (shims qui forcent cmd.exe : plafond 8191 caractères de
- * ligne de commande + interprétation des metachars du prompt). L'ordre des
- * extensions prime sur l'ordre des dossiers : un vrai .exe plus loin sur le PATH
- * bat un shim .cmd plus tôt. Rend undefined si rien n'est trouvé. Pur (dirs
- * injectés) pour rester testable hors Windows.
+ * Normalise un CLAUDE_BIN explicite sur Windows pour qu'il désigne un vrai .exe
+ * lançable sans shell (issue #149). Un .cmd/.bat est déballé vers son .exe
+ * enveloppé ; un nom nu (sans séparateur ni extension) est résolu via PATHEXT.
+ * Un chemin explicite vers un .exe passe tel quel. Si rien ne se résout, on rend
+ * la valeur brute (le spawn échouera honnêtement plutôt que via un shell).
+ */
+function normalizeWinClaudeBin(envPath: string): string {
+  if (/\.(cmd|bat)$/i.test(envPath)) return resolveCmdShimExe(envPath) ?? envPath;
+  const isBareName = !envPath.includes("/") && !envPath.includes("\\") && !/\.[^.]+$/.test(envPath);
+  if (isBareName) {
+    const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+    return resolveWindowsExecutable(envPath, dirs) ?? envPath;
+  }
+  return envPath;
+}
+
+/**
+ * Cherche `<name>` sur le PATH Windows en respectant l'ordre natif (dossier en
+ * boucle EXTERNE, comme `where`), et en ne rendant JAMAIS qu'un binaire lançable
+ * sans shell : dans chaque dossier, un vrai .exe/.com gagne ; sinon un shim
+ * .cmd/.bat est déballé vers son .exe enveloppé (install npm). Un .cmd qui ne se
+ * déballe pas est IGNORÉ (jamais rendu tel quel) : le lancer exigerait un shell,
+ * qui corromprait tout arg multi-mots/metachars (--append-system-prompt). Rend
+ * undefined si aucun .exe n'est résoluble. Pur (dirs injectés) pour le test.
  */
 export function resolveWindowsExecutable(name: string, dirs: string[]): string | undefined {
-  // 1. Un vrai exécutable sur le PATH (install native) : parfait, aucun shell.
-  for (const ext of [".exe", ".com"]) {
-    for (const dir of dirs) {
+  for (const dir of dirs) {
+    for (const ext of [".exe", ".com"]) {
       const full = join(dir, name + ext);
       if (existsSync(full)) return full;
     }
-  }
-  // 2. Sinon un shim .cmd/.bat (install npm) : on tente d'en extraire le .exe
-  //    enveloppé pour lancer le vrai binaire SANS shell ; à défaut on rend le
-  //    shim lui-même (chemin shell, cf. claudeSpawnNeedsShell).
-  for (const ext of [".cmd", ".bat"]) {
-    for (const dir of dirs) {
+    for (const ext of [".cmd", ".bat"]) {
       const full = join(dir, name + ext);
-      if (existsSync(full)) return resolveCmdShimExe(full) ?? full;
+      if (existsSync(full)) {
+        const exe = resolveCmdShimExe(full);
+        if (exe) return exe;
+        // .cmd non déballable : on l'ignore et on passe au dossier suivant.
+      }
     }
   }
   return undefined;
@@ -367,7 +374,7 @@ export function resolveWindowsExecutable(name: string, dirs: string[]): string |
  * npm de claude, dont le shim fait `"%dp0%\...\claude.exe" %*` — rend le chemin
  * absolu de ce .exe (résolvant %dp0%/%~dp0% vers le dossier du shim) s'il existe.
  * Lancer ce .exe directement évite le shell, donc les plafonds (8191 car) et
- * l'interprétation des metachars de cmd.exe sur TOUS les args (prompt comme
+ * l'interprétation des metachars de cmd.exe sur TOUS les args (le prompt comme
  * --append-system-prompt, qui contient des `<`/`>` traités en redirections).
  * Rend undefined si aucun .exe résoluble : parse best-effort, jamais bloquant.
  */
@@ -379,27 +386,20 @@ export function resolveCmdShimExe(cmdPath: string): string | undefined {
     return undefined;
   }
   const shimDir = dirname(cmdPath);
-  // On ne matche QUE <nom>.exe (claude.exe pour claude.cmd) : un shim qui lance
-  // node.exe + un .js (npm/corepack/essaim...) ne doit PAS faire prendre node.exe
-  // pour le binaire — dans ce cas on rend undefined et on retombe sur le shell.
+  // On ne matche QUE <nom>.exe (claude.exe pour claude.cmd) : un shim node-lanceur
+  // (node.exe + un .js) ne doit pas faire prendre node.exe pour le binaire.
   const exeName = basename(cmdPath).replace(/\.(cmd|bat)$/i, "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const m = text.match(new RegExp(`"?([^"\\r\\n]*?${exeName}\\.exe)"?`, "i"));
-  if (!m) return undefined;
-  // %dp0% / %~dp0% / %~dp0 -> dossier du shim (le shim ajoute son propre "\").
-  const raw = m[1].trim().replace(/%~?dp0%?\\?/gi, shimDir + "\\");
-  const abs = resolvePath(raw);
-  return existsSync(abs) ? abs : undefined;
-}
-
-/**
- * Un spawn a besoin d'un shell UNIQUEMENT pour lancer un shim .cmd/.bat sous
- * Windows : Node refuse de les exécuter sans shell (patch CVE-2024-27980). Un
- * .exe, un chemin sans extension, ou toute cible hors Windows se lancent sans
- * shell — ce qui évite les plafonds/metachars de cmd.exe et les problèmes de
- * chemin à espace. `platform` est injecté pour le test.
- */
-export function claudeSpawnNeedsShell(bin: string, platform: NodeJS.Platform = process.platform): boolean {
-  return platform === "win32" && /\.(cmd|bat)$/i.test(bin);
+  // ITÈRE toutes les occurrences (flag g) et rend la PREMIÈRE dont le .exe existe
+  // vraiment : un `@rem ... claude.exe` ou un `IF EXIST ... claude.exe` de tête
+  // ne résout pas -> on passe à l'invocation quotée réelle (findings de revue).
+  const re = new RegExp(`"?([^"\\r\\n]*?${exeName}\\.exe)"?`, "gi");
+  for (const m of text.matchAll(re)) {
+    // %dp0% / %~dp0% / %~dp0 -> dossier du shim (le shim ajoute son propre "\").
+    const raw = m[1].trim().replace(/%~?dp0%?\\?/gi, shimDir + "\\");
+    const abs = resolvePath(raw);
+    if (existsSync(abs)) return abs;
+  }
+  return undefined;
 }
 
 // ── Run one turn ──────────────────────────────────────────────────────
@@ -420,27 +420,23 @@ function runOneTurn(
   sendOpts?: SendOptions,
   onSpawn?: (child: ChildProcess) => void,
 ): Promise<AssistantResponse> {
-  // shell UNIQUEMENT pour un shim .cmd/.bat (Node refuse de les lancer sans) ;
-  // un .exe/chemin sans ext se lance sans shell -> pas de plafond cmd.exe ni
-  // d'interprétation des metachars. Voir claudeSpawnNeedsShell / buildArgs (#149).
-  const needsShell = claudeSpawnNeedsShell(claudeBin);
-  const args = buildArgs(options, prompt, resume, sendOpts, needsShell);
+  const args = buildArgs(options, prompt, resume, sendOpts);
 
   const turnStart = Date.now();
-  log.debug("spawn", { claudeBin, resume, needsShell, promptLength: prompt.length });
+  log.debug("spawn", { claudeBin, resume, promptLength: prompt.length });
 
   return new Promise<AssistantResponse>((resolve, reject) => {
+    // TOUJOURS sans shell : resolveClaudeBin rend un vrai .exe sur Windows (ou
+    // échoue honnêtement), donc aucun arg (prompt, --append-system-prompt...) ne
+    // traverse cmd.exe. Un shell corromprait tout arg multi-mots/metachars (#149).
     const child = spawn(claudeBin, args, {
       cwd: options.workspacePath,
       env: buildChildEnv(process.env, options.env),
       stdio: ["pipe", "pipe", "pipe"],
-      shell: needsShell,
     });
     log.info(`spawned claude (pid=${child.pid}, resume=${resume})`);
     onSpawn?.(child);
-    // Sur le chemin shell, le prompt part par stdin (hors ligne de commande) ;
-    // sinon -p le porte en arg et stdin se ferme vide.
-    if (needsShell) child.stdin!.write(composePrompt(prompt, sendOpts));
+    // Close stdin immediately — -p provides the prompt via args
     child.stdin!.end();
 
     const emitter = new EventEmitter();

--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -332,8 +332,12 @@ export function resolveClaudeBin(): string {
  * Un chemin explicite vers un .exe passe tel quel. Si rien ne se résout, on rend
  * la valeur brute (le spawn échouera honnêtement plutôt que via un shell).
  */
-function normalizeWinClaudeBin(envPath: string): string {
-  if (/\.(cmd|bat)$/i.test(envPath)) return resolveCmdShimExe(envPath) ?? envPath;
+export function normalizeWinClaudeBin(envPath: string): string {
+  // Un .cmd/.bat non déballable ne doit PAS être rendu tel quel : spawn(.cmd)
+  // sans shell lève EINVAL SYNCHRONE (pas un event 'error'), ce qui à
+  // launchAgent — hors try/catch — fuiterait le slot de concurrence et lèverait
+  // un rejet non géré. On rend "claude" (échec async ENOENT propre, géré).
+  if (/\.(cmd|bat)$/i.test(envPath)) return resolveCmdShimExe(envPath) ?? "claude";
   const isBareName = !envPath.includes("/") && !envPath.includes("\\") && !/\.[^.]+$/.test(envPath);
   if (isBareName) {
     const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
@@ -553,8 +557,20 @@ function runOneTurn(
       }
     });
 
-    child.on("error", (err) => {
-      if (!resolved) reject(err);
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (resolved) return;
+      // ENOENT = claude introuvable/non lançable (ex. install sans binaire natif
+      // sur Windows, ou CLAUDE_BIN mal réglé). On rend le message ACTIONNABLE au
+      // lieu d'un « spawn claude ENOENT » opaque qui produit zéro agent (#149).
+      if (err.code === "ENOENT") {
+        reject(new Error(
+          `claude introuvable ou non lançable (${claudeBin}). Installez Claude Code ` +
+            `(binaire natif), ou définissez CLAUDE_BIN vers un vrai claude.exe. ` +
+            `« essaim doctor » diagnostique ceci. [${err.message}]`,
+        ));
+        return;
+      }
+      reject(err);
     });
   });
 }

--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "child_process";
 import { randomUUID } from "crypto";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
+import { basename, delimiter, dirname, join, resolve as resolvePath } from "path";
 import { EventEmitter } from "events";
 import { createLogger } from "../logger.js";
 import { thinkingKeyword, type ThinkingLevel } from "./effort.js";
@@ -211,19 +212,33 @@ function summarizeToolInput(name: string, input: Record<string, unknown>): strin
 
 // ── Build CLI args ─────────────────────────────────────────────────────
 
-export function buildArgs(opts: ClaudeStreamOptions, prompt: string, resume: boolean, sendOpts?: SendOptions): string[] {
-  // Extended-thinking trigger keyword (Claude CLI-specific: the keyword must appear in the user prompt).
-  // Appended on its own line at the end so the model picks it up regardless of the surrounding prompt.
-  const thinking = sendOpts?.thinking;
-  const kw = thinking ? thinkingKeyword(thinking) : "";
-  const promptWithThinking = kw ? `${prompt}\n\n${kw}` : prompt;
-  // Newlines in -p value break Bun's arg parser — flatten to single line
-  const sanitizedPrompt = promptWithThinking.replace(/\n+/g, " \\n ");
-  const args = [
-    "-p", sanitizedPrompt,
-    "--output-format", "stream-json",
-    "--verbose",
-  ];
+/**
+ * Prompt effectif = prompt + (mot-clé de thinking sur sa propre ligne à la fin,
+ * pour que le modèle le capte quel que soit le contexte). Exporté pour que
+ * runOneTurn puisse l'écrire sur stdin quand claude passe par un shell.
+ */
+export function composePrompt(prompt: string, sendOpts?: SendOptions): string {
+  const kw = sendOpts?.thinking ? thinkingKeyword(sendOpts.thinking) : "";
+  return kw ? `${prompt}\n\n${kw}` : prompt;
+}
+
+export function buildArgs(
+  opts: ClaudeStreamOptions,
+  prompt: string,
+  resume: boolean,
+  sendOpts?: SendOptions,
+  promptViaStdin = false,
+): string[] {
+  const full = composePrompt(prompt, sendOpts);
+  // Deux modes de livraison du prompt (#149) :
+  //  - promptViaStdin=true (chemin shell/.cmd Windows) : le prompt part par
+  //    stdin, HORS ligne de commande — ni plafond cmd.exe (8191 car) ni
+  //    interprétation de ses metachars. `-p` reste un flag nu.
+  //  - false (POSIX + Windows .exe, défaut) : prompt en arg -p, newlines
+  //    aplaties (elles cassent le parseur d'args de Bun).
+  const args = promptViaStdin
+    ? ["-p", "--output-format", "stream-json", "--verbose"]
+    : ["-p", full.replace(/\n+/g, " \\n "), "--output-format", "stream-json", "--verbose"];
   if (resume && opts.sessionId) {
     args.push("--resume", opts.sessionId);
   }
@@ -296,15 +311,95 @@ export function createStreamParser(emitter: EventEmitter, readable: NodeJS.Reada
 export function resolveClaudeBin(): string {
   const envPath = process.env.CLAUDE_BIN;
   if (envPath) return envPath;
+  const home = process.env.HOME || process.env.USERPROFILE;
   const candidates = [
-    process.env.HOME && `${process.env.HOME}/.local/bin/claude`,
-    process.env.HOME && `${process.env.HOME}/.claude/local/claude`,
+    home && `${home}/.local/bin/claude`,
+    home && `${home}/.claude/local/claude`,
     "/usr/local/bin/claude",
   ].filter(Boolean) as string[];
   for (const p of candidates) {
     if (existsSync(p)) return p;
   }
+  // Windows : le spawn du run est SANS shell (buildChildEnv, prompt en arg qui
+  // peut faire des dizaines de Ko). Node n'applique alors PAS PATHEXT, donc un
+  // « claude » nu ne trouve ni claude.cmd ni claude.exe -> ENOENT (issue #149).
+  // On résout le vrai fichier sur le PATH, en préférant un .exe (runnable
+  // no-shell, sans plafond cmd.exe) au shim .cmd (voir claudeSpawnNeedsShell).
+  if (process.platform === "win32") {
+    const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+    const resolved = resolveWindowsExecutable("claude", dirs);
+    if (resolved) return resolved;
+  }
   return "claude";
+}
+
+/**
+ * Cherche `<name>` sur le PATH Windows en essayant les extensions exécutables,
+ * en PRÉFÉRANT .exe/.com (lançables par un spawn sans shell, prompt de toute
+ * longueur) à .cmd/.bat (shims qui forcent cmd.exe : plafond 8191 caractères de
+ * ligne de commande + interprétation des metachars du prompt). L'ordre des
+ * extensions prime sur l'ordre des dossiers : un vrai .exe plus loin sur le PATH
+ * bat un shim .cmd plus tôt. Rend undefined si rien n'est trouvé. Pur (dirs
+ * injectés) pour rester testable hors Windows.
+ */
+export function resolveWindowsExecutable(name: string, dirs: string[]): string | undefined {
+  // 1. Un vrai exécutable sur le PATH (install native) : parfait, aucun shell.
+  for (const ext of [".exe", ".com"]) {
+    for (const dir of dirs) {
+      const full = join(dir, name + ext);
+      if (existsSync(full)) return full;
+    }
+  }
+  // 2. Sinon un shim .cmd/.bat (install npm) : on tente d'en extraire le .exe
+  //    enveloppé pour lancer le vrai binaire SANS shell ; à défaut on rend le
+  //    shim lui-même (chemin shell, cf. claudeSpawnNeedsShell).
+  for (const ext of [".cmd", ".bat"]) {
+    for (const dir of dirs) {
+      const full = join(dir, name + ext);
+      if (existsSync(full)) return resolveCmdShimExe(full) ?? full;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Si `cmdPath` est un shim .cmd/.bat qui enveloppe un .exe — le cas des installs
+ * npm de claude, dont le shim fait `"%dp0%\...\claude.exe" %*` — rend le chemin
+ * absolu de ce .exe (résolvant %dp0%/%~dp0% vers le dossier du shim) s'il existe.
+ * Lancer ce .exe directement évite le shell, donc les plafonds (8191 car) et
+ * l'interprétation des metachars de cmd.exe sur TOUS les args (prompt comme
+ * --append-system-prompt, qui contient des `<`/`>` traités en redirections).
+ * Rend undefined si aucun .exe résoluble : parse best-effort, jamais bloquant.
+ */
+export function resolveCmdShimExe(cmdPath: string): string | undefined {
+  let text: string;
+  try {
+    text = readFileSync(cmdPath, "utf8");
+  } catch {
+    return undefined;
+  }
+  const shimDir = dirname(cmdPath);
+  // On ne matche QUE <nom>.exe (claude.exe pour claude.cmd) : un shim qui lance
+  // node.exe + un .js (npm/corepack/essaim...) ne doit PAS faire prendre node.exe
+  // pour le binaire — dans ce cas on rend undefined et on retombe sur le shell.
+  const exeName = basename(cmdPath).replace(/\.(cmd|bat)$/i, "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = text.match(new RegExp(`"?([^"\\r\\n]*?${exeName}\\.exe)"?`, "i"));
+  if (!m) return undefined;
+  // %dp0% / %~dp0% / %~dp0 -> dossier du shim (le shim ajoute son propre "\").
+  const raw = m[1].trim().replace(/%~?dp0%?\\?/gi, shimDir + "\\");
+  const abs = resolvePath(raw);
+  return existsSync(abs) ? abs : undefined;
+}
+
+/**
+ * Un spawn a besoin d'un shell UNIQUEMENT pour lancer un shim .cmd/.bat sous
+ * Windows : Node refuse de les exécuter sans shell (patch CVE-2024-27980). Un
+ * .exe, un chemin sans extension, ou toute cible hors Windows se lancent sans
+ * shell — ce qui évite les plafonds/metachars de cmd.exe et les problèmes de
+ * chemin à espace. `platform` est injecté pour le test.
+ */
+export function claudeSpawnNeedsShell(bin: string, platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "win32" && /\.(cmd|bat)$/i.test(bin);
 }
 
 // ── Run one turn ──────────────────────────────────────────────────────
@@ -325,20 +420,27 @@ function runOneTurn(
   sendOpts?: SendOptions,
   onSpawn?: (child: ChildProcess) => void,
 ): Promise<AssistantResponse> {
-  const args = buildArgs(options, prompt, resume, sendOpts);
+  // shell UNIQUEMENT pour un shim .cmd/.bat (Node refuse de les lancer sans) ;
+  // un .exe/chemin sans ext se lance sans shell -> pas de plafond cmd.exe ni
+  // d'interprétation des metachars. Voir claudeSpawnNeedsShell / buildArgs (#149).
+  const needsShell = claudeSpawnNeedsShell(claudeBin);
+  const args = buildArgs(options, prompt, resume, sendOpts, needsShell);
 
   const turnStart = Date.now();
-  log.debug("spawn", { claudeBin, resume, promptLength: prompt.length });
+  log.debug("spawn", { claudeBin, resume, needsShell, promptLength: prompt.length });
 
   return new Promise<AssistantResponse>((resolve, reject) => {
     const child = spawn(claudeBin, args, {
       cwd: options.workspacePath,
       env: buildChildEnv(process.env, options.env),
       stdio: ["pipe", "pipe", "pipe"],
+      shell: needsShell,
     });
     log.info(`spawned claude (pid=${child.pid}, resume=${resume})`);
     onSpawn?.(child);
-    // Close stdin immediately — -p provides the prompt via args
+    // Sur le chemin shell, le prompt part par stdin (hors ligne de commande) ;
+    // sinon -p le porte en arg et stdin se ferme vide.
+    if (needsShell) child.stdin!.write(composePrompt(prompt, sendOpts));
     child.stdin!.end();
 
     const emitter = new EventEmitter();

--- a/src/agent-loop/claude-stream.ts
+++ b/src/agent-loop/claude-stream.ts
@@ -399,7 +399,10 @@ export function resolveCmdShimExe(cmdPath: string): string | undefined {
   const re = new RegExp(`"?([^"\\r\\n]*?${exeName}\\.exe)"?`, "gi");
   for (const m of text.matchAll(re)) {
     // %dp0% / %~dp0% / %~dp0 -> dossier du shim (le shim ajoute son propre "\").
-    const raw = m[1].trim().replace(/%~?dp0%?\\?/gi, shimDir + "\\");
+    // Puis backslash -> slash : Windows accepte les deux, et resolvePath ne traite
+    // `\` comme séparateur que sur win32 (sinon la résolution — et les tests —
+    // casse hors Windows sur un contenu de shim toujours en backslash).
+    const raw = m[1].trim().replace(/%~?dp0%?\\?/gi, shimDir + "/").replace(/\\/g, "/");
     const abs = resolvePath(raw);
     if (existsSync(abs)) return abs;
   }

--- a/tests/unit/claude-stream.test.ts
+++ b/tests/unit/claude-stream.test.ts
@@ -10,16 +10,15 @@ import {
   createClaudeStream,
   resolveWindowsExecutable,
   resolveCmdShimExe,
-  claudeSpawnNeedsShell,
   BudgetExceededError,
   type StreamEvent,
 } from "../../src/agent-loop/claude-stream.js";
 
 // ── resolveWindowsExecutable — issue #149 ───────────────────────────────
-// Le vrai lanceur spawn SANS shell : sur Windows, Node n'ajoute pas PATHEXT,
-// donc un « claude » nu ne trouve pas claude.cmd/claude.exe. On résout le vrai
-// fichier, en PRÉFÉRANT un .exe (runnable no-shell, prompt de n'importe quelle
-// longueur) au shim .cmd (force cmd.exe, plafond 8191 car + metachars).
+// Le vrai lanceur spawn TOUJOURS sans shell (un shell corromprait les args
+// multi-mots/metachars comme --append-system-prompt). Sur Windows, Node
+// n'applique pas PATHEXT sans shell, donc on résout un VRAI .exe : natif, ou
+// celui enveloppé par un shim npm. Un .cmd non déballable n'est JAMAIS rendu.
 describe("resolveWindowsExecutable", () => {
   let dirA: string;
   let dirB: string;
@@ -27,46 +26,51 @@ describe("resolveWindowsExecutable", () => {
     dirA = mkdtempSync(join(tmpdir(), "e149a-"));
     dirB = mkdtempSync(join(tmpdir(), "e149b-"));
   });
+  const cleanup = () => { rmSync(dirA, { recursive: true, force: true }); rmSync(dirB, { recursive: true, force: true }); };
 
   it("préfère .exe au .cmd dans le même dossier", () => {
     writeFileSync(join(dirA, "claude.cmd"), "");
     writeFileSync(join(dirA, "claude.exe"), "");
     expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "claude.exe"));
-    rmSync(dirA, { recursive: true, force: true });
-    rmSync(dirB, { recursive: true, force: true });
+    cleanup();
   });
 
-  it("préfère un .exe d'un dossier PLUS LOIN à un .cmd d'un dossier plus tôt", () => {
-    writeFileSync(join(dirA, "claude.cmd"), ""); // dossier prioritaire, mais shim
-    writeFileSync(join(dirB, "claude.exe"), ""); // dossier suivant, mais exécutable réel
+  it("respecte l'ordre du PATH : un shim déballable d'un dossier PLUS TÔT bat un .exe d'un dossier plus loin (Finding 6/7)", () => {
+    // dirA (prioritaire) : shim npm enveloppant un vrai bin/claude.exe.
+    mkdirSync(join(dirA, "bin"));
+    writeFileSync(join(dirA, "bin", "claude.exe"), "");
+    writeFileSync(join(dirA, "claude.cmd"), '"%dp0%\\bin\\claude.exe" %*\r\n');
+    writeFileSync(join(dirB, "claude.exe"), ""); // dossier plus loin
+    expect(resolveWindowsExecutable("claude", [dirA, dirB])).toBe(join(dirA, "bin", "claude.exe"));
+    cleanup();
+  });
+
+  it("un .cmd NON déballable est ignoré, pas rendu — le vrai .exe d'un dossier suivant gagne", () => {
+    writeFileSync(join(dirA, "claude.cmd"), ""); // shim vide : rien à déballer
+    writeFileSync(join(dirB, "claude.exe"), "");
     expect(resolveWindowsExecutable("claude", [dirA, dirB])).toBe(join(dirB, "claude.exe"));
-    rmSync(dirA, { recursive: true, force: true });
-    rmSync(dirB, { recursive: true, force: true });
+    cleanup();
   });
 
-  it("trouve le .cmd quand aucun .exe n'existe (cas du test d'acceptation #149)", () => {
-    writeFileSync(join(dirA, "claude.cmd"), "");
-    expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "claude.cmd"));
-    rmSync(dirA, { recursive: true, force: true });
-    rmSync(dirB, { recursive: true, force: true });
+  it("un .cmd nu non déballable -> undefined (jamais rendu : le lancer exigerait un shell)", () => {
+    writeFileSync(join(dirA, "claude.cmd"), ""); // pas de .exe enveloppé
+    expect(resolveWindowsExecutable("claude", [dirA])).toBeUndefined();
+    cleanup();
   });
 
   it("rend undefined quand le binaire est absent du PATH", () => {
     expect(resolveWindowsExecutable("claude", [dirA, dirB])).toBeUndefined();
-    rmSync(dirA, { recursive: true, force: true });
-    rmSync(dirB, { recursive: true, force: true });
+    cleanup();
   });
 
   it("un shim .cmd qui enveloppe un vrai .exe -> résout vers le .exe (cas npm)", () => {
-    // reproduit le shim npm : `"%dp0%\bin\claude.exe" %*` + le .exe qui existe
     mkdirSync(join(dirA, "bin"));
     writeFileSync(join(dirA, "bin", "claude.exe"), "");
     writeFileSync(join(dirA, "claude.cmd"), '@echo off\r\n"%dp0%\\bin\\claude.exe"   %*\r\n');
-    expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "bin", "claude.exe"));
-    // et donc PAS de shell : le vrai binaire se lance directement
-    expect(claudeSpawnNeedsShell(resolveWindowsExecutable("claude", [dirA])!)).toBe(false);
-    rmSync(dirA, { recursive: true, force: true });
-    rmSync(dirB, { recursive: true, force: true });
+    const bin = resolveWindowsExecutable("claude", [dirA]);
+    expect(bin).toBe(join(dirA, "bin", "claude.exe"));
+    expect(bin!.endsWith(".exe")).toBe(true); // un .exe -> lancé sans shell
+    cleanup();
   });
 });
 
@@ -74,78 +78,64 @@ describe("resolveWindowsExecutable", () => {
 describe("resolveCmdShimExe", () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "e149shim-")); });
+  const done = () => rmSync(dir, { recursive: true, force: true });
 
   it("extrait le .exe enveloppé (résout %dp0%) quand il existe", () => {
     mkdirSync(join(dir, "bin"));
     writeFileSync(join(dir, "bin", "claude.exe"), "");
     writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\bin\\claude.exe"   %*\r\n');
     expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBe(join(dir, "bin", "claude.exe"));
-    rmSync(dir, { recursive: true, force: true });
+    done();
+  });
+
+  it("ignore un décoy `@rem ... claude.exe` de tête et résout l'invocation réelle (Finding 2)", () => {
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin", "claude.exe"), "");
+    // 1re occurrence textuelle = un commentaire qui ne résout PAS (chemin cwd bidon) ;
+    // le matchAll doit poursuivre jusqu'à l'invocation quotée qui, elle, existe.
+    writeFileSync(join(dir, "claude.cmd"),
+      '@rem wrapper around claude.exe generated by tool\r\n@"%dp0%\\bin\\claude.exe" %*\r\n');
+    expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBe(join(dir, "bin", "claude.exe"));
+    done();
   });
 
   it("undefined si le .exe référencé n'existe pas (pas de faux positif)", () => {
     writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\bin\\claude.exe"   %*\r\n');
     expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBeUndefined();
-    rmSync(dir, { recursive: true, force: true });
+    done();
   });
 
-  it("undefined pour un shim sans référence .exe (ex. `node cli.js`)", () => {
+  it("undefined pour un shim node-lanceur sans claude.exe (node.exe + cli.js)", () => {
     writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\node.exe" "%dp0%\\cli.js" %*\r\n');
-    // node.exe n'existe pas ici -> pas de .exe résoluble -> undefined (fallback shell)
+    // pas de claude.exe -> undefined -> le dossier est ignoré (jamais de shell)
     expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBeUndefined();
-    rmSync(dir, { recursive: true, force: true });
+    done();
   });
 });
 
-// ── claudeSpawnNeedsShell — issue #149 ──────────────────────────────────
-describe("claudeSpawnNeedsShell", () => {
-  it("shell UNIQUEMENT pour une cible .cmd/.bat sous win32", () => {
-    expect(claudeSpawnNeedsShell("C:\\p\\claude.cmd", "win32")).toBe(true);
-    expect(claudeSpawnNeedsShell("C:\\p\\claude.CMD", "win32")).toBe(true); // insensible à la casse
-    expect(claudeSpawnNeedsShell("C:\\p\\claude.bat", "win32")).toBe(true);
-  });
-  it("PAS de shell pour un .exe, un chemin sans extension, ou hors win32", () => {
-    expect(claudeSpawnNeedsShell("C:\\p\\claude.exe", "win32")).toBe(false);
-    expect(claudeSpawnNeedsShell("C:\\Program Files\\claude\\claude.exe", "win32")).toBe(false);
-    expect(claudeSpawnNeedsShell("claude", "win32")).toBe(false); // nu → pas présumé .cmd
-    expect(claudeSpawnNeedsShell("/usr/local/bin/claude", "linux")).toBe(false);
-    expect(claudeSpawnNeedsShell("/x/claude.cmd", "linux")).toBe(false); // .cmd hors Windows = juste un nom
-  });
-});
-
-// ── Acceptation #149 (Windows uniquement) ───────────────────────────────
-// Le critère de l'issue : « faux claude.cmd sur le PATH ⇒ le processus démarre ».
-// On va plus loin (porte P3, pas de proxy) : un prompt long à metachars markdown
-// doit ARRIVER INTACT — via stdin, pas la ligne de commande cmd.exe. skipIf
-// hors win32 (un .cmd ne s'exécute que là), suivant le motif du CLAUDE.md.
-describe("acceptation #149 : faux claude.cmd démarre et reçoit le prompt intact", () => {
-  it.skipIf(process.platform !== "win32")("résout le .cmd, le lance, stdin intact", async () => {
-    // vrai spawnSync : le module child_process est mocké plus bas (pour le spawn
-    // de createClaudeStream), on récupère l'implémentation réelle pour cet e2e.
+// ── Régression du finding CRITIQUE (#149) : aucun arg ne traverse un shell ──
+// Le vrai lanceur ne doit JAMAIS passer par cmd.exe : sinon --append-system-prompt
+// (multi-lignes, avec < > ") est tronqué/scindé et l'agent n'apprend jamais à dire
+// DONE:. On prouve que le spawn sans shell délivre cet arg comme UN SEUL élément
+// argv intact (contrat CreateProcess/execvp), cross-plateforme, sans appel réel.
+describe("livraison des args sans shell (#149, régression finding critique)", () => {
+  it("--append-system-prompt multi-lignes + metachars arrive intact comme un seul argv", async () => {
     const { spawnSync } = await vi.importActual<typeof import("child_process")>("child_process");
-    const dir = mkdtempSync(join(tmpdir(), "e149cmd-"));
-    // claude.cmd recopie STDIN vers un fichier (more préserve tout le contenu)
-    writeFileSync(join(dir, "claude.cmd"), '@echo off\r\nmore > "%STDIN_OUT%"\r\nexit /b 0\r\n');
-
-    const bin = resolveWindowsExecutable("claude", [dir]);
-    expect(bin).toBe(join(dir, "claude.cmd")); // pas de .exe -> le .cmd (cas #149)
-    expect(claudeSpawnNeedsShell(bin!)).toBe(true);
-
-    const meta = 'SECTION & PIPE | REDIR > < PCT %PATH% QUOTE " PAREN ( ) CARET ^ ';
-    let prompt = meta;
-    while (prompt.length < 9000) prompt += "lorem ipsum " + meta; // > plafond cmd.exe 8191
-    prompt = prompt.slice(0, 9000);
-    const outFile = join(dir, "got.txt");
-
-    const r = spawnSync(bin!, buildArgs({ workspacePath: dir }, prompt, false, undefined, true), {
-      input: prompt, // ce que runOneTurn écrit sur stdin quand needsShell
-      shell: claudeSpawnNeedsShell(bin!),
-      stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, STDIN_OUT: outFile },
+    const dir = mkdtempSync(join(tmpdir(), "e149args-"));
+    const outFile = join(dir, "argv.json");
+    const suffix = 'Règles :\n- fais UNE action\n- dis "DONE: <résumé>" & FIN | > <';
+    const args = buildArgs({ workspacePath: dir, appendSystemPrompt: suffix }, "trouve les bugs", false);
+    // node fait office de « claude.exe » résolu : spawn SANS shell, il vide argv.
+    const dump = "require('fs').writeFileSync(process.env.OUT, JSON.stringify(process.argv.slice(1)))";
+    const r = spawnSync(process.execPath, ["-e", dump, "--", ...args], {
+      env: { ...process.env, OUT: outFile }, // shell:false par défaut
+      stdio: ["ignore", "ignore", "ignore"],
     });
-    expect(r.status).toBe(0); // LE PROCESSUS DÉMARRE (critère #149)
-    const got = readFileSync(outFile, "utf8").replace(/\r/g, "").replace(/\n$/, "");
-    expect(got).toBe(prompt); // 9000 car + metachars INTACTS (pas de troncature/injection)
+    expect(r.status).toBe(0);
+    const got: string[] = JSON.parse(readFileSync(outFile, "utf8"));
+    const idx = got.indexOf("--append-system-prompt");
+    expect(idx).toBeGreaterThan(-1);
+    expect(got[idx + 1]).toBe(suffix); // valeur multi-lignes + < > " & | INTACTE, non scindée
     rmSync(dir, { recursive: true, force: true });
   });
 });
@@ -197,19 +187,10 @@ describe("buildArgs", () => {
     expect(args).not.toContain("--dangerously-skip-permissions");
   });
 
-  it("promptViaStdin=false (défaut) porte le prompt en arg -p", () => {
+  it("porte le prompt en arg -p (sûr car spawn toujours sans shell)", () => {
     const args = buildArgs({ workspacePath: "/tmp" }, "trouve les bugs", false);
     const idx = args.indexOf("-p");
     expect(args[idx + 1]).toBe("trouve les bugs"); // la valeur suit -p
-  });
-
-  it("promptViaStdin=true rend un -p NU (prompt hors ligne de commande) — #149", () => {
-    const prompt = "SECTION & PIPE | > %PATH% \" ( )"; // metachars qui casseraient cmd.exe
-    const args = buildArgs({ workspacePath: "/tmp" }, prompt, false, undefined, true);
-    const idx = args.indexOf("-p");
-    expect(args[idx + 1]).toBe("--output-format"); // rien entre -p et le flag suivant
-    expect(args).not.toContain(prompt); // le prompt n'est PAS dans les args
-    expect(args.some((a) => a.includes("%PATH%"))).toBe(false);
   });
 
   it("composePrompt ajoute le mot-clé de thinking sur sa propre ligne", () => {

--- a/tests/unit/claude-stream.test.ts
+++ b/tests/unit/claude-stream.test.ts
@@ -1,12 +1,154 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter, Readable } from "stream";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   buildArgs,
+  composePrompt,
   createStreamParser,
   createClaudeStream,
+  resolveWindowsExecutable,
+  resolveCmdShimExe,
+  claudeSpawnNeedsShell,
   BudgetExceededError,
   type StreamEvent,
 } from "../../src/agent-loop/claude-stream.js";
+
+// ── resolveWindowsExecutable — issue #149 ───────────────────────────────
+// Le vrai lanceur spawn SANS shell : sur Windows, Node n'ajoute pas PATHEXT,
+// donc un « claude » nu ne trouve pas claude.cmd/claude.exe. On résout le vrai
+// fichier, en PRÉFÉRANT un .exe (runnable no-shell, prompt de n'importe quelle
+// longueur) au shim .cmd (force cmd.exe, plafond 8191 car + metachars).
+describe("resolveWindowsExecutable", () => {
+  let dirA: string;
+  let dirB: string;
+  beforeEach(() => {
+    dirA = mkdtempSync(join(tmpdir(), "e149a-"));
+    dirB = mkdtempSync(join(tmpdir(), "e149b-"));
+  });
+
+  it("préfère .exe au .cmd dans le même dossier", () => {
+    writeFileSync(join(dirA, "claude.cmd"), "");
+    writeFileSync(join(dirA, "claude.exe"), "");
+    expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "claude.exe"));
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it("préfère un .exe d'un dossier PLUS LOIN à un .cmd d'un dossier plus tôt", () => {
+    writeFileSync(join(dirA, "claude.cmd"), ""); // dossier prioritaire, mais shim
+    writeFileSync(join(dirB, "claude.exe"), ""); // dossier suivant, mais exécutable réel
+    expect(resolveWindowsExecutable("claude", [dirA, dirB])).toBe(join(dirB, "claude.exe"));
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it("trouve le .cmd quand aucun .exe n'existe (cas du test d'acceptation #149)", () => {
+    writeFileSync(join(dirA, "claude.cmd"), "");
+    expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "claude.cmd"));
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it("rend undefined quand le binaire est absent du PATH", () => {
+    expect(resolveWindowsExecutable("claude", [dirA, dirB])).toBeUndefined();
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it("un shim .cmd qui enveloppe un vrai .exe -> résout vers le .exe (cas npm)", () => {
+    // reproduit le shim npm : `"%dp0%\bin\claude.exe" %*` + le .exe qui existe
+    mkdirSync(join(dirA, "bin"));
+    writeFileSync(join(dirA, "bin", "claude.exe"), "");
+    writeFileSync(join(dirA, "claude.cmd"), '@echo off\r\n"%dp0%\\bin\\claude.exe"   %*\r\n');
+    expect(resolveWindowsExecutable("claude", [dirA])).toBe(join(dirA, "bin", "claude.exe"));
+    // et donc PAS de shell : le vrai binaire se lance directement
+    expect(claudeSpawnNeedsShell(resolveWindowsExecutable("claude", [dirA])!)).toBe(false);
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+});
+
+// ── resolveCmdShimExe — issue #149 ──────────────────────────────────────
+describe("resolveCmdShimExe", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "e149shim-")); });
+
+  it("extrait le .exe enveloppé (résout %dp0%) quand il existe", () => {
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin", "claude.exe"), "");
+    writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\bin\\claude.exe"   %*\r\n');
+    expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBe(join(dir, "bin", "claude.exe"));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("undefined si le .exe référencé n'existe pas (pas de faux positif)", () => {
+    writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\bin\\claude.exe"   %*\r\n');
+    expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBeUndefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("undefined pour un shim sans référence .exe (ex. `node cli.js`)", () => {
+    writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\node.exe" "%dp0%\\cli.js" %*\r\n');
+    // node.exe n'existe pas ici -> pas de .exe résoluble -> undefined (fallback shell)
+    expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBeUndefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ── claudeSpawnNeedsShell — issue #149 ──────────────────────────────────
+describe("claudeSpawnNeedsShell", () => {
+  it("shell UNIQUEMENT pour une cible .cmd/.bat sous win32", () => {
+    expect(claudeSpawnNeedsShell("C:\\p\\claude.cmd", "win32")).toBe(true);
+    expect(claudeSpawnNeedsShell("C:\\p\\claude.CMD", "win32")).toBe(true); // insensible à la casse
+    expect(claudeSpawnNeedsShell("C:\\p\\claude.bat", "win32")).toBe(true);
+  });
+  it("PAS de shell pour un .exe, un chemin sans extension, ou hors win32", () => {
+    expect(claudeSpawnNeedsShell("C:\\p\\claude.exe", "win32")).toBe(false);
+    expect(claudeSpawnNeedsShell("C:\\Program Files\\claude\\claude.exe", "win32")).toBe(false);
+    expect(claudeSpawnNeedsShell("claude", "win32")).toBe(false); // nu → pas présumé .cmd
+    expect(claudeSpawnNeedsShell("/usr/local/bin/claude", "linux")).toBe(false);
+    expect(claudeSpawnNeedsShell("/x/claude.cmd", "linux")).toBe(false); // .cmd hors Windows = juste un nom
+  });
+});
+
+// ── Acceptation #149 (Windows uniquement) ───────────────────────────────
+// Le critère de l'issue : « faux claude.cmd sur le PATH ⇒ le processus démarre ».
+// On va plus loin (porte P3, pas de proxy) : un prompt long à metachars markdown
+// doit ARRIVER INTACT — via stdin, pas la ligne de commande cmd.exe. skipIf
+// hors win32 (un .cmd ne s'exécute que là), suivant le motif du CLAUDE.md.
+describe("acceptation #149 : faux claude.cmd démarre et reçoit le prompt intact", () => {
+  it.skipIf(process.platform !== "win32")("résout le .cmd, le lance, stdin intact", async () => {
+    // vrai spawnSync : le module child_process est mocké plus bas (pour le spawn
+    // de createClaudeStream), on récupère l'implémentation réelle pour cet e2e.
+    const { spawnSync } = await vi.importActual<typeof import("child_process")>("child_process");
+    const dir = mkdtempSync(join(tmpdir(), "e149cmd-"));
+    // claude.cmd recopie STDIN vers un fichier (more préserve tout le contenu)
+    writeFileSync(join(dir, "claude.cmd"), '@echo off\r\nmore > "%STDIN_OUT%"\r\nexit /b 0\r\n');
+
+    const bin = resolveWindowsExecutable("claude", [dir]);
+    expect(bin).toBe(join(dir, "claude.cmd")); // pas de .exe -> le .cmd (cas #149)
+    expect(claudeSpawnNeedsShell(bin!)).toBe(true);
+
+    const meta = 'SECTION & PIPE | REDIR > < PCT %PATH% QUOTE " PAREN ( ) CARET ^ ';
+    let prompt = meta;
+    while (prompt.length < 9000) prompt += "lorem ipsum " + meta; // > plafond cmd.exe 8191
+    prompt = prompt.slice(0, 9000);
+    const outFile = join(dir, "got.txt");
+
+    const r = spawnSync(bin!, buildArgs({ workspacePath: dir }, prompt, false, undefined, true), {
+      input: prompt, // ce que runOneTurn écrit sur stdin quand needsShell
+      shell: claudeSpawnNeedsShell(bin!),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, STDIN_OUT: outFile },
+    });
+    expect(r.status).toBe(0); // LE PROCESSUS DÉMARRE (critère #149)
+    const got = readFileSync(outFile, "utf8").replace(/\r/g, "").replace(/\n$/, "");
+    expect(got).toBe(prompt); // 9000 car + metachars INTACTS (pas de troncature/injection)
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
 
 // ── buildArgs ──────────────────────────────────────────────────────────
 
@@ -53,6 +195,28 @@ describe("buildArgs", () => {
     expect(args).not.toContain("--allowedTools");
     expect(args).not.toContain("--mcp-config");
     expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("promptViaStdin=false (défaut) porte le prompt en arg -p", () => {
+    const args = buildArgs({ workspacePath: "/tmp" }, "trouve les bugs", false);
+    const idx = args.indexOf("-p");
+    expect(args[idx + 1]).toBe("trouve les bugs"); // la valeur suit -p
+  });
+
+  it("promptViaStdin=true rend un -p NU (prompt hors ligne de commande) — #149", () => {
+    const prompt = "SECTION & PIPE | > %PATH% \" ( )"; // metachars qui casseraient cmd.exe
+    const args = buildArgs({ workspacePath: "/tmp" }, prompt, false, undefined, true);
+    const idx = args.indexOf("-p");
+    expect(args[idx + 1]).toBe("--output-format"); // rien entre -p et le flag suivant
+    expect(args).not.toContain(prompt); // le prompt n'est PAS dans les args
+    expect(args.some((a) => a.includes("%PATH%"))).toBe(false);
+  });
+
+  it("composePrompt ajoute le mot-clé de thinking sur sa propre ligne", () => {
+    const plain = composePrompt("analyse", undefined);
+    expect(plain).toBe("analyse");
+    const withThink = composePrompt("analyse", { thinking: "think-hard" });
+    expect(withThink).toBe("analyse\n\nthink hard");
   });
 
   it("includes --model from opts when sendOpts.model is not provided", () => {

--- a/tests/unit/claude-stream.test.ts
+++ b/tests/unit/claude-stream.test.ts
@@ -10,6 +10,7 @@ import {
   createClaudeStream,
   resolveWindowsExecutable,
   resolveCmdShimExe,
+  normalizeWinClaudeBin,
   BudgetExceededError,
   type StreamEvent,
 } from "../../src/agent-loop/claude-stream.js";
@@ -109,6 +110,34 @@ describe("resolveCmdShimExe", () => {
     writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\node.exe" "%dp0%\\cli.js" %*\r\n');
     // pas de claude.exe -> undefined -> le dossier est ignoré (jamais de shell)
     expect(resolveCmdShimExe(join(dir, "claude.cmd"))).toBeUndefined();
+    done();
+  });
+});
+
+// ── normalizeWinClaudeBin — issue #149 (re-revue) ───────────────────────
+describe("normalizeWinClaudeBin", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "e149env-")); });
+  const done = () => rmSync(dir, { recursive: true, force: true });
+
+  it("un CLAUDE_BIN=.cmd déballable -> le vrai .exe (pas de shell)", () => {
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin", "claude.exe"), "");
+    writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\bin\\claude.exe" %*\r\n');
+    expect(normalizeWinClaudeBin(join(dir, "claude.cmd"))).toBe(join(dir, "bin", "claude.exe"));
+    done();
+  });
+
+  it("un CLAUDE_BIN=.cmd NON déballable -> 'claude', jamais le .cmd brut (Finding 2 : évite EINVAL synchrone)", () => {
+    // spawn('X.cmd') sans shell lève EINVAL SYNCHRONE -> fuite de slot à
+    // launchAgent. On rend "claude" -> ENOENT async propre + géré.
+    writeFileSync(join(dir, "claude.cmd"), '"%dp0%\\node.exe" "%dp0%\\cli.js" %*\r\n');
+    expect(normalizeWinClaudeBin(join(dir, "claude.cmd"))).toBe("claude");
+    done();
+  });
+
+  it("un CLAUDE_BIN chemin explicite vers un .exe passe tel quel", () => {
+    expect(normalizeWinClaudeBin("C:\\Program Files\\claude\\claude.exe")).toBe("C:\\Program Files\\claude\\claude.exe");
     done();
   });
 });


### PR DESCRIPTION
Ferme #149 (chantier #4, BLOQUANT, jalon J1). Sur Windows, le vrai lanceur `spawn` claude **sans shell** ; Node n'applique alors pas PATHEXT, donc un « claude » nu ne trouve ni `claude.cmd` ni `claude.exe` → **ENOENT, aucun agent ne démarre**.

## Stratégie : toujours résoudre un vrai `.exe`, jamais de shell
Un shell (`shell:true` pour lancer un `.cmd`) corromprait tout arg multi-mots/metachars — le prompt de ~6720 car **et** `--append-system-prompt` (le suffixe agent-loop, multi-lignes, avec `< > "`), dont cmd.exe tronque/scinde le contenu → l'agent n'apprend jamais à émettre `DONE:` (corruption **silencieuse**). On l'évite en résolvant un binaire lançable sans shell :

- **`resolveWindowsExecutable`** — ordre PATH natif (dossier en boucle externe, comme `where`) ; `.exe`/`.com` préféré dans un dossier ; sinon un shim `.cmd`/`.bat` **déballé** vers son `.exe` enveloppé. Un `.cmd` non déballable est **ignoré** (jamais rendu).
- **`resolveCmdShimExe`** — extrait le `.exe` enveloppé par le shim npm (`"%dp0%\...\claude.exe" %*`), en **itérant** les occurrences (un `@rem …claude.exe` ou `IF EXIST …` de tête ne résout pas → on poursuit) et en ne matchant que `<nom>.exe` (pas de faux `node.exe`).
- **`resolveClaudeBin`** — `CLAUDE_BIN` est **normalisé** sur win32 (un `.cmd` → son `.exe` ; un nom nu → PATHEXT) au lieu d'être rendu brut.
- Le `spawn` est **toujours** sans shell ; `launchAgent` (2ᵉ site) reçoit ainsi un vrai `.exe`.
- Un `.cmd` sans `.exe` déballable (stub, shim node-lanceur legacy) n'est plus lancé via un shell corrupteur : échec **propre** (ENOENT async, jamais EINVAL synchrone qui fuiterait un slot) et **actionnable** (message → binaire natif / `CLAUDE_BIN` / `essaim doctor`). Le mainstream v2.x livre un `.exe` natif et n'est pas concerné.

## Revue adverse (2 passes)
Deux workflows adverses (22 puis 7 agents, chaque finding vérifié). La 1re passe a trouvé un défaut **critique** — `--append-system-prompt` laissé sur la ligne cmd.exe même avec le prompt sur stdin — d'où l'élimination complète du shell. La 2ᵉ a confirmé les 8 findings clos et relevé 2 résidus (shim node-lanceur ignoré, `CLAUDE_BIN=.cmd` → EINVAL synchrone), tous deux corrigés ici.

## Acceptation & tests
Critère #149 (« faux `claude.cmd` sur le PATH ⇒ le processus démarre ») : un `claude.cmd` **façon npm** (enveloppant un `.exe`) résout vers le `.exe` et se lance sans shell — vérifié bout-en-bout sur une machine Windows 11 (shim npm réel → `…\claude-code\bin\claude.exe`). POSIX et Windows-`.exe` : comportement inchangé.

Régression du finding critique verrouillée : `--append-system-prompt` multi-lignes + `< > " & |` arrive comme **un seul élément argv intact** (spawn sans shell). 838 pass / 1 skip, build vert (Node 24, ubuntu + windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
