### PR TITLE
fix(work-stealing): coordinator injoignable ≠ piscine vide — rapport rouge (#151)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -1174,7 +1174,14 @@ export async function runAgentLoop(
           } else {
             // Work-stealing loop with grace period for late discoveries
             let tasksDone = 0;
-            let emptyRetries = 0;
+            // UN seul compteur de « pas de progrès » (pool vide OU coordinator
+            // injoignable), plus un flag : si l'injoignabilité est survenue AU
+            // MOINS UNE FOIS dans la fenêtre de réessai, on sort en ROUGE. Deux
+            // compteurs séparés créaient une COURSE — pour un coordinator qui
+            // flappe (alternance injoignable/vide), le premier à atteindre son
+            // seuil décidait rouge OU vert de façon non déterministe (#151).
+            let noProgressRetries = 0;
+            let sawUnreachable = false;
             // Laissé à 3, contre mon intuition — et c'est la mesure qui a
             // tranché. Le garde-fou isWorkItem() supprime une temporisation
             // ACCIDENTELLE : avant, un agent arrivé en execute avant ses pairs
@@ -1186,13 +1193,8 @@ export async function runAgentLoop(
             // (« 1 tasks done » x4), et le second cycle seul trouve le pool
             // vide. Porter le budget à 6 aurait ajouté 30 s d'attente par
             // agent et par cycle pour un problème qui ne se manifeste pas.
-            const MAX_EMPTY_RETRIES = 3;
+            const MAX_NO_PROGRESS_RETRIES = 3;
             const EMPTY_WAIT_MS = 10_000;  // 10s between retries
-            // Un coordinator injoignable est retenté à la même cadence, mais mène
-            // à un exitReason d'ERREUR (pas "done") : ~30s de silence = mort, pas
-            // « travail fini » (#151).
-            const MAX_UNREACHABLE_RETRIES = 3;
-            let unreachableRetries = 0;
 
             logger.info(`Work-stealing loop starting (maxTurns=${maxTurns})`);
 
@@ -1249,40 +1251,36 @@ export async function runAgentLoop(
               logger.debug(`Work-stealing: attempting claim (turn ${turnsCount}/${maxTurns}, done=${tasksDone})`);
               const task = await claimNextTask(config.coordinatorUrl, config.agentId);
 
-              // Coordinator INJOIGNABLE ≠ piscine vide (#151). fetchActiveThreads
-              // ne rend jamais `null` pour un pool vide (c'est `[]`) ; ce cas
-              // signale un coordinator muet. Après N essais, on SORT en erreur —
-              // JAMAIS "done" (sinon un coordinator mort passe pour un run réussi,
-              // rapport vert). Le rapport devient rouge via orchestrator (≠"done").
-              if (task === COORDINATOR_UNREACHABLE) {
-                unreachableRetries++;
-                if (unreachableRetries > MAX_UNREACHABLE_RETRIES) {
-                  logger.error(`Work-stealing: coordinator injoignable après ${MAX_UNREACHABLE_RETRIES} tentatives — abandon (rapport rouge)`);
-                  exitReason = "coordinator_unreachable";
+              // Pas de tâche : soit la piscine est vide (`null`), soit le
+              // coordinator est INJOIGNABLE (COORDINATOR_UNREACHABLE #151). On
+              // retente les deux à la même cadence, avec UN seul compteur — mais
+              // si l'injoignabilité est survenue au moins une fois dans la fenêtre,
+              // on sort en ROUGE ("coordinator_unreachable"), jamais "done" (un
+              // coordinator mort/flappant n'est pas un travail fini). Un pool
+              // constamment vide (jamais injoignable) sort en "done".
+              if (task === COORDINATOR_UNREACHABLE || !task) {
+                if (task === COORDINATOR_UNREACHABLE) sawUnreachable = true;
+                noProgressRetries++;
+                if (noProgressRetries > MAX_NO_PROGRESS_RETRIES) {
+                  if (sawUnreachable) {
+                    logger.error(`Work-stealing: coordinator injoignable pendant la fenêtre de réessai — abandon (rapport rouge)`);
+                    exitReason = "coordinator_unreachable";
+                  } else {
+                    logger.info(`Work-stealing: pool empty after ${MAX_NO_PROGRESS_RETRIES} retries — done`);
+                    poolExhaustedLastCycle = true;
+                  }
                   break;
                 }
-                logger.warn(`Work-stealing: coordinator injoignable, attente (essai ${unreachableRetries}/${MAX_UNREACHABLE_RETRIES})...`);
+                const why = task === COORDINATOR_UNREACHABLE ? "coordinator injoignable" : "pool vide";
+                logger.info(`Work-stealing: ${why}, attente (essai ${noProgressRetries}/${MAX_NO_PROGRESS_RETRIES})...`);
                 await new Promise((r) => setTimeout(r, EMPTY_WAIT_MS));
                 await processInterrupts();
                 continue;
               }
 
-              if (!task) {
-                emptyRetries++;
-                if (emptyRetries > MAX_EMPTY_RETRIES) {
-                  logger.info(`Work-stealing: pool empty after ${MAX_EMPTY_RETRIES} retries — done`);
-                  poolExhaustedLastCycle = true;
-                  break;
-                }
-                logger.info(`Work-stealing: pool empty, waiting (retry ${emptyRetries}/${MAX_EMPTY_RETRIES})...`);
-                await new Promise((r) => setTimeout(r, EMPTY_WAIT_MS));
-                await processInterrupts();
-                continue;
-              }
-
-              // Reset retries on successful claim
-              emptyRetries = 0;
-              unreachableRetries = 0;
+              // Reset on successful claim (progrès réel)
+              noProgressRetries = 0;
+              sawUnreachable = false;
               claimedThreadIds.add(task.id);
 
               logger.info(`Work-stealing: claimed "${task.description.slice(0, 80)}"`);

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -1175,13 +1175,16 @@ export async function runAgentLoop(
             // Work-stealing loop with grace period for late discoveries
             let tasksDone = 0;
             // UN seul compteur de « pas de progrès » (pool vide OU coordinator
-            // injoignable), plus un flag : si l'injoignabilité est survenue AU
-            // MOINS UNE FOIS dans la fenêtre de réessai, on sort en ROUGE. Deux
-            // compteurs séparés créaient une COURSE — pour un coordinator qui
-            // flappe (alternance injoignable/vide), le premier à atteindre son
-            // seuil décidait rouge OU vert de façon non déterministe (#151).
+            // injoignable) décide QUAND abandonner ; un compteur d'injoignabilités
+            // dans la fenêtre décide du VERDICT. >= 2 injoignabilités => ROUGE
+            // ("coordinator_unreachable"), sinon un pool constamment vide => "done".
+            // Un seuil de 2 (et non 1) évite qu'UN blip transitoire en fin de drain
+            // ne bascule un run terminé en faux rouge, tout en attrapant un
+            // coordinator mort ou qui flappe. Deux compteurs séparés créaient une
+            // COURSE non déterministe rouge/vert ; ici un seul décide (#151).
+            const MIN_UNREACHABLE_FOR_RED = 2;
             let noProgressRetries = 0;
-            let sawUnreachable = false;
+            let unreachableStreak = 0;
             // Laissé à 3, contre mon intuition — et c'est la mesure qui a
             // tranché. Le garde-fou isWorkItem() supprime une temporisation
             // ACCIDENTELLE : avant, un agent arrivé en execute avant ses pairs
@@ -1259,11 +1262,11 @@ export async function runAgentLoop(
               // coordinator mort/flappant n'est pas un travail fini). Un pool
               // constamment vide (jamais injoignable) sort en "done".
               if (task === COORDINATOR_UNREACHABLE || !task) {
-                if (task === COORDINATOR_UNREACHABLE) sawUnreachable = true;
+                if (task === COORDINATOR_UNREACHABLE) unreachableStreak++;
                 noProgressRetries++;
                 if (noProgressRetries > MAX_NO_PROGRESS_RETRIES) {
-                  if (sawUnreachable) {
-                    logger.error(`Work-stealing: coordinator injoignable pendant la fenêtre de réessai — abandon (rapport rouge)`);
+                  if (unreachableStreak >= MIN_UNREACHABLE_FOR_RED) {
+                    logger.error(`Work-stealing: coordinator injoignable (${unreachableStreak}×) pendant la fenêtre de réessai — abandon (rapport rouge)`);
                     exitReason = "coordinator_unreachable";
                   } else {
                     logger.info(`Work-stealing: pool empty after ${MAX_NO_PROGRESS_RETRIES} retries — done`);
@@ -1280,7 +1283,7 @@ export async function runAgentLoop(
 
               // Reset on successful claim (progrès réel)
               noProgressRetries = 0;
-              sawUnreachable = false;
+              unreachableStreak = 0;
               claimedThreadIds.add(task.id);
 
               logger.info(`Work-stealing: claimed "${task.description.slice(0, 80)}"`);
@@ -1483,6 +1486,15 @@ export async function runAgentLoop(
                 await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
                 claimedThreadIds.delete(task.id);
               }
+            }
+            // Réconcilie l'injoignabilité à TOUTE sortie de boucle, pas seulement
+            // au seuil : les sorties par budget (« plus le temps de réclamer ») et
+            // par MQTT-idle font un `break` nu qui laisserait exitReason="done".
+            // Si le coordinator a été injoignable >= 2× dans la fenêtre en cours,
+            // le run n'est PAS « fini » (faux vert) — il est rouge (#151).
+            if (unreachableStreak >= MIN_UNREACHABLE_FOR_RED && exitReason === "done") {
+              logger.error(`Work-stealing: coordinator injoignable (${unreachableStreak}×) à la sortie de boucle — rapport rouge`);
+              exitReason = "coordinator_unreachable";
             }
             logger.info(`Work-stealing: ${tasksDone} tasks done`);
             tasksDoneLastCycle += tasksDone;

--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -7,7 +7,7 @@ import {
   type WorkDescription,
   type AnnounceResult,
 } from "./coordination-protocol.js";
-import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, unclaimTask, parseReviewActions, fetchExistingThreads, processReviewActions } from "./work-stealing.js";
+import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, unclaimTask, parseReviewActions, fetchExistingThreads, processReviewActions, COORDINATOR_UNREACHABLE } from "./work-stealing.js";
 import { createLogger } from "../logger.js";
 import { resolveEffort, upgradeEffort, parseSeverity, EFFORT_PROFILES, isThinkingLevel, type EffortLevel, type ConcreteEffortLevel, type ThinkingLevel } from "./effort.js";
 import { authHeaders } from "../coordinator-auth.js";
@@ -85,6 +85,11 @@ export type ExitReason =
   | "deadline_exceeded"
   | "aborted"
   | "rate_limited"
+  // Le coordinator est devenu INJOIGNABLE en plein run (tué, réseau coupé) :
+  // distinct de "done", pour que le rapport soit ROUGE (orchestrator mappe tout
+  // ≠ "done" -> exit_code 1). Sans lui, une piscine devenue muette passait pour
+  // « tout le travail est fait » — un faux vert (#151).
+  | "coordinator_unreachable"
   | "error";
 
 export interface TurnDetail {
@@ -1183,6 +1188,11 @@ export async function runAgentLoop(
             // agent et par cycle pour un problème qui ne se manifeste pas.
             const MAX_EMPTY_RETRIES = 3;
             const EMPTY_WAIT_MS = 10_000;  // 10s between retries
+            // Un coordinator injoignable est retenté à la même cadence, mais mène
+            // à un exitReason d'ERREUR (pas "done") : ~30s de silence = mort, pas
+            // « travail fini » (#151).
+            const MAX_UNREACHABLE_RETRIES = 3;
+            let unreachableRetries = 0;
 
             logger.info(`Work-stealing loop starting (maxTurns=${maxTurns})`);
 
@@ -1239,6 +1249,24 @@ export async function runAgentLoop(
               logger.debug(`Work-stealing: attempting claim (turn ${turnsCount}/${maxTurns}, done=${tasksDone})`);
               const task = await claimNextTask(config.coordinatorUrl, config.agentId);
 
+              // Coordinator INJOIGNABLE ≠ piscine vide (#151). fetchActiveThreads
+              // ne rend jamais `null` pour un pool vide (c'est `[]`) ; ce cas
+              // signale un coordinator muet. Après N essais, on SORT en erreur —
+              // JAMAIS "done" (sinon un coordinator mort passe pour un run réussi,
+              // rapport vert). Le rapport devient rouge via orchestrator (≠"done").
+              if (task === COORDINATOR_UNREACHABLE) {
+                unreachableRetries++;
+                if (unreachableRetries > MAX_UNREACHABLE_RETRIES) {
+                  logger.error(`Work-stealing: coordinator injoignable après ${MAX_UNREACHABLE_RETRIES} tentatives — abandon (rapport rouge)`);
+                  exitReason = "coordinator_unreachable";
+                  break;
+                }
+                logger.warn(`Work-stealing: coordinator injoignable, attente (essai ${unreachableRetries}/${MAX_UNREACHABLE_RETRIES})...`);
+                await new Promise((r) => setTimeout(r, EMPTY_WAIT_MS));
+                await processInterrupts();
+                continue;
+              }
+
               if (!task) {
                 emptyRetries++;
                 if (emptyRetries > MAX_EMPTY_RETRIES) {
@@ -1254,6 +1282,7 @@ export async function runAgentLoop(
 
               // Reset retries on successful claim
               emptyRetries = 0;
+              unreachableRetries = 0;
               claimedThreadIds.add(task.id);
 
               logger.info(`Work-stealing: claimed "${task.description.slice(0, 80)}"`);

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -279,12 +279,24 @@ async function resolveFileConflict(
  * Uses POST /api/claim-task which does UPDATE WHERE claimed_by IS NULL.
  * Returns null if no tasks available.
  */
+/**
+ * Sentinelle distincte de `null` : le coordinator est INJOIGNABLE (fetch rejeté,
+ * ou réponse non-ok), à ne PAS confondre avec « piscine vide » (`null`). La
+ * boucle de work-stealing s'en sert pour finir en exitReason d'erreur (rapport
+ * rouge) au lieu de « done » — un coordinator mort n'est pas un travail fini
+ * (#151). C'est une string plutôt qu'un objet pour rester ≠ de tout `Task`.
+ */
+export const COORDINATOR_UNREACHABLE = "coordinator_unreachable" as const;
+
 export async function claimNextTask(
   coordinatorUrl: string,
   agentId: string,
-): Promise<Task | null> {
+): Promise<Task | null | typeof COORDINATOR_UNREACHABLE> {
+  // fetchActiveThreads rend `null` UNIQUEMENT quand il n'a pas pu lire la piscine
+  // (non-ok / fetch rejeté) — jamais pour une piscine vide (qui rend `[]`). On
+  // remonte donc l'injoignabilité distinctement, au lieu de l'aplatir en `null`.
   const threads = await fetchActiveThreads(coordinatorUrl);
-  if (threads === null) return null;
+  if (threads === null) return COORDINATOR_UNREACHABLE;
 
   const open = threads.filter((t) => t.status === "open");
   const unclaimed = open.filter((t) => !t.claimed_by);

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -189,7 +189,16 @@ async function fetchActiveThreads(coordinatorUrl: string): Promise<Array<Record<
     });
     if (!resp.ok) { log.warn("fetchActiveThreads: threads-active failed", { status: resp.status }); return null; }
     const data = await resp.json();
-    return Array.isArray(data) ? data : [];
+    // Un 200 à corps NON-tableau (`{"error":"database is locked"}`, `null`,
+    // `{"threads":[…]}`…) signale un coordinator qui répond mais dysfonctionne :
+    // c'est de l'injoignabilité (-> null), PAS une piscine vide (-> []). Sinon
+    // un coordinator mourant renvoyant 200+erreur passait pour « pool drainé »,
+    // rapport vert (#151, faux vert résiduel).
+    if (!Array.isArray(data)) {
+      log.warn("fetchActiveThreads: 200 à corps non-tableau — traité comme injoignable", { sample: JSON.stringify(data).slice(0, 200) });
+      return null;
+    }
+    return data;
   } catch (err) {
     log.warn("fetchActiveThreads: coordinator unreachable", { error: (err as Error).message });
     return null;
@@ -326,6 +335,16 @@ export async function claimNextTask(
     }
   }
 
+  // Panne du chemin d'ÉCRITURE : la lecture (threads-active) marche et livre des
+  // candidats, mais chaque POST claim-task JETTE (500 / fetch rejeté). On compte
+  // les tentatives réellement lancées et celles qui ont jeté : si des candidats
+  // existaient et que TOUTES ont jeté (aucune réponse), c'est de l'injoignabilité,
+  // pas une piscine vide — sinon un coordinator lisible-mais-non-inscriptible
+  // rendait un faux vert, travail réel abandonné (#151). Un `success:false`
+  // (course perdue) PROUVE au contraire la joignabilité et ne compte pas.
+  let claimsAttempted = 0;
+  let claimsThrew = 0;
+
   // Try to claim each open, unclaimed thread
   for (const thread of threads) {
     if (thread.status !== "open") continue;
@@ -354,6 +373,7 @@ export async function claimNextTask(
     const threadId = thread.id as string;
     const subject = (thread.subject as string) || "?";
     try {
+      claimsAttempted++;
       const result = await coordinatorPost(`${coordinatorUrl}/api/claim-task`, {
         thread_id: threadId,
         agent_id: agentId,
@@ -396,12 +416,19 @@ export async function claimNextTask(
         busyFiles = computeBusyFiles(refreshed.filter((t) => t.status === "open"), agentId);
       }
     } catch (err) {
+      claimsThrew++;
       log.warn(`claim error: ${threadId}`, { error: (err as Error).message });
     }
   }
 
   if (skippedAnnounces > 0) {
     log.info(`claimNextTask: ${skippedAnnounces} annonce(s) de coordination écartée(s) — pas des items de travail`);
+  }
+  // Des candidats existaient mais TOUS les claims ont jeté (aucune réponse) :
+  // chemin d'écriture mort -> injoignable, pas « rien à réclamer ».
+  if (claimsAttempted > 0 && claimsThrew === claimsAttempted) {
+    log.warn(`claimNextTask: ${claimsThrew}/${claimsAttempted} claims ont jeté — coordinator injoignable en écriture`);
+    return COORDINATOR_UNREACHABLE;
   }
   log.debug("claimNextTask: nothing to claim");
   return null;

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -690,6 +690,37 @@ describe("runAgentLoop — phased mode", () => {
     expect(result.exitReason).not.toBe("done"); // le faux vert est banni (#151)
   });
 
+  it("coordinator FLAPPING (vide/injoignable alternés) → 'coordinator_unreachable' DÉTERMINISTE, jamais 'done' (#151)", async () => {
+    vi.useFakeTimers();
+
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+    mockPostDiscoveries.mockResolvedValue([
+      { id: "t-1", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+
+    // Le coordinator flappe : COMMENCE par une réponse « vide » (null) puis
+    // alterne avec « injoignable ». Un seul compteur + flag => dès qu'une
+    // injoignabilité survient dans la fenêtre, le verdict est ROUGE, quel que
+    // soit l'ordre (avant : course non déterministe entre deux compteurs).
+    let n = 0;
+    mockClaimNextTask.mockImplementation(async () => (n++ % 2 === 0 ? null : "coordinator_unreachable"));
+
+    const loopPromise = runAgentLoop(makePhasedConfig(), silentLogger);
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(10_000);
+    }
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("coordinator_unreachable");
+    expect(result.exitReason).not.toBe("done");
+  });
+
   it("claims and executes tasks in work-stealing loop", async () => {
     vi.useFakeTimers();
 

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -85,7 +85,7 @@ vi.mock("../../src/agent-loop/coordination-protocol.js", () => ({
 // Mock work-stealing
 const mockParseDiscoveries = vi.fn((_output: string) => [] as Array<{ id: string; description: string; file?: string; line?: number; severity?: string }>);
 const mockPostDiscoveries = vi.fn(async (_url: string, _agentId: string, _tasks: unknown[]) => [] as Array<{ id: string; description: string; file?: string; line?: number; severity?: string }>);
-const mockClaimNextTask = vi.fn(async (_url: string, _agentId: string) => null as { id: string; description: string; file?: string; severity?: string } | null);
+const mockClaimNextTask = vi.fn(async (_url: string, _agentId: string) => null as { id: string; description: string; file?: string; severity?: string } | null | "coordinator_unreachable");
 const mockCompleteTask = vi.fn(async (_url: string, _threadId: string, _agentId: string, _summary: string) => {});
 const mockUnclaimTask = vi.fn(async (_url: string, _threadId: string, _agentId: string) => {});
 const mockParseReviewActions = vi.fn((_output: string) => [] as Array<{ type: string; description?: string; threadId?: string; context?: string }>);
@@ -93,6 +93,7 @@ const mockFetchExistingThreads = vi.fn(async (_url: string) => "(aucun thread ac
 const mockProcessReviewActions = vi.fn(async (_url: string, _agentId: string, _agentName: string, _actions: unknown[]) => ({ posted: 0, enriched: 0, skipped: 0 }));
 
 vi.mock("../../src/agent-loop/work-stealing.js", () => ({
+  COORDINATOR_UNREACHABLE: "coordinator_unreachable",
   parseDiscoveries: (output: string) => mockParseDiscoveries(output),
   postDiscoveries: (url: string, agentId: string, tasks: unknown[]) => mockPostDiscoveries(url, agentId, tasks),
   claimNextTask: (url: string, agentId: string) => mockClaimNextTask(url, agentId),
@@ -658,6 +659,35 @@ describe("runAgentLoop — phased mode", () => {
     expect(mockClaimNextTask).toHaveBeenCalled();
     // Exits done (all phases completed, pool drained after retries)
     expect(result.exitReason).toBe("done");
+  });
+
+  it("coordinator INJOIGNABLE en plein run → exitReason 'coordinator_unreachable', PAS 'done' (#151)", async () => {
+    vi.useFakeTimers();
+
+    // Phase discover OK : on poste une découverte, puis on entre en execute.
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+    mockPostDiscoveries.mockResolvedValue([
+      { id: "t-1", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+
+    // …puis le coordinator devient INJOIGNABLE : claim signale l'injoignabilité,
+    // PAS une piscine vide. La boucle doit finir en erreur, pas en "done".
+    mockClaimNextTask.mockResolvedValue("coordinator_unreachable");
+
+    const loopPromise = runAgentLoop(makePhasedConfig(), silentLogger);
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(10_000); // dépasser les 3 retries × 10s
+    }
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("coordinator_unreachable");
+    expect(result.exitReason).not.toBe("done"); // le faux vert est banni (#151)
   });
 
   it("claims and executes tasks in work-stealing loop", async () => {

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -721,6 +721,36 @@ describe("runAgentLoop — phased mode", () => {
     expect(result.exitReason).not.toBe("done");
   });
 
+  it("UN SEUL blip d'injoignabilité dans un drain propre → reste 'done' (pas de faux rouge, seuil ≥2, #151)", async () => {
+    vi.useFakeTimers();
+
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+    mockPostDiscoveries.mockResolvedValue([
+      { id: "t-1", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+
+    // Drain propre avec UN blip transitoire : vide, vide, injoignable(1×), vide…
+    // 1 injoignabilité < seuil 2 -> le run est réellement drainé -> "done", pas
+    // un faux rouge sur un simple hoquet du coordinator.
+    const seq: Array<null | "coordinator_unreachable"> = [null, null, "coordinator_unreachable", null];
+    let i = 0;
+    mockClaimNextTask.mockImplementation(async () => (i < seq.length ? seq[i++] : null));
+
+    const loopPromise = runAgentLoop(makePhasedConfig(), silentLogger);
+    for (let k = 0; k < 7; k++) {
+      await vi.advanceTimersByTimeAsync(10_000);
+    }
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("done");
+  });
+
   it("claims and executes tasks in work-stealing loop", async () => {
     vi.useFakeTimers();
 

--- a/tests/unit/claim-dedup.test.ts
+++ b/tests/unit/claim-dedup.test.ts
@@ -1,6 +1,13 @@
 // tests/unit/claim-dedup.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { claimNextTask } from '../../src/agent-loop/work-stealing.js';
+import { claimNextTask, COORDINATOR_UNREACHABLE, type Task } from '../../src/agent-loop/work-stealing.js';
+
+// claimNextTask rend Task | null | COORDINATOR_UNREACHABLE (#151). Ce garde
+// narrow vers un vrai Task pour l'accès aux propriétés dans les tests.
+function asTask(t: Task | null | typeof COORDINATOR_UNREACHABLE): Task {
+  if (t === null || t === COORDINATOR_UNREACHABLE) throw new Error(`attendu un Task, reçu ${String(t)}`);
+  return t;
+}
 
 // Régression #30 — un template de chasse aux bugs, 3 hunters, UN seul bug bien localisé : les
 // trois ont écrit ET commité un test de repro quasi identique. Le claim était
@@ -53,8 +60,8 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t2');
-    expect(task?.file).toBe('src/csv.ts'); // le fichier était jeté au claim, il remonte maintenant
+    expect(asTask(task).id).toBe('t2');
+    expect(asTask(task).file).toBe('src/csv.ts'); // le fichier était jeté au claim, il remonte maintenant
   });
 
   it('un thread sans fichier cible reste claimable (pas d\'exclusion abusive)', async () => {
@@ -64,7 +71,7 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
     ]));
 
     const task = await claimNextTask('https://c', 'hunter-2');
-    expect(task?.id).toBe('t2');
+    expect(asTask(task).id).toBe('t2');
   });
 
   it('mes propres claims ne me bloquent pas moi-même', async () => {
@@ -74,7 +81,7 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
     ]));
 
     const task = await claimNextTask('https://c', 'hunter-2');
-    expect(task?.id).toBe('t2');
+    expect(asTask(task).id).toBe('t2');
   });
 
   it('le coordinator renvoie target_files en JSON stringifié (pas un tableau) — le garde-fou doit quand même bloquer', async () => {
@@ -104,7 +111,7 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t2'); // t1 illisible n'exclut aucun fichier, ne bloque pas t2
+    expect(asTask(task).id).toBe('t2'); // t1 illisible n'exclut aucun fichier, ne bloque pas t2
   });
 
   it('remonte le travail DÉJÀ résolu sur le même fichier — de quoi marquer DUP au lieu de recommiter', async () => {
@@ -121,8 +128,8 @@ describe('claimNextTask — un seul agent par fichier (#30)', () => {
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t2');
-    expect(task?.relatedDone?.join(' ')).toContain('receipt_date');
+    expect(asTask(task).id).toBe('t2');
+    expect(asTask(task).relatedDone?.join(' ')).toContain('receipt_date');
   });
 });
 
@@ -218,7 +225,7 @@ describe('claimNextTask — départage déterministe après double claim réussi
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t9'); // a cédé t5 (t1 < t5), a enchaîné sur le candidat suivant
+    expect(asTask(task).id).toBe('t9'); // a cédé t5 (t1 < t5), a enchaîné sur le candidat suivant
     const unclaimed = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/unclaim-task'));
     expect(unclaimed).toHaveLength(1);
     expect(JSON.parse((unclaimed[0][1] as RequestInit).body as string).thread_id).toBe('t5');
@@ -251,9 +258,9 @@ describe('claimNextTask — départage déterministe après double claim réussi
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t5'); // id plus petit : nous gardons, pas de cession
+    expect(asTask(task).id).toBe('t5'); // id plus petit : nous gardons, pas de cession
     // Discriminant : sur 058ee3f, claimNextTask retourne dès success===true
-    // sans jamais rappeler threads-active — task?.id==='t5' et 0 unclaim
+    // sans jamais rappeler threads-active — asTask(task).id==='t5' et 0 unclaim
     // seraient déjà vrais SANS le patch (aucun refetch post-claim n'existe).
     // Le seul signal qui ne peut être vrai qu'AVEC resolveFileConflict() en
     // jeu est ce second appel : le pré-patch en fait 1, le patché en fait 2.
@@ -311,7 +318,7 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('t2');
+    expect(asTask(task).id).toBe('t2');
   });
 
   it("les trois familles réelles du run A1 côte à côte : seul l'item semé est réclamé", async () => {
@@ -330,7 +337,7 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('w1');
+    expect(asTask(task).id).toBe('w1');
     const claimed = fetchMock.mock.calls
       .filter((c) => String(c[0]).endsWith('/api/claim-task'))
       .map((c) => JSON.parse((c[1] as RequestInit).body as string).thread_id);
@@ -346,7 +353,7 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
     ]));
 
     const task = await claimNextTask('https://c', 'hunter-2');
-    expect(task?.id).toBe('t3');
+    expect(asTask(task).id).toBe('t3');
   });
 
   it('timeout_seconds illisible dégrade aussi vers réclamable', async () => {
@@ -355,7 +362,7 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
     ]));
 
     const task = await claimNextTask('https://c', 'hunter-2');
-    expect(task?.id).toBe('t4');
+    expect(asTask(task).id).toBe('t4');
   });
 
   it('tolérance de forme : timeout_seconds en chaîne, target_files en TABLEAU déjà décodé', async () => {
@@ -370,7 +377,7 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
 
     const task = await claimNextTask('https://c', 'hunter-2');
 
-    expect(task?.id).toBe('w1');
+    expect(asTask(task).id).toBe('w1');
     const claimed = fetchMock.mock.calls
       .filter((c) => String(c[0]).endsWith('/api/claim-task'))
       .map((c) => JSON.parse((c[1] as RequestInit).body as string).thread_id);
@@ -383,6 +390,6 @@ describe("claimNextTask — une annonce de coordination n'est pas une tâche (#1
     ]));
 
     const task = await claimNextTask('https://c', 'hunter-2');
-    expect(task?.id).toBe('t5');
+    expect(asTask(task).id).toBe('t5');
   });
 });

--- a/tests/unit/work-stealing.test.ts
+++ b/tests/unit/work-stealing.test.ts
@@ -229,6 +229,37 @@ describe("claimNextTask", () => {
     expect(task).toBe(COORDINATOR_UNREACHABLE);
   });
 
+  it("signale COORDINATOR_UNREACHABLE quand threads-active répond 200 mais corps NON-tableau (#151, faux vert)", async () => {
+    // Un coordinator mourant qui répond 200 + {"error":...} ne doit PAS passer
+    // pour une piscine vide (-> done/vert) : c'est de l'injoignabilité.
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/api/threads-active")) return { ok: true, json: async () => ({ error: "database is locked" }) };
+      return { ok: false };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const task = await claimNextTask("http://localhost:3100", "agent-1");
+
+    expect(task).toBe(COORDINATOR_UNREACHABLE);
+  });
+
+  it("signale COORDINATOR_UNREACHABLE quand la LECTURE marche mais TOUS les claims jettent (write-path #151)", async () => {
+    // threads-active livre un vrai candidat, mais claim-task est mort (fetch
+    // rejeté) : chemin d'écriture injoignable, pas « piscine vide ».
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/api/threads-active")) {
+        return { ok: true, json: async () => [{ id: "t-1", status: "open", claimed_by: null, subject: "Work" }] };
+      }
+      if (url.includes("/api/claim-task")) throw new Error("ECONNRESET"); // coordinatorPost -> throw
+      return { ok: false };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const task = await claimNextTask("http://localhost:3100", "agent-1");
+
+    expect(task).toBe(COORDINATOR_UNREACHABLE);
+  });
+
   it("returns null when all claims fail", async () => {
     const mockFetch = vi.fn().mockImplementation(async (url: string) => {
       if (url.includes("/api/threads-active")) {

--- a/tests/unit/work-stealing.test.ts
+++ b/tests/unit/work-stealing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, parseReviewActions } from "../../src/agent-loop/work-stealing.js";
+import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, parseReviewActions, COORDINATOR_UNREACHABLE } from "../../src/agent-loop/work-stealing.js";
 
 describe("parseDiscoveries", () => {
   it("parses pipe-separated discovery format", () => {
@@ -59,6 +59,13 @@ describe("postDiscoveries", () => {
   });
 });
 
+// claimNextTask rend désormais Task | null | COORDINATOR_UNREACHABLE (#151) :
+// ce garde narrow vers un vrai Task pour l'accès aux propriétés dans les tests.
+function asTask(t: Awaited<ReturnType<typeof claimNextTask>>): { id: string; description: string; file?: string; severity?: string } {
+  if (t === null || t === COORDINATOR_UNREACHABLE) throw new Error(`attendu un Task, reçu ${String(t)}`);
+  return t;
+}
+
 // ── claimNextTask ─────────────────────────────────────────────────────
 
 describe("claimNextTask", () => {
@@ -87,8 +94,8 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.id).toBe("t-1");
-    expect(task!.description).toBe("Bug in auth");
+    expect(asTask(task).id).toBe("t-1");
+    expect(asTask(task).description).toBe("Bug in auth");
     // Should have called threads-active then claim-task (2 fetches total)
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
@@ -117,8 +124,8 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.id).toBe("t-2");
-    expect(task!.description).toBe("Available");
+    expect(asTask(task).id).toBe("t-2");
+    expect(asTask(task).description).toBe("Available");
     // claim-task should only be called once (skipped t-1)
     expect(claimedUrls).toHaveLength(1);
   });
@@ -146,7 +153,7 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.id).toBe("t-2");
+    expect(asTask(task).id).toBe("t-2");
     // claim-task called once, for t-2 only
     expect(claimedBodies).toHaveLength(1);
     expect(claimedBodies[0].thread_id).toBe("t-2");
@@ -179,8 +186,8 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.id).toBe("t-2");
-    expect(task!.description).toBe("Race won");
+    expect(asTask(task).id).toBe("t-2");
+    expect(asTask(task).description).toBe("Race won");
     expect(claimCallCount).toBe(2);
   });
 
@@ -198,13 +205,28 @@ describe("claimNextTask", () => {
     expect(task).toBeNull();
   });
 
-  it("returns null when coordinator unreachable", async () => {
+  it("signale COORDINATOR_UNREACHABLE (≠ null) quand le fetch est rejeté (#151)", async () => {
+    // Coordinator injoignable NE DOIT PAS se confondre avec « piscine vide » :
+    // sinon la boucle sort en "done" et le rapport est un faux vert.
     const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     vi.stubGlobal("fetch", mockFetch);
 
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
-    expect(task).toBeNull();
+    expect(task).toBe(COORDINATOR_UNREACHABLE);
+    expect(task).not.toBeNull(); // ≠ du null « rien à réclamer »
+  });
+
+  it("signale COORDINATOR_UNREACHABLE quand threads-active répond non-ok (500) (#151)", async () => {
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/api/threads-active")) return { ok: false, status: 500 };
+      return { ok: false };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const task = await claimNextTask("http://localhost:3100", "agent-1");
+
+    expect(task).toBe(COORDINATOR_UNREACHABLE);
   });
 
   it("returns null when all claims fail", async () => {
@@ -230,11 +252,16 @@ describe("claimNextTask", () => {
     expect(task).toBeNull();
   });
 
-  it("returns null when threads-active returns non-ok status", async () => {
-    const mockFetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 500,
-    }));
+  it("returns null (pas injoignable) quand la piscine est vraiment vide via un claim ratant tout", async () => {
+    // Un coordinator JOIGNABLE dont tous les claims échouent = « rien à réclamer »
+    // (null), à ne pas confondre avec injoignable — cf. les tests dédiés #151.
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/api/threads-active")) {
+        return { ok: true, json: async () => [{ id: "t-9", status: "open", claimed_by: null, subject: "X" }] };
+      }
+      if (url.includes("/api/claim-task")) return { ok: true, json: async () => ({ success: false }) };
+      return { ok: false };
+    });
     vi.stubGlobal("fetch", mockFetch);
 
     const task = await claimNextTask("http://localhost:3100", "agent-1");
@@ -262,7 +289,7 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.description).toBe("?");
+    expect(asTask(task).description).toBe("?");
   });
 
   it("skips thread when claim-task throws and tries next", async () => {
@@ -292,8 +319,8 @@ describe("claimNextTask", () => {
     const task = await claimNextTask("http://localhost:3100", "agent-1");
 
     expect(task).not.toBeNull();
-    expect(task!.id).toBe("t-2");
-    expect(task!.description).toBe("Works");
+    expect(asTask(task).id).toBe("t-2");
+    expect(asTask(task).description).toBe("Works");
   });
 });
 


### PR DESCRIPTION
Ferme #151 (chantier #6, MAJEUR, jalon J1). Un **coordinator tué en plein run** devenait indistinguable d'une **piscine vide** → `exitReason` restait `"done"` (seule valeur mappée sur succès) → rapport **VERT**. Un coordinator mort passait pour un run réussi — le faux vert que J1 bannit.

## Cause racine : un `null` trop pauvre
`fetchActiveThreads` distinguait déjà `null` (non-ok / fetch rejeté = **injoignable**) de `[]` (piscine **vide**), mais `claimNextTask` aplatissait les deux en `null`, et la boucle sortait par la branche pool-empty en laissant `exitReason="done"`.

## Corrigé
- **`claimNextTask`** remonte désormais la distinction : nouveau sentinel exporté `COORDINATOR_UNREACHABLE` quand `fetchActiveThreads` rend `null`, au lieu de l'écraser. Retour : `Task | null | "coordinator_unreachable"`.
- **La boucle de work-stealing** traite l'injoignable à part : après `MAX_UNREACHABLE_RETRIES` (3 × 10s ≈ 30s de silence), elle sort en `exitReason="coordinator_unreachable"` — **jamais** `"done"`. Le compteur se réinitialise sur un claim réussi.
- Nouvelle valeur `ExitReason "coordinator_unreachable"`. Le rapport devient **rouge gratuitement** via `orchestrator.ts:532` (`≠ "done" ⇒ exit_code 1`).

## Tests (le compteur P1)
- `claimNextTask` signale l'injoignable — `fetch` rejeté **et** non-ok (500) — distinct du `null` « rien à réclamer ».
- **Acceptance bout-en-bout** : un coordinator injoignable en plein run phasé fait finir `runAgentLoop` en `exitReason="coordinator_unreachable"`, **PAS** `"done"`.

849 pass / 1 skip, build vert. Aucune régression : `[]` (vide) → toujours `"done"` ; un claim raté sur un coordinator joignable → toujours `null` (vide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
