### PR TITLE
fix(reporter): colonne Compilation tri-état par code de sortie de tsc (#152)

### DIFF
--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -45,8 +45,14 @@ export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
         : safeExec("git diff HEAD", wsPath);
 
     const compilationOk = workspace.type !== "none"
-      ? !safeExec("npx tsc --noEmit 2>&1", wsPath).includes("error")
+      ? tscCompilationStatus(wsPath)
       : undefined;
+    // tsc n'a pas pu tourner (npx/tsc introuvable) sur un workspace où on
+    // l'attendait : ce n'est PAS « OK », c'est « non vérifié » — on le dit, sinon
+    // un rapport vert masquerait qu'aucune compilation n'a eu lieu (#152).
+    if (workspace.type !== "none" && compilationOk === undefined) {
+      console.warn(`reporter: tsc injoignable dans ${wsPath} — compilation NON vérifiée (colonne N/A, pas OK)`);
+    }
 
     results.push({
       agent_id: agentId,
@@ -244,6 +250,40 @@ function safeExec(cmd: string, cwd: string): string {
   } catch (e) {
     return (e as { stdout?: string }).stdout || "";
   }
+}
+
+/** Lance `npx tsc --noEmit` et rend {code, output}. code=0 en succès ; sur échec,
+ *  le code de sortie du process (null s'il n'a pas pu spawn). */
+function runTsc(cwd: string): { code: number | null; output: string } {
+  try {
+    execSync("npx tsc --noEmit", { cwd, encoding: "utf-8", stdio: "pipe" });
+    return { code: 0, output: "" };
+  } catch (e) {
+    const err = e as { status?: number | null; stdout?: string; stderr?: string };
+    return { code: err.status ?? null, output: (err.stdout ?? "") + (err.stderr ?? "") };
+  }
+}
+
+/**
+ * État de compilation TRI-ÉTAT (#152), fondé sur le CODE DE SORTIE de tsc — non
+ * sur `includes("error")`, qui rendait un FAUX OK quand tsc était injoignable
+ * (« command not found » ne contient pas « error »).
+ *   - `true`      : tsc a tourné et rendu 0 (OK).
+ *   - `false`     : tsc a tourné et rapporté des erreurs de type (FAIL) —
+ *                   reconnu à sa signature `error TSxxxx`, ce qui le distingue
+ *                   d'un échec de LANCEMENT.
+ *   - `undefined` : tsc n'a PAS pu tourner (npx/tsc introuvable) — « non vérifié »,
+ *                   JAMAIS confondu avec OK (acceptance #152 : injoignable ⇒ !== true).
+ * `run` est injecté pour le test.
+ */
+export function tscCompilationStatus(
+  cwd: string,
+  run: (cwd: string) => { code: number | null; output: string } = runTsc,
+): boolean | undefined {
+  const { code, output } = run(cwd);
+  if (code === 0) return true;                 // OK
+  if (/error TS\d+/.test(output)) return false; // tsc a tourné et échoué -> FAIL
+  return undefined;                             // tsc n'a pas pu tourner -> non vérifié
 }
 
 

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -3,7 +3,30 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { uniqueReportBase } from '../../src/orchestrator/reporter.js';
+import { uniqueReportBase, tscCompilationStatus } from '../../src/orchestrator/reporter.js';
+
+// #152 — colonne Compilation TRI-ÉTAT, fondée sur le code de sortie de tsc et non
+// sur includes("error") (qui rendait un faux OK quand tsc était injoignable).
+describe('tscCompilationStatus (#152)', () => {
+  it('tsc rend 0 -> true (OK)', () => {
+    expect(tscCompilationStatus('/ws', () => ({ code: 0, output: '' }))).toBe(true);
+  });
+
+  it('tsc tourne et échoue (error TSxxxx) -> false (FAIL)', () => {
+    const output = 'src/a.ts(12,3): error TS2322: Type string is not assignable to number.';
+    expect(tscCompilationStatus('/ws', () => ({ code: 1, output }))).toBe(false);
+  });
+
+  it("tsc INJOIGNABLE (npx introuvable, code 127, aucun diagnostic tsc) -> undefined, JAMAIS true (acceptance #152)", () => {
+    const r = tscCompilationStatus('/ws', () => ({ code: 127, output: 'npx: command not found' }));
+    expect(r).toBeUndefined();
+    expect(r).not.toBe(true); // le faux OK est banni
+  });
+
+  it('spawn impossible (code null) -> undefined (non vérifié)', () => {
+    expect(tscCompilationStatus('/ws', () => ({ code: null, output: '' }))).toBeUndefined();
+  });
+});
 import { loadTemplates } from '../../src/template-loader.js';
 
 let dir: string;


### PR DESCRIPTION
Ferme #152 (chantier #7, BLOQUANT hors TS, jalon J1). Le rapport calculait `compilation_ok` avec `!tscOutput.includes("error")`. Quand `tsc` était **injoignable** (npx/tsc absent), la sortie (« command not found ») ne contient pas « error » → `!false` = **true** → colonne **OK** : un faux vert affirmant une compilation qui n'a jamais eu lieu.

## Corrigé — `tscCompilationStatus`, tri-état par code de sortie
- tsc rend **0** → `true` (OK)
- tsc **tourne et échoue** → `false` (FAIL), reconnu à sa signature `error TSxxxx` (distingue un vrai échec de type d'un échec de **lancement**)
- tsc **ne peut pas tourner** → `undefined` (« non vérifié »), **jamais** `true`

Un `console.warn` signale « tsc injoignable » sur un workspace où on l'attendait, pour que « non vérifié » ne se lise pas comme un silence rassurant.

## Acceptance & tests
Critère #152 : reporter lancé sans `tsc` joignable ⇒ `compilation_ok !== true`. Fonction pure (`run` injecté), 4 tests : `0→true`, échec tsc (`error TS…`)→`false`, injoignable (code 127, pas de diagnostic)→`undefined`, spawn impossible (code null)→`undefined`. Vérifié empiriquement : `tscCompilationStatus` sur ce dépôt → `true`. 864 pass / 1 skip, build vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
