### PR TITLE
fix(solo): échec propre + CLAUDE_BIN + exit non-zéro sur kill (#150)

### DIFF
--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -1,11 +1,12 @@
 import { Command } from "commander";
 import { resolve } from "path";
 import { existsSync } from "fs";
-import { spawn } from "child_process";
+import { spawn, type ChildProcess } from "child_process";
 import { scanProject } from "../src/orchestrator/scanner.js";
 import { listTemplates } from "../src/orchestrator/template-engine.js";
 import { buildSolo } from "../src/bridge.js";
 import { buildAllowedTools } from "../src/orchestrator/agent-launcher.js";
+import { resolveClaudeBin } from "../src/agent-loop/claude-stream.js";
 import type { AgentConfig } from "../src/orchestrator/types.js";
 import { collect, parseSetParams, parseSetFileParams, buildParamTypeMap } from "./params.js";
 
@@ -38,6 +39,60 @@ export function buildSoloArgs(
   // (buildSolo le derive de la presence du behavior read-only-mode).
   args.push("--allowedTools", buildAllowedTools({ tools: mcpTools, read_only: readOnly } as AgentConfig));
   return args;
+}
+
+export interface SoloLaunchDeps {
+  spawn: (cmd: string, args: string[], opts: { stdio: "inherit"; cwd: string }) => ChildProcess;
+  resolveClaudeBin: () => string;
+  exit: (code: number) => void;
+  /** Enregistre un handler de signal ; injecté pour ne pas polluer process en test. */
+  onSignal?: (sig: "SIGINT" | "SIGTERM", cb: () => void) => void;
+}
+
+/**
+ * Lance `claude -p` pour un run solo et gère timeout / erreurs / signaux (#150).
+ * Extrait du `.action` pour être testable. Garanties du chantier :
+ *  - claude absent/non lançable -> UNE ligne d'erreur ACTIONNABLE sur stderr +
+ *    exit 1, jamais un stack trace nu (spawn peut lever EINVAL SYNCHRONE pour un
+ *    .cmd, ou émettre 'error' ENOENT en async — les deux sont attrapés) ;
+ *  - ZÉRO octet écrit sur stdout ici : stdout reste réservé à la sortie de
+ *    l'agent (stdio: "inherit"). Les diagnostics vont sur stderr ;
+ *  - le binaire vient de resolveClaudeBin (honore CLAUDE_BIN).
+ */
+export function launchSolo(args: string[], cwd: string, timeoutMin: number, deps: SoloLaunchDeps): void {
+  const claudeBin = deps.resolveClaudeBin();
+  const fail = (msg: string) => {
+    console.error(
+      `Impossible de lancer claude (${claudeBin}) : ${msg}. ` +
+        `Installez Claude Code, ou définissez CLAUDE_BIN vers un vrai claude.`,
+    );
+    deps.exit(1);
+  };
+  let child: ChildProcess;
+  try {
+    child = deps.spawn(claudeBin, args, { stdio: "inherit", cwd });
+  } catch (e) {
+    fail(e instanceof Error ? e.message : String(e)); // spawn(.cmd) sans shell = EINVAL synchrone
+    return;
+  }
+
+  const timer = setTimeout(() => {
+    console.error(`\nTimeout: ${timeoutMin} minutes exceeded. Killing agent.`);
+    child.kill();
+  }, timeoutMin * 60 * 1000);
+
+  const onSignal = deps.onSignal ?? ((s, cb) => { process.on(s, cb); });
+  onSignal("SIGINT", () => child.kill("SIGINT"));
+  onSignal("SIGTERM", () => child.kill("SIGTERM"));
+
+  child.on("error", (err: NodeJS.ErrnoException) => {
+    clearTimeout(timer);
+    fail(err.message); // ex. ENOENT : claude absent du PATH
+  });
+  child.on("exit", (code) => {
+    clearTimeout(timer);
+    deps.exit(code ?? 0);
+  });
 }
 
 export function createSoloCommand(): Command {
@@ -109,32 +164,20 @@ export function createSoloCommand(): Command {
           read_only,
         );
 
-        console.log(`\nSolo mode: ${template}`);
-        console.log(`  Project:  ${projectPath}`);
-        console.log(`  Timeout:  ${opts.timeout} minutes`);
-        console.log(`  Prompt:   ${prompt.length} chars`);
-        console.log(`  Tools:    ${args[args.indexOf("--allowedTools") + 1]}`);
-        console.log(`\nLaunching Claude Code...\n`);
+        // Diagnostics sur STDERR : stdout est réservé à la sortie de l'agent, donc
+        // « 0 octet de prompt sur stdout » quand claude est absent (#150). On
+        // n'imprime que la LONGUEUR du prompt, jamais son contenu.
+        console.error(`\nSolo mode: ${template}`);
+        console.error(`  Project:  ${projectPath}`);
+        console.error(`  Timeout:  ${opts.timeout} minutes`);
+        console.error(`  Prompt:   ${prompt.length} chars`);
+        console.error(`  Tools:    ${args[args.indexOf("--allowedTools") + 1]}`);
+        console.error(`\nLaunching Claude Code...\n`);
 
-        const child = spawn("claude", args, {
-          stdio: "inherit",
-          cwd: projectPath,
-        });
-
-        // Timeout
-        const timeoutMs = parseInt(opts.timeout, 10) * 60 * 1000;
-        const timer = setTimeout(() => {
-          console.error(
-            `\nTimeout: ${opts.timeout} minutes exceeded. Killing agent.`,
-          );
-          child.kill();
-        }, timeoutMs);
-
-        process.on("SIGINT", () => child.kill("SIGINT"));
-        process.on("SIGTERM", () => child.kill("SIGTERM"));
-        child.on("exit", (code) => {
-          clearTimeout(timer);
-          process.exit(code ?? 0);
+        launchSolo(args, projectPath, parseInt(opts.timeout, 10), {
+          spawn,
+          resolveClaudeBin, // honore CLAUDE_BIN
+          exit: (code) => process.exit(code),
         });
       },
     );

--- a/cli/solo.ts
+++ b/cli/solo.ts
@@ -76,10 +76,15 @@ export function launchSolo(args: string[], cwd: string, timeoutMin: number, deps
     return;
   }
 
-  const timer = setTimeout(() => {
-    console.error(`\nTimeout: ${timeoutMin} minutes exceeded. Killing agent.`);
-    child.kill();
-  }, timeoutMin * 60 * 1000);
+  // timeoutMin <= 0 => pas de limite (le .action valide déjà NaN/négatif). Sans
+  // ce garde, `-t 0` posait setTimeout(kill, 0) et tuait l'agent au spawn (#150).
+  const timer: NodeJS.Timeout | undefined =
+    timeoutMin > 0
+      ? setTimeout(() => {
+          console.error(`\nTimeout: ${timeoutMin} minutes exceeded. Killing agent.`);
+          child.kill();
+        }, timeoutMin * 60 * 1000)
+      : undefined;
 
   const onSignal = deps.onSignal ?? ((s, cb) => { process.on(s, cb); });
   onSignal("SIGINT", () => child.kill("SIGINT"));
@@ -89,9 +94,12 @@ export function launchSolo(args: string[], cwd: string, timeoutMin: number, deps
     clearTimeout(timer);
     fail(err.message); // ex. ENOENT : claude absent du PATH
   });
-  child.on("exit", (code) => {
+  child.on("exit", (code, signal) => {
     clearTimeout(timer);
-    deps.exit(code ?? 0);
+    // Un enfant TUÉ (timeout, SIGINT/SIGTERM) émet code=null + un signal : ne
+    // JAMAIS le rapporter comme 0 (faux vert — l'anti-but même de J1). 124 =
+    // convention « timed out / killed ».
+    deps.exit(signal ? 124 : (code ?? 0));
   });
 }
 
@@ -164,17 +172,25 @@ export function createSoloCommand(): Command {
           read_only,
         );
 
+        // Valider le timeout AVANT de lancer : un NaN/négatif poserait un timer
+        // qui tue l'agent au spawn (#150). 0 = pas de limite.
+        const timeoutMin = parseInt(opts.timeout, 10);
+        if (Number.isNaN(timeoutMin) || timeoutMin < 0) {
+          console.error(`Error: --timeout doit être un entier ≥ 0 (0 = pas de limite), reçu « ${opts.timeout} »`);
+          process.exit(1);
+        }
+
         // Diagnostics sur STDERR : stdout est réservé à la sortie de l'agent, donc
         // « 0 octet de prompt sur stdout » quand claude est absent (#150). On
         // n'imprime que la LONGUEUR du prompt, jamais son contenu.
         console.error(`\nSolo mode: ${template}`);
         console.error(`  Project:  ${projectPath}`);
-        console.error(`  Timeout:  ${opts.timeout} minutes`);
+        console.error(`  Timeout:  ${timeoutMin === 0 ? "aucune limite" : `${timeoutMin} minutes`}`);
         console.error(`  Prompt:   ${prompt.length} chars`);
         console.error(`  Tools:    ${args[args.indexOf("--allowedTools") + 1]}`);
         console.error(`\nLaunching Claude Code...\n`);
 
-        launchSolo(args, projectPath, parseInt(opts.timeout, 10), {
+        launchSolo(args, projectPath, timeoutMin, {
           spawn,
           resolveClaudeBin, // honore CLAUDE_BIN
           exit: (code) => process.exit(code),

--- a/tests/unit/solo.test.ts
+++ b/tests/unit/solo.test.ts
@@ -100,11 +100,47 @@ describe('launchSolo — échec propre quand claude est absent (#150)', () => {
     h.restore();
   });
 
-  it("propage le code de sortie de l'agent", () => {
+  it("propage le code de sortie de l'agent (sortie propre)", () => {
     const h = harness();
     launchSolo(['-p', 'x'], '/tmp', 15, h.deps);
     h.child.emit('exit', 3);
     expect(h.exits).toEqual([3]);
+    h.restore();
+  });
+
+  it("enfant tué par signal (SIGINT/SIGTERM) → exit 124, JAMAIS 0 (pas de faux vert)", () => {
+    const h = harness();
+    launchSolo(['-p', 'x'], '/tmp', 15, h.deps);
+    h.child.emit('exit', null, 'SIGINT'); // code=null + signal : tué, pas fini
+    expect(h.exits).toEqual([124]);
+    h.restore();
+  });
+
+  it("timeout : tue l'agent puis exit 124 (l'anti-but même de J1)", () => {
+    vi.useFakeTimers();
+    const h = harness();
+    let killed = false;
+    (h.child as EventEmitter & { kill: () => void }).kill = () => { killed = true; };
+    launchSolo(['-p', 'x'], '/tmp', 1, h.deps); // 1 minute
+    vi.advanceTimersByTime(60_000);
+    expect(killed).toBe(true);
+    h.child.emit('exit', null, 'SIGTERM');
+    expect(h.exits).toEqual([124]);
+    vi.useRealTimers();
+    h.restore();
+  });
+
+  it("timeoutMin=0 → aucun timer, l'agent n'est pas tué au spawn (#150)", () => {
+    vi.useFakeTimers();
+    const h = harness();
+    let killed = false;
+    (h.child as EventEmitter & { kill: () => void }).kill = () => { killed = true; };
+    launchSolo(['-p', 'x'], '/tmp', 0, h.deps);
+    vi.advanceTimersByTime(3_600_000); // une heure : rien ne doit tuer
+    expect(killed).toBe(false);
+    h.child.emit('exit', 0);
+    expect(h.exits).toEqual([0]);
+    vi.useRealTimers();
     h.restore();
   });
 });

--- a/tests/unit/solo.test.ts
+++ b/tests/unit/solo.test.ts
@@ -1,6 +1,7 @@
 // tests/unit/solo.test.ts
-import { describe, it, expect } from 'vitest';
-import { buildSoloArgs } from '../../cli/solo.js';
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { buildSoloArgs, launchSolo, type SoloLaunchDeps } from '../../cli/solo.js';
 import { buildSolo } from '../../src/bridge.js';
 
 const CONTEXT = { language: 'typescript', test_command: 'npm test', modules: ['core'] };
@@ -45,6 +46,66 @@ describe('solo — allowlist d\'outils en headless (#34)', () => {
     const args = buildSoloArgs('mon-prompt', [], null);
     expect(args[0]).toBe('-p');
     expect(args[1]).toBe('mon-prompt');
+  });
+});
+
+// #150 — claude absent ⇒ une ligne d'erreur, 0 octet de prompt sur stdout.
+describe('launchSolo — échec propre quand claude est absent (#150)', () => {
+  function harness(over: Partial<SoloLaunchDeps> = {}) {
+    const child = new EventEmitter() as EventEmitter & { kill: () => void };
+    child.kill = () => {};
+    const errs: string[] = [];
+    const exits: number[] = [];
+    let spawnedBin = '';
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((m?: unknown) => { errs.push(String(m)); });
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const deps: SoloLaunchDeps = {
+      spawn: (bin: string) => { spawnedBin = bin; return child as never; },
+      resolveClaudeBin: () => 'claude',
+      exit: (c: number) => { exits.push(c); },
+      onSignal: () => {}, // ne pollue pas process en test
+      ...over,
+    };
+    return { child, errs, exits, get spawnedBin() { return spawnedBin; }, deps, restore: () => { errSpy.mockRestore(); outSpy.mockRestore(); }, outSpy };
+  }
+
+  it("child 'error' (ENOENT) → une ligne actionnable sur stderr, exit 1, 0 octet sur stdout", () => {
+    const h = harness();
+    launchSolo(['-p', 'PROMPT_SECRET'], '/tmp', 15, h.deps);
+    h.child.emit('error', Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }));
+    expect(h.exits).toEqual([1]);
+    expect(h.errs.some((e) => /CLAUDE_BIN|Installez Claude Code/.test(e))).toBe(true);
+    expect(h.errs.some((e) => e.includes('PROMPT_SECRET'))).toBe(false); // jamais le prompt
+    expect(h.outSpy).not.toHaveBeenCalled(); // 0 octet sur stdout
+    h.restore();
+  });
+
+  it('spawn qui throw (EINVAL synchrone) → même échec propre, exit 1, pas de stdout', () => {
+    const h = harness({
+      spawn: () => { throw Object.assign(new Error('spawn EINVAL'), { code: 'EINVAL' }); },
+    });
+    launchSolo(['-p', 'x'], '/tmp', 15, h.deps);
+    expect(h.exits).toEqual([1]);
+    expect(h.errs.some((e) => /Installez Claude Code/.test(e))).toBe(true);
+    expect(h.outSpy).not.toHaveBeenCalled();
+    h.restore();
+  });
+
+  it('honore le binaire de resolveClaudeBin (CLAUDE_BIN)', () => {
+    const h = harness({ resolveClaudeBin: () => '/custom/claude.exe' });
+    launchSolo(['-p', 'x'], '/tmp', 15, h.deps);
+    expect(h.spawnedBin).toBe('/custom/claude.exe');
+    h.child.emit('exit', 0);
+    expect(h.exits).toEqual([0]);
+    h.restore();
+  });
+
+  it("propage le code de sortie de l'agent", () => {
+    const h = harness();
+    launchSolo(['-p', 'x'], '/tmp', 15, h.deps);
+    h.child.emit('exit', 3);
+    expect(h.exits).toEqual([3]);
+    h.restore();
   });
 });
 


### PR DESCRIPTION
Ferme #150 (chantier #5, BLOQUANT, jalon J1). **Empilée sur #180 (#149)** — `essaim solo` a besoin de sa résolution `.cmd→.exe` pour lancer claude sur Windows ; GitHub retargettera cette PR sur `main` quand #180 sera fusionnée. Le diff propre (hors #149) ne touche que `cli/solo.ts` + `tests/unit/solo.test.ts`.

`essaim solo` codait `spawn("claude")` en dur, sans `child.on("error")` (claude absent → stack trace + crash), ignorait `CLAUDE_BIN`, et dumpait ses diagnostics sur stdout.

## Corrigé
- **Binaire via `resolveClaudeBin()`** (honore `CLAUDE_BIN` + la résolution win32 de #149). Un vrai `claude.cmd` npm est désormais lancé via son `.exe`, plus rejeté en EINVAL.
- **`launchSolo()`** extrait du `.action` (testable) : `spawn` dans un try/catch (EINVAL synchrone) **et** `child.on("error")` (ENOENT async) → **une** ligne d'erreur actionnable sur stderr + `exit 1`, jamais un stack trace.
- **Diagnostics → stderr** : stdout reste réservé à la sortie de l'agent → **0 octet** quand claude est absent. On imprime la longueur du prompt, jamais son contenu.

## Corrigé après revue adverse (5 findings)
- **[HIGH]** un enfant **tué** (timeout ou SIGINT/SIGTERM) émettait `code=null` → `code ?? 0` = **exit 0** : un run avorté passait pour un succès — l'anti-but même de J1. Fix : `signal ? 124 : (code ?? 0)`.
- **[HIGH]** vrai `claude.cmd` Windows rejeté (EINVAL) → fermé par la résolution `.cmd→.exe` de #149 (le fix `shell:true` suggéré par la revue est écarté : il corromprait le prompt-arg, cf. #149).
- **[MEDIUM]** `-t 0`/`-t abc`/négatif posaient un timer à 0/NaN qui tuait l'agent au spawn → validé (`0` = pas de limite ; NaN/négatif → erreur + exit 1).

## Acceptation & tests
Critère #150 (« claude absent ⇒ une ligne d'erreur, 0 octet de prompt sur stdout ») prouvé bout-en-bout : `essaim solo gardien` avec `CLAUDE_BIN` bidon → **stdout = 0 octet**, stderr = diagnostics + 1 ligne d'erreur, exit 1. 7 tests sur `launchSolo` (error async, throw synchrone, `CLAUDE_BIN` honoré, code propagé, signal→124, timeout→124, `timeoutMin=0`→pas de timer). 845 pass / 1 skip, build vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
