### PR TITLE
fix(agent-loop): rouge si un semis discover/review perd TOUTES ses écritures (#184)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -569,6 +569,14 @@ export async function runAgentLoop(
   let lastSendMs = 0;
   let mqttMessagesProcessed = 0;
   let exitReason: ExitReason = "done";
+  // #184 — SANTÉ DU CHEMIN D'ÉCRITURE AU SEMIS. Une phase discover/review qui a
+  // TROUVÉ du travail mais n'en a consigné AUCUN (tous les POST /api/announce
+  // échouent : coordinator lisible, écriture morte) laisse la piscine « vide-
+  // mais-joignable » ; la boucle execute en sortait "done" — faux vert : l'agent
+  // a trouvé des bugs qui n'existeront jamais côté coordinator. Sticky : un seul
+  // semis totalement perdu suffit à teindre le run en rouge. Le garde #151
+  // (unreachableStreak) ne le voit pas — il ne surveille que le chemin de CLAIM.
+  let seedWriteFailed = false;
   let summary = "";
   // ── Token + cost diagnostics ──────────────────────────────────────────
   const totalTokens = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
@@ -1112,7 +1120,11 @@ export async function runAgentLoop(
                 // No review phase — post discoveries immediately (backward compat)
                 if (tasks.length > 0) {
                   logger.info(`Discovery: found ${tasks.length} items, posting to coordinator`);
-                  await postDiscoveries(config.coordinatorUrl, config.agentId, tasks);
+                  const posted = await postDiscoveries(config.coordinatorUrl, config.agentId, tasks);
+                  if (posted.length === 0) {
+                    logger.error(`Discovery: ${tasks.length} trouvaille(s) et 0 thread enregistré — write-path coordinator mort (#184)`);
+                    seedWriteFailed = true;
+                  }
                 }
               }
 
@@ -1151,6 +1163,11 @@ export async function runAgentLoop(
                   config.coordinatorUrl, config.agentId, config.agentName, actions
                 );
                 logger.info(`Review: ${result.posted} new, ${result.enriched} enriched, ${result.skipped} duplicates skipped`);
+                // La review a du NEUF à semer mais l'écriture a tout raté : faux vert (#184).
+                if (result.newAttempted > 0 && result.posted === 0) {
+                  logger.error(`Review: ${result.newAttempted} nouveau(x) thread(s) tenté(s), 0 enregistré — write-path coordinator mort (#184)`);
+                  seedWriteFailed = true;
+                }
               } else {
                 // Fallback: if LLM didn't follow format, post all discoveries as-is
                 logger.warn("Review: no structured actions found, posting all discoveries as fallback");
@@ -1158,7 +1175,11 @@ export async function runAgentLoop(
                 const reviewPreview = resp.content.slice(0, 300).replace(/\n/g, "\\n");
                 logger.info(`Review fallback: ${tasks.length} tasks parsed from discovery content (${discoveryContent.length} chars). Haiku's response preview: ${reviewPreview}`);
                 if (tasks.length > 0) {
-                  await postDiscoveries(config.coordinatorUrl, config.agentId, tasks);
+                  const posted = await postDiscoveries(config.coordinatorUrl, config.agentId, tasks);
+                  if (posted.length === 0) {
+                    logger.error(`Review fallback: ${tasks.length} trouvaille(s) et 0 thread enregistré — write-path coordinator mort (#184)`);
+                    seedWriteFailed = true;
+                  }
                 }
               }
             } else {
@@ -1512,6 +1533,14 @@ export async function runAgentLoop(
           break;
         }
         logger.info(`Cycle ${cycle}: ${tasksDoneLastCycle} tasks done, pool exhausted — will re-discover`);
+        }
+        // #184 — Un semis totalement perdu (trouvailles trouvées, 0 consigné) prime
+        // sur "done" : le run n'est pas fini, il est rouge. Même verdict que le
+        // chemin de claim injoignable (#151) — l'utilisateur voit du rouge, pas un
+        // faux succès sur un travail qui n'existera jamais côté coordinator.
+        if (seedWriteFailed && exitReason === "done") {
+          logger.error("Semis: des trouvailles n'ont JAMAIS été enregistrées (write-path coordinator mort) — rapport rouge (#184)");
+          exitReason = "coordinator_unreachable";
         }
         // Only stamp "done" if no earlier phase/work-stealing loop set a terminal reason
         // (aborted, deadline_exceeded, rate_limited).

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -596,7 +596,7 @@ export async function processReviewActions(
   agentId: string,
   agentName: string,
   actions: ReviewAction[],
-): Promise<{ posted: number; enriched: number; skipped: number }> {
+): Promise<{ posted: number; enriched: number; skipped: number; newAttempted: number }> {
   let posted = 0;
   let enriched = 0;
   let skipped = 0;
@@ -640,6 +640,13 @@ export async function processReviewActions(
     } catch (err) { log.warn("NOUVEAU group post failed", { error: (err as Error).message }); }
   }
 
