### PR TITLE
fix(security): un semis de findings raté DÉGRADE le run — plus de faux vert (#190)

### DIFF
--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -231,7 +231,10 @@ export function writeReport(results: RunResult[], outputDir: string): string {
       md += `| ${s.engine} | ${s.license} | ${s.status}${s.degraded ? " (degraded)" : ""} | ${Math.round(s.durationMs / 1000)}s | ${s.exitCode ?? "N/A"} | ${s.engineVersion ?? "N/A"} | \`${s.imageDigest ?? "N/A"}\` |\n`;
       md += `\n**Findings par sévérité:** `;
       md += `critical ${s.findingsBySeverity.critical}, high ${s.findingsBySeverity.high}, medium ${s.findingsBySeverity.medium}, low ${s.findingsBySeverity.low}, info ${s.findingsBySeverity.info}\n`;
-      md += `\n**Remédiation:** ${s.ingested} ingérés · ${s.verified} verified · ${s.reopened} reopened · ${s.falsePositives} faux-positifs · ${s.suppressed} baselinés · ${s.outOfScopeDropped} hors-scope écartés\n`;
+      md += `\n**Remédiation:** ${s.ingested} ingérés · ${s.verified} verified · ${s.reopened} reopened · ${s.falsePositives} faux-positifs · ${s.suppressed} baselinés · ${s.outOfScopeDropped} hors-scope écartés`;
+      // Nommer les findings perdus au semis (thème #137) : sinon `degraded` est
+      // vrai sans dire pourquoi, et N vulnérabilités non consignées restent muettes.
+      md += s.ingestFailed > 0 ? ` · **${s.ingestFailed} ÉCHECS de semis (findings non consignés)**\n` : `\n`;
       if (s.reopened > 0) {
         md += `\n> ⚠️ ${s.reopened} finding(s) re-détecté(s) à la vérification — le run n'est PAS "clean" (révision humaine requise).\n`;
       }

--- a/src/security/ingest.ts
+++ b/src/security/ingest.ts
@@ -110,7 +110,17 @@ export async function ingestFindings(coordinatorUrl: string, agentId: string, fi
   for (const f of findings) {
     try {
       const data = await coordPost(`${coordinatorUrl}/api/announce`, findingToAnnounce(f, agentId));
-      posted.push({ threadId: String(data.thread_id ?? ""), finding: f });
+      // Un 200 SANS thread_id = thread NON créé (coordinator « vivant mais
+      // dysfonctionnel », ex. base verrouillée qui répond 200+erreur). Le compter
+      // comme ingéré faussait le ledger et laissait un finding perdu passer pour
+      // semé — faux vert (#190). On le traite comme un échec de semis.
+      const threadId = String(data.thread_id ?? "");
+      if (threadId) {
+        posted.push({ threadId, finding: f });
+      } else {
+        failed++;
+        log.error("security: announce 200 sans thread_id — finding NON semé", { fingerprint: f.fingerprint });
+      }
     } catch (err) {
       failed++;
       log.error("security: failed to ingest finding", { fingerprint: f.fingerprint, err: (err as Error).message });

--- a/src/security/pre-phase.ts
+++ b/src/security/pre-phase.ts
@@ -43,7 +43,7 @@ function imageDigestOf(image: string): string {
 
 export function buildLedger(
   scan: ScanResult,
-  extra: { ingested: number; outOfScopeDropped: number; suppressed: number },
+  extra: { ingested: number; outOfScopeDropped: number; suppressed: number; ingestFailed: number },
 ): SecurityRunLedger {
   const r = scan.results[0];
   const bySev: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
@@ -53,10 +53,15 @@ export function buildLedger(
     status: r?.status ?? "skipped",
     findingsBySeverity: bySev,
     ingested: extra.ingested,
+    ingestFailed: extra.ingestFailed,
     verified: 0,
     reopened: 0,
     falsePositives: 0,
-    degraded: scan.degraded,
+    // Posture conservatrice anti-false-clean (cf. verify.ts:41) : un finding
+    // trouvé mais non semé est une vuln qui ne sera jamais corrigée. Tout échec
+    // de semis dégrade le run -> exit 1 (cli/security.ts). Sinon exit 0 vert
+    // malgré N vulnérabilités perdues (#190).
+    degraded: scan.degraded || extra.ingestFailed > 0,
     durationMs: r?.durationMs ?? 0,
     exitCode: r?.exitCode,
     engineVersion: r?.engineVersion,
@@ -165,7 +170,7 @@ export async function runSecurityPrePhase(
   const ingest = await ingestFindings(p.coordinatorUrl, authorId, fresh.fresh);
   writeEngineReport(p.projectPath, p.runId, scan);
 
-  const ledger = buildLedger(scan, { ingested: ingest.posted.length, outOfScopeDropped: inScope.dropped, suppressed: fresh.suppressed });
+  const ledger = buildLedger(scan, { ingested: ingest.posted.length, outOfScopeDropped: inScope.dropped, suppressed: fresh.suppressed, ingestFailed: ingest.failed });
   return { ledger, postedMap: ingest.posted, engineId: cfg.engines[0] };
 }
 

--- a/src/security/types.ts
+++ b/src/security/types.ts
@@ -154,6 +154,10 @@ export interface SecurityRunLedger {
   status: EngineStatus;
   findingsBySeverity: Record<Severity, number>;
   ingested: number;
+  // Findings que le scan a trouvés mais que le semis n'a PAS pu enregistrer
+  // (POST /api/announce en échec, ou 200 sans thread_id). >0 => `degraded`, sinon
+  // N vulnérabilités jamais consignées passeraient pour un run propre (#190).
+  ingestFailed: number;
   verified: number;
   reopened: number;
   falsePositives: number;

--- a/tests/unit/security-cli.test.ts
+++ b/tests/unit/security-cli.test.ts
@@ -66,7 +66,7 @@ describe("securityExitCode (mirrors Strix)", () => {
     return {
       engine: "strix", status: "no_vulns",
       findingsBySeverity: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
-      ingested: 0, verified: 0, reopened: 0, falsePositives: 0, degraded: false,
+      ingested: 0, ingestFailed: 0, verified: 0, reopened: 0, falsePositives: 0, degraded: false,
       durationMs: 1, license: "Apache-2.0", outOfScopeDropped: 0, suppressed: 0, ...over,
     };
   }

--- a/tests/unit/security-ingest.test.ts
+++ b/tests/unit/security-ingest.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { findingToAnnounce, ingestFindings, registerSyntheticAuthor, syntheticAuthorId } from "../../src/security/ingest.js";
 import type { Finding } from "../../src/security/types.js";
+import { buildLedger } from "../../src/security/pre-phase.js";
+import type { ScanResult } from "../../src/security/scan.js";
 
 function finding(over: Partial<Finding> = {}): Finding {
   return {
@@ -177,5 +179,29 @@ describe("ingestFindings + registerSyntheticAuthor", () => {
 describe("syntheticAuthorId", () => {
   it("derives a stable id from the project basename", () => {
     expect(syntheticAuthorId("C:/Users/gagno/projet/essaim-new")).toBe("security-scanner@essaim-new");
+  });
+});
+
+describe("faux vert du semis sécurité (#190)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("ingestFindings : 200 SANS thread_id (thread non créé) → failed++, PAS ingéré", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url.includes("/api/announce")) return { ok: true, json: async () => ({ status: "open" }) }; // pas de thread_id
+      return { ok: true, json: async () => ({}) };
+    }));
+    const res = await ingestFindings("http://c", "a", [finding()]);
+    expect(res.failed).toBe(1);
+    expect(res.posted).toHaveLength(0);
+  });
+
+  it("buildLedger : un échec de semis (ingestFailed>0) DÉGRADE le run → exit rouge, jamais vert sur findings perdus", () => {
+    const scan: ScanResult = { results: [], findings: [finding()], degraded: false };
+    const degradedLedger = buildLedger(scan, { ingested: 0, outOfScopeDropped: 0, suppressed: 0, ingestFailed: 2 });
+    expect(degradedLedger.degraded).toBe(true);
+    expect(degradedLedger.ingestFailed).toBe(2);
+    // Contrôle : 0 échec de semis et scan sain → PAS dégradé (pas de faux rouge).
+    const cleanLedger = buildLedger(scan, { ingested: 1, outOfScopeDropped: 0, suppressed: 0, ingestFailed: 0 });
+    expect(cleanLedger.degraded).toBe(false);
   });
 });

--- a/tests/unit/security-report.test.ts
+++ b/tests/unit/security-report.test.ts
@@ -27,7 +27,7 @@ describe("writeReport — security section", () => {
       security: {
         engine: "strix", status: "vulns_found",
         findingsBySeverity: { critical: 0, high: 2, medium: 1, low: 0, info: 0 },
-        ingested: 3, verified: 2, reopened: 1, falsePositives: 0, degraded: false,
+        ingested: 3, ingestFailed: 0, verified: 2, reopened: 1, falsePositives: 0, degraded: false,
         durationMs: 142000, exitCode: 2, engineVersion: "1.3.1", license: "Apache-2.0",
         imageDigest: "sha256:abc", outOfScopeDropped: 4, suppressed: 1,
       },


### PR DESCRIPTION
## Le compteur (P1)

`essaim security --no-require-findings` où le scan trouve N>0 findings mais où **chaque** `POST /api/announce` échoue (coordinator joignable en lecture, écriture morte) rapportait **exit 0 (vert)** — alors que N vulnérabilités n'ont jamais atteint le coordinator et ne seront jamais corrigées. Fixes #190.

Même thème que #184 (« ne pas dire vert quand rien n'a eu lieu »), chemin `essaim security`. Confirmé par **double revue adversariale** (session courante + session paire, indépendamment).

## Cause

`buildLedger` fixait `degraded: scan.degraded` **uniquement** (dégradation du moteur de scan), jamais les échecs de semis. `cli/security.ts:91` fait exit 1 sur `ledger.degraded` — mais il restait `false`.

Escape secondaire : `ingest.ts` poussait `posted` avec `threadId=""` sur un 200 sans `thread_id` (coordinator « vivant mais dysfonctionnel »), comptant un finding perdu comme ingéré.

## Correctif

- **ingest.ts** — `ingestFindings` ne compte `posted` que si `thread_id` réel, sinon `failed++`.
- **types.ts** — `SecurityRunLedger.ingestFailed` (nouveau champ).
- **pre-phase.ts** — `buildLedger` : `degraded = scan.degraded || ingestFailed > 0` (posture conservatrice anti-false-clean, cf. `verify.ts:41`).
- **reporter.ts** — nomme « N ÉCHECS de semis (findings non consignés) » (thème #137).

## Tests

`buildLedger` avec `ingestFailed>0` → `degraded=true` (rouge) ; `ingestFailed=0` + scan sain → `degraded=false` (pas de faux rouge) ; `ingestFindings` 200 sans `thread_id` → `failed++`, non ingéré.

`pnpm test` (872) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)