### PR TITLE
fix(run): exit 1 quand rien n'a eu lieu — 0 résolu ET 0 diff (#153)

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -3,6 +3,7 @@ import { listTemplates } from "../src/orchestrator/template-engine.js";
 import { resolve } from "path";
 import { collect, parseSetParams, parseSetFileParams, buildParamTypeMap } from "./params.js";
 import { executeRun } from "./run-core.js";
+import { countDiffLines } from "../src/orchestrator/reporter.js";
 import type { RunResult } from "../src/orchestrator/types.js";
 
 /**
@@ -33,7 +34,18 @@ import type { RunResult } from "../src/orchestrator/types.js";
  */
 export function runExitCode(result: RunResult | undefined): 0 | 1 {
   if (!result || result.agent_results.length === 0) return 0;
-  return result.agent_results.every((a) => a.exit_code !== 0) ? 1 : 0;
+  // Tous les agents ont fini en erreur.
+  if (result.agent_results.every((a) => a.exit_code !== 0)) return 1;
+  // RIEN n'a eu lieu : 0 thread résolu ET 0 ligne de diff MESURÉE -> échec, pas
+  // un faux vert (#153 ; « il ne te dit pas vert quand rien n'a eu lieu »). On
+  // exige que le diff ait été MESURÉ (worktree) : sans mesure (run in-place),
+  // l'absence de diff ne prouve pas l'absence de travail, donc on ne conclut pas.
+  const m = result.coordinator_metrics;
+  const resolved = m.threads_final?.resolved ?? (m.threads_resolved_consensus + m.threads_auto_resolved);
+  const measured = result.agent_results.filter((a) => a.diff_measured);
+  const measuredDiffLines = measured.reduce((sum, a) => sum + countDiffLines(a.diff), 0);
+  if (resolved === 0 && measured.length > 0 && measuredDiffLines === 0) return 1;
+  return 0;
 }
 
 export function createRunCommand(): Command {
@@ -130,8 +142,11 @@ export function createRunCommand(): Command {
         }
         const code = runExitCode(result);
         if (code !== 0) {
+          const allFailed = (result?.agent_results ?? []).every((a) => a.exit_code !== 0);
           console.error(
-            `Aucun agent n'a terminé proprement : les ${result?.agent_results.length ?? 0} agents ont un exit_code non nul — voir la colonne Raison du rapport (error, process_died, mais aussi max_turns ou yielded).`,
+            allFailed
+              ? `Aucun agent n'a terminé proprement : les ${result?.agent_results.length ?? 0} agents ont un exit_code non nul — voir la colonne Raison du rapport (error, process_died, mais aussi max_turns ou yielded).`
+              : `Rien n'a eu lieu : 0 thread résolu et 0 ligne de diff — le run n'a produit aucun résultat mesurable (#153). Voir le rapport.`,
           );
         }
         // Force exit to release the in-process coordinator's HTTP server

--- a/tests/unit/run-exit-code.test.ts
+++ b/tests/unit/run-exit-code.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect } from "vitest";
 import { runExitCode } from "../../cli/run.js";
 import type { AgentResult, RunResult } from "../../src/orchestrator/types.js";
 
-function agent(id: string, exit_code: number): AgentResult {
-  return { agent_id: id, agent_name: id, exit_code, diff: "", stdout_length: 0 };
+function agent(id: string, exit_code: number, diff = "", diff_measured?: boolean): AgentResult {
+  return { agent_id: id, agent_name: id, exit_code, diff, diff_measured, stdout_length: 0 };
 }
 
-function runResult(agents: AgentResult[]): RunResult {
+function runResult(
+  agents: AgentResult[],
+  metrics: Partial<RunResult["coordinator_metrics"]> = {},
+): RunResult {
   return {
     project_id: "p",
     project_name: "proj",
@@ -18,6 +21,7 @@ function runResult(agents: AgentResult[]): RunResult {
       messages_exchanged: 0,
       conflicts_by_layer: {}, introspections_triggered: 0, introspections_concerned: 0,
       avg_resolution_time_ms: 0, hot_files: [],
+      ...metrics,
     },
     agent_results: agents,
     custom_metrics: {},
@@ -51,5 +55,35 @@ describe("runExitCode — TOUS les agents, pas « au moins un »", () => {
 
   it("0 pour un dry-run : executeRun renvoie undefined, rien n'a tourné", () => {
     expect(runExitCode(undefined)).toBe(0);
+  });
+});
+
+// #153 — « il ne te dit pas vert quand rien n'a eu lieu ». Des agents qui sortent
+// proprement mais ne produisent RIEN (0 thread résolu ET 0 ligne de diff mesurée)
+// doivent donner exit 1, pas un faux vert.
+describe("runExitCode — 0 résolu ET 0 diff mesuré => 1 (#153)", () => {
+  it("agents propres mais 0 résolu et 0 diff MESURÉ -> 1 (acceptance)", () => {
+    // diff_measured=true (worktree) + diff vide + 0 thread résolu = rien n'a eu lieu.
+    expect(runExitCode(runResult([agent("a1", 0, "", true), agent("a2", 0, "", true)]))).toBe(1);
+  });
+
+  it("0 résolu mais du DIFF réel a été livré -> 0 (du travail a eu lieu)", () => {
+    expect(runExitCode(runResult([agent("a1", 0, "+ajout\n-suppr", true)]))).toBe(0);
+  });
+
+  it("0 diff mais des threads RÉSOLUS -> 0 (du travail a eu lieu)", () => {
+    expect(runExitCode(runResult([agent("a1", 0, "", true)], { threads_resolved_consensus: 2 }))).toBe(0);
+  });
+
+  it("threads_final fait autorité : resolved=0 y prime sur un compte SSE non nul -> 1", () => {
+    const r = runResult([agent("a1", 0, "", true)], {
+      threads_resolved_consensus: 3, // estimation SSE, mais…
+      threads_final: { total: 3, open: 0, resolving: 0, resolved: 0, cancelled: 0, poisoned: 3 }, // …autorité: 0 résolu
+    });
+    expect(runExitCode(r)).toBe(1);
+  });
+
+  it("run IN-PLACE (diff NON mesuré) + 0 résolu -> 0 (pas de faux rouge : on ne peut pas prouver l'absence de travail)", () => {
+    expect(runExitCode(runResult([agent("a1", 0)]))).toBe(0); // diff_measured undefined
   });
 });


### PR DESCRIPTION
Ferme #153 (chantier #8, MAJEUR, jalon J1). `runExitCode` ne sortait `1` que si **tous** les agents avaient un `exit_code` non nul. Un run où les agents finissent proprement mais ne produisent **rien** (0 thread résolu, 0 ligne de diff) sortait `0` — un faux vert.

## Corrigé
Nouvelle règle : **0 thread résolu ET 0 ligne de diff mesurée → exit 1**.
- `resolved` = `coordinator_metrics.threads_final.resolved` (autorité DB) sinon la somme SSE consensus + auto-résolus.
- On exige que le diff ait été **mesuré** (worktree) : sans mesure (run in-place), l'absence de diff ne prouve pas l'absence de travail → **pas de faux rouge**.
- Le message d'échec distingue « tous les agents en erreur » de « rien produit ».

## Acceptance & tests
Critère #153 : rejeu d'un run à 0 résolu + 0 diff ⇒ `exit 1`. 5 cas : `0+0→1` ; diff réel→`0` ; threads résolus→`0` ; `threads_final` fait autorité (`resolved=0` prime sur l'estimation SSE)→`1` ; run in-place (diff non mesuré)→`0`. Le test existant « défaillance partielle, survivants livrent » reste vert (règle inerte sans mesure de diff). 869 pass / 1 skip, build vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