+  // Nombre de nouveaux threads que la review a TENTÉ de semer. Le déccompte des
+  // tentatives (et pas seulement des succès) est ce qui permet à l'appelant de
+  // distinguer « la review n'a rien de neuf à poster » (newAttempted=0, OK) de
+  // « la review a du neuf mais l'écriture coordinator est morte » (newAttempted>0
+  // && posted=0 -> faux vert, #184).
+  const newAttempted = byFile.size;
+
   // Process enrichments and doublons normally
   for (const action of others) {
     if (action.type === "enrichit") {
@@ -670,6 +677,6 @@ export async function processReviewActions(
     }
   }
 
-  return { posted, enriched, skipped };
+  return { posted, enriched, skipped, newAttempted };
 }
 

--- a/src/agent-loop/work-stealing.ts
+++ b/src/agent-loop/work-stealing.ts
@@ -623,7 +623,7 @@ export async function processReviewActions(
     const plan = descriptions.map((d, i) => `${i + 1}. ${d}`).join("\n");
     log.debug(`NOUVEAU (grouped): ${subject} — ${descriptions.length} items`);
     try {
-      await coordinatorPost(`${coordinatorUrl}/api/announce`, {
+      const data = await coordinatorPost(`${coordinatorUrl}/api/announce`, {
         agent_id: agentId,
         subject: subject.slice(0, 200),
         plan,
@@ -636,7 +636,12 @@ export async function processReviewActions(
         // de la phase review d'un run mort.
         run_id: currentRunId(),
       });
-      posted++;
+      // Un 200 SANS thread_id = thread NON créé (côté coordinator). Le compter
+      // gonflerait `posted` et rendrait le garde #184 AVEUGLE (posted>0 alors que
+      // la piscine reste vide) — faux vert résiduel. postDiscoveries valide déjà
+      // thread_id de la même façon ; on aligne ici pour que `posted` ne mente pas.
+      if (data.thread_id) posted++;
+      else log.warn("NOUVEAU group post: 200 sans thread_id — non compté", { subject: subject.slice(0, 80) });
     } catch (err) { log.warn("NOUVEAU group post failed", { error: (err as Error).message }); }
   }
 

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -90,7 +90,7 @@ const mockCompleteTask = vi.fn(async (_url: string, _threadId: string, _agentId:
 const mockUnclaimTask = vi.fn(async (_url: string, _threadId: string, _agentId: string) => {});
 const mockParseReviewActions = vi.fn((_output: string) => [] as Array<{ type: string; description?: string; threadId?: string; context?: string }>);
 const mockFetchExistingThreads = vi.fn(async (_url: string) => "(aucun thread actif)");
-const mockProcessReviewActions = vi.fn(async (_url: string, _agentId: string, _agentName: string, _actions: unknown[]) => ({ posted: 0, enriched: 0, skipped: 0 }));
+const mockProcessReviewActions = vi.fn(async (_url: string, _agentId: string, _agentName: string, _actions: unknown[]) => ({ posted: 0, enriched: 0, skipped: 0, newAttempted: 0 }));
 
 vi.mock("../../src/agent-loop/work-stealing.js", () => ({
   COORDINATOR_UNREACHABLE: "coordinator_unreachable",
@@ -585,7 +585,7 @@ describe("runAgentLoop — phased mode", () => {
     mockFetchExistingThreads.mockReset();
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockProcessReviewActions.mockReset();
-    mockProcessReviewActions.mockResolvedValue({ posted: 0, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 0, enriched: 0, skipped: 0, newAttempted: 0 });
 
     const mod = await import("../../src/agent-loop/agent-loop.js");
     runAgentLoop = mod.runAgentLoop;
@@ -749,6 +749,71 @@ describe("runAgentLoop — phased mode", () => {
     const result = await loopPromise;
 
     expect(result.exitReason).toBe("done");
+  });
+
+  it("découverte TROUVÉE mais AUCUN thread posté (write-path coordinator mort) → 'coordinator_unreachable', PAS 'done' (#184)", async () => {
+    vi.useFakeTimers();
+
+    // Le coordinator est LISIBLE (threads-active répondra vide) mais son ÉCRITURE
+    // est morte : chaque POST /api/announce échoue, donc postDiscoveries enregistre
+    // ZÉRO thread malgré 1 trouvaille. C'est le faux vert propre à #184 : la piscine
+    // paraît « vide-mais-joignable » à la phase execute, qui sortait "done" — alors
+    // que l'agent a TROUVÉ du travail et n'en a RIEN consigné.
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+    mockPostDiscoveries.mockResolvedValue([]); // 0 posté malgré 1 trouvé
+
+    // Piscine vide-mais-joignable : claim rend null, PAS UNREACHABLE — le garde
+    // #151 (unreachableStreak) est donc AVEUGLE ici, c'est bien #184 qui doit voir.
+    mockClaimNextTask.mockResolvedValue(null);
+
+    const loopPromise = runAgentLoop(makePhasedConfig(), silentLogger);
+    for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("coordinator_unreachable");
+    expect(result.exitReason).not.toBe("done"); // faux vert banni (#184)
+  });
+
+  it("phase review : NOUVEAUX trouvés mais 0 posté (write-path mort) → 'coordinator_unreachable', PAS 'done' (#184)", async () => {
+    vi.useFakeTimers();
+
+    const config = makeConfig({
+      phases: [
+        { name: "discover", prompt: "Find bugs", toolsMode: "read_only", loop: false },
+        { name: "review", prompt: "Review:\n{{params.my_discoveries}}", toolsMode: "none", loop: false },
+        { name: "execute", prompt: "Fix: {{params.current_task}}", toolsMode: "full", loop: true },
+      ],
+    });
+
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 42 | Bug A | critical",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 42, severity: "critical" },
+    ]);
+    mockSend.mockResolvedValueOnce({
+      content: "REVIEW:\nNOUVEAU | Bug A",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "Bug A" }]);
+    // La review a tenté de semer 1 nouveau thread et TOUT a échoué (write-path mort).
+    mockProcessReviewActions.mockResolvedValue({ posted: 0, enriched: 0, skipped: 0, newAttempted: 1 });
+
+    mockClaimNextTask.mockResolvedValue(null);
+
+    const loopPromise = runAgentLoop(config, silentLogger);
+    for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
+    const result = await loopPromise;
+
+    expect(result.exitReason).toBe("coordinator_unreachable");
+    expect(result.exitReason).not.toBe("done"); // faux vert banni (#184)
   });
 
   it("claims and executes tasks in work-stealing loop", async () => {
@@ -991,7 +1056,7 @@ describe("runAgentLoop — phased mode", () => {
     mockParseReviewActions.mockReturnValue([
       { type: "nouveau", description: "Bug A" },
     ]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
 
     // Execute: claimNextTask returns one task then null
     let claimCall = 0;
@@ -1172,7 +1237,7 @@ describe("runAgentLoop — phased mode", () => {
       toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
     });
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "Bug A" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
     mockClaimNextTask.mockResolvedValue(null);
 
     const loopPromise = runAgentLoop(config, silentLogger);
@@ -1463,7 +1528,7 @@ describe("runAgentLoop — phased mode", () => {
     });
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "finding 1" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
     mockClaimNextTask.mockResolvedValue(null);
 
     const config = makeConfig({
@@ -1521,7 +1586,7 @@ describe("runAgentLoop — phased mode", () => {
     });
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "finding" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
     mockClaimNextTask.mockResolvedValue(null);
 
     const config = makeConfig({
@@ -1668,7 +1733,7 @@ describe("runAgentLoop — phased mode", () => {
     mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "item" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
 
     const config = makeConfig({
       maxDiscoverCycles: 3,
@@ -1707,7 +1772,7 @@ describe("runAgentLoop — phased mode", () => {
     mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "item" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
 
     const config = makeConfig({
       phases: [
@@ -1834,7 +1899,7 @@ describe("runAgentLoop — phased mode", () => {
     mockParseDiscoveries.mockReturnValue([{ id: "", description: "item", file: undefined, line: undefined, severity: undefined }]);
     mockFetchExistingThreads.mockResolvedValue("(aucun thread actif)");
     mockParseReviewActions.mockReturnValue([{ type: "nouveau", description: "item" }]);
-    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0 });
+    mockProcessReviewActions.mockResolvedValue({ posted: 1, enriched: 0, skipped: 0, newAttempted: 1 });
 
     const config = makeConfig({
       phases: [

--- a/tests/unit/work-stealing.test.ts
+++ b/tests/unit/work-stealing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, parseReviewActions, COORDINATOR_UNREACHABLE } from "../../src/agent-loop/work-stealing.js";
+import { parseDiscoveries, postDiscoveries, claimNextTask, completeTask, parseReviewActions, processReviewActions, COORDINATOR_UNREACHABLE } from "../../src/agent-loop/work-stealing.js";
 
 describe("parseDiscoveries", () => {
   it("parses pipe-separated discovery format", () => {
@@ -466,3 +466,28 @@ describe("parseReviewActions", () => {
   });
 });
 
+
+describe("processReviewActions — comptage honnête de `posted` (#184)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const nouveau = [{ type: "nouveau" as const, description: "src/a.ts:10 — Bug A" }];
+
+  it("200 AVEC thread_id → posted=1, newAttempted=1", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ thread_id: "t-1" }) })));
+    const r = await processReviewActions("http://c", "agent-1", "Agent 1", nouveau);
+    expect(r).toMatchObject({ posted: 1, newAttempted: 1 });
+  });
+
+  it("200 SANS thread_id (thread non créé) → posted=0, newAttempted=1 — le garde #184 doit voir le semis perdu", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    const r = await processReviewActions("http://c", "agent-1", "Agent 1", nouveau);
+    // Sans la validation thread_id, posted valait 1 (mensonge) et le faux vert #184 revenait.
+    expect(r).toMatchObject({ posted: 0, newAttempted: 1 });
+  });
+
+  it("POST qui échoue (réseau) → posted=0, newAttempted=1", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    const r = await processReviewActions("http://c", "agent-1", "Agent 1", nouveau);
+    expect(r).toMatchObject({ posted: 0, newAttempted: 1 });
+  });
+});


### PR DESCRIPTION
## Le compteur (P1)

`essaim run` en mode phasé où le LLM **trouve** du travail mais où **chaque** `POST /api/announce` échoue (coordinator lisible en lecture, écriture morte) rapportait **vert** (`done`). L'agent a trouvé des bugs qui n'existeront jamais côté coordinator → faux vert. Fixes #184.

C'est la sœur de #151 : #151 couvre le chemin de **claim** (`unreachableStreak`), qui est **aveugle** au chemin de **semis** (discover/review).

## Mécanisme du faux vert

`discover`/`review` sèment via `postDiscoveries`/`processReviewActions`. Semis totalement perdu → piscine **vide-mais-joignable** → `claimNextTask` rend `null` (pas `coordinator_unreachable`) → boucle execute sort `done`.

## Correctif

- **work-stealing.ts** — `processReviewActions` rend `newAttempted` (= `byFile.size`, nb de nouveaux threads *tentés*). Distingue « rien de neuf » (`newAttempted=0`, OK) de « du neuf mais écriture morte » (`newAttempted>0 && posted=0`).
- **agent-loop.ts** — `seedWriteFailed` sticky aux **3** sites de semis (discover sans review ; review structurée ; review fallback). Réconcilié avant le résumé : `seedWriteFailed && exitReason==="done"` → `coordinator_unreachable`. Un verdict terminal antérieur (rate_limited/deadline/…) n'est jamais écrasé.

`postDiscoveries` rend `tasks.filter(t=>t.id)` ; les tâches partent `id:""` et ne reçoivent un id que d'un POST réussi → `posted.length===0` ⟺ tout a échoué.

## Test d'acceptation

2 cas dans `agent-loop.test.ts` : découverte et review qui trouvent du travail avec **0 posté** → `exitReason` `coordinator_unreachable`, **jamais** `done`. Rouges sans le fix, verts avec. Les cas `done` existants restent verts (pas de faux rouge).

`pnpm test` (872) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)