### PR TITLE
fix(reporter): lancer tsc seulement sur un dépôt TS — dépôt Go ⇒ N/A (#160)

### DIFF
--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -30,7 +30,10 @@ export function formatCost(costUsd: number | undefined, hasTokens: boolean): str
   return `$${(costUsd ?? 0).toFixed(4)}`;
 }
 
-export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
+export function collectAgentResults(
+  workspace: WorkspaceResult,
+  run: (cwd: string) => { code: number | null; output: string } = runTsc,
+): AgentResult[] {
   const results: AgentResult[] = [];
 
   for (const [agentId, wsPath] of workspace.paths) {
@@ -44,13 +47,19 @@ export function collectAgentResults(workspace: WorkspaceResult): AgentResult[] {
         ? safeExec(`git diff ${workspace.baseSha}`, wsPath)
         : safeExec("git diff HEAD", wsPath);
 
-    const compilationOk = workspace.type !== "none"
-      ? tscCompilationStatus(wsPath)
-      : undefined;
-    // tsc n'a pas pu tourner (npx/tsc introuvable) sur un workspace où on
+    // `npx tsc --noEmit` n'a de sens que sur un dépôt TypeScript. Sur un dépôt
+    // Go/Python/Rust il ne prouve RIEN (rien à typer) et coûte ~10 s/agent — le
+    // lancer y produisait une colonne trompeuse au lieu d'un franc N/A (#160). Le
+    // signal d'applicabilité est tsconfig.json dans le workspace de l'agent (même
+    // heuristique que scanner.ts) : sans lui, tsc ne saurait pas quoi compiler.
+    const isTypeScript = fs.existsSync(path.join(wsPath, "tsconfig.json"));
+    const shouldCheck = workspace.type !== "none" && isTypeScript;
+    const compilationOk = shouldCheck ? tscCompilationStatus(wsPath, run) : undefined;
+    // tsc n'a pas pu tourner (npx/tsc introuvable) sur un dépôt TS où on
     // l'attendait : ce n'est PAS « OK », c'est « non vérifié » — on le dit, sinon
-    // un rapport vert masquerait qu'aucune compilation n'a eu lieu (#152).
-    if (workspace.type !== "none" && compilationOk === undefined) {
+    // un rapport vert masquerait qu'aucune compilation n'a eu lieu (#152). Un
+    // dépôt non-TS N'est PAS « non vérifié » mais « non applicable » : pas de warn.
+    if (shouldCheck && compilationOk === undefined) {
       console.warn(`reporter: tsc injoignable dans ${wsPath} — compilation NON vérifiée (colonne N/A, pas OK)`);
     }
 

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -1,9 +1,10 @@
 // tests/unit/minors.test.ts — minors différés du pilote
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { uniqueReportBase, tscCompilationStatus } from '../../src/orchestrator/reporter.js';
+import { uniqueReportBase, tscCompilationStatus, collectAgentResults } from '../../src/orchestrator/reporter.js';
+import type { WorkspaceResult } from '../../src/orchestrator/types.js';
 
 // #152 — colonne Compilation TRI-ÉTAT, fondée sur le code de sortie de tsc et non
 // sur includes("error") (qui rendait un faux OK quand tsc était injoignable).
@@ -104,5 +105,35 @@ agents:
     count: beaucoup
 `);
     expect(() => loadTemplates(p)).toThrow(/count/);
+  });
+});
+
+// #160 — `npx tsc --noEmit` seulement sur dépôt TS. Un dépôt Go/Python n'a rien à
+// typer : tsc n'y prouve rien et coûte ~10 s/agent. Compteur : dépôt Go ⇒ N/A,
+// et tsc n'est JAMAIS lancé.
+describe('collectAgentResults — tsc seulement sur dépôt TS (#160)', () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function workspaceOf(wsPath: string): WorkspaceResult {
+    // `shared` (pas `worktree`) pour éviter tout `git diff` : on isole la porte tsc.
+    return { type: 'shared', basePath: wsPath, paths: new Map([['a1', wsPath]]), branches: new Map() };
+  }
+
+  it('dépôt NON-TS (pas de tsconfig) ⇒ compilation N/A et tsc JAMAIS lancé', () => {
+    dir = mkdtempSync(join(tmpdir(), 'nots-'));
+    const run = vi.fn(() => ({ code: 0 as number | null, output: '' }));
+    const results = collectAgentResults(workspaceOf(dir), run);
+    expect(run).not.toHaveBeenCalled();                 // LE compteur : pas de tsc sur un dépôt Go
+    expect(results[0].compilation_ok).toBeUndefined();  // colonne N/A, pas OK/FAIL
+  });
+
+  it('dépôt TS (tsconfig présent) ⇒ tsc lancé, statut honoré', () => {
+    dir = mkdtempSync(join(tmpdir(), 'ts-'));
+    writeFileSync(join(dir, 'tsconfig.json'), '{}');
+    const run = vi.fn(() => ({ code: 0 as number | null, output: '' }));
+    const results = collectAgentResults(workspaceOf(dir), run);
+    expect(run).toHaveBeenCalledWith(dir);
+    expect(results[0].compilation_ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Le compteur (P1)

Dépôt **Go/Python/Rust** ⇒ colonne Compilation **`N/A`**, et **tsc n'est jamais lancé** (~10 s/agent économisés). Fixes #160.

## Cause

`collectAgentResults` lançait `npx tsc --noEmit` sur tout workspace non-`none`, quel que soit le langage. Sur un dépôt non-TS, tsc ne prouve rien (rien à typer) et coûte ~10 s/agent, en produisant une colonne trompeuse.

## Correctif

Gate sur la présence de `tsconfig.json` dans le workspace de l'agent — **même heuristique d'applicabilité que `scanner.ts:18`**. Sans tsconfig, `tsc --noEmit` ne saurait pas quoi compiler → `compilation_ok=undefined` (N/A).

Distinction #152 préservée : un dépôt non-TS est « non **applicable** » (pas de warn), pas « non **vérifié** » (dépôt TS où tsc n'a pas pu tourner → warn maintenu).

`collectAgentResults` accepte un runner tsc injectable (défaut = `runTsc` réel) pour que le test prouve « tsc jamais lancé » sans lancer tsc.

## Tests

- dépôt non-TS (pas de tsconfig) ⇒ `compilation_ok` undefined **ET** runner tsc jamais appelé.
- dépôt TS (tsconfig présent) ⇒ runner appelé, statut honoré.

`pnpm test` (879) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)