### PR TITLE
fix(agent-loop): un claim réussi efface seedWriteFailed — plus de faux ROUGE au semis (#191)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -1305,6 +1305,18 @@ export async function runAgentLoop(
               // Reset on successful claim (progrès réel)
               noProgressRetries = 0;
               unreachableStreak = 0;
+              // #191 — Un claim RÉUSSI (claim-task UPDATE la ligne côté coordinator)
+              // prouve que l'écriture fonctionne MAINTENANT. Si un semis discover/
+              // review avait tout raté (seedWriteFailed), c'était donc un blip
+              // transitoire, pas une écriture morte : sinon ce faux rouge teindrait
+              // un run qui corrige réellement du travail des pairs. On efface le
+              // drapeau sur la preuve d'écriture, comme unreachableStreak plus haut.
+              // Le cas #184 (agent seul, piscine vide) ne claim JAMAIS, donc
+              // n'atteint jamais cette ligne → reste rouge, invariant préservé.
+              if (seedWriteFailed) {
+                logger.warn("Work-stealing: claim réussi — coordinator writable, l'échec de semis était transitoire (#191) ; seedWriteFailed effacé");
+                seedWriteFailed = false;
+              }
               claimedThreadIds.add(task.id);
 
               logger.info(`Work-stealing: claimed "${task.description.slice(0, 80)}"`);

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -816,6 +816,46 @@ describe("runAgentLoop — phased mode", () => {
     expect(result.exitReason).not.toBe("done"); // faux vert banni (#184)
   });
 
+  it("semis raté MAIS l'agent réclame+complète du travail des pairs → coordinator prouvé writable → 'done', PAS faux rouge (#191)", async () => {
+    vi.useFakeTimers();
+
+    // L'agent trouve du travail mais TOUS ses POST announce échouent (blip
+    // transitoire) → 0 semé → seedWriteFailed=true (#184). MAIS la piscine
+    // contient du travail des pairs : le claim RÉUSSIT (claim-task UPDATE la
+    // ligne = preuve que le coordinator accepte des écritures MAINTENANT), et
+    // l'agent complète le fix. Le semis raté était donc transitoire, pas une
+    // écriture morte : le run corrige réellement du code → "done", pas rouge.
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([
+      { id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" },
+    ]);
+    mockPostDiscoveries.mockResolvedValue([]); // semis raté (transitoire)
+
+    // Piscine des pairs : un claim réussit, puis pool vide.
+    let claimCall = 0;
+    mockClaimNextTask.mockImplementation(async () => {
+      claimCall++;
+      if (claimCall === 1) return { id: "t-peer", description: "Peer bug", file: "src/peer.ts", severity: "major" };
+      return null;
+    });
+    // L'agent complète la tâche des pairs.
+    mockSend.mockResolvedValueOnce({
+      content: "DONE: fixed peer bug",
+      toolCalls: [], costUsd: 0.02, durationMs: 300, sessionId: "s1",
+    });
+
+    const loopPromise = runAgentLoop(makePhasedConfig(), silentLogger);
+    for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
+    const result = await loopPromise;
+
+    // Le coordinator s'est prouvé writable (claim réussi) → le faux rouge est banni.
+    expect(result.exitReason).toBe("done");
+    expect(result.exitReason).not.toBe("coordinator_unreachable");
+  });
+
   it("claims and executes tasks in work-stealing loop", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Le compteur (P1)

Un run qui **corrige réellement du code** était rapporté **rouge** (`coordinator_unreachable`) quand le semis discover/review de l'agent échouait à 100 % transitoirement, alors même que l'agent réclamait ensuite du travail des pairs et le complétait. Fixes #191.

## Pourquoi PAS le retry (proposé dans l'issue)

Lecture du **coordinator réel** (`mcp-coordinator`, `serve-http.ts` + `consultation.announceWork`) :
- `/api/announce` fait **toujours un INSERT neuf** — pas de dédup, pas de 409. Rejouer un POST commité crée un **thread DOUBLON** (le gaspillage tué par #142).
- Il rend **500** sur erreur (jamais 503/429), et absorbe `SQLITE_BUSY` via `busy_timeout=5000`.

Donc le retry est **dangereux** (doublons, announce non-idempotent) et **inerte** (les statuts transitoires visés n'arrivent pas sur cet endpoint).

## Le fix (sûr, sans retry)

Le signal de fiabilité existe déjà côté agent : un **claim réussi** (`claim-task` = UPDATE côté coordinator) prouve que l'écriture fonctionne *maintenant*. On efface alors `seedWriteFailed`, exactement comme `unreachableStreak` se remet à 0 sur un claim réussi (#151). Pas de retry, pas de doublon, aucune modif coordinator.

**Invariant #184 préservé** : l'agent seul à piscine vide ne claim jamais → n'efface jamais le drapeau → reste rouge. Les deux tests #184 restent verts.

## Tests

- **#191** (nouveau) : semis raté (`postDiscoveries→[]`) MAIS claim d'un pair réussi + complété → `done`, jamais `coordinator_unreachable`. Rouge sans le fix, vert avec.
- **#184** (les deux) : inchangés, toujours rouges.

`pnpm test` (878) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)