### PR TITLE
feat(reporter): rapport nommé par run_id, écrit aussi dans le runDir, en-tête d'identité (#164)

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -27,6 +27,7 @@ import { scanProject } from "./scanner.js";
 import { runSecurityPrePhase, runSecurityVerifyPhase } from "../security/pre-phase.js";
 
 import { getCatalogRoots, getScriptsDirs } from "../../cli/bce-resolver.js";
+import { getVersion } from "../../cli/version.js";
 import { runPipeline } from "@swoofer/promptweave";
 import { preflightQuotaCheck, resolveMaxUtilizationPct } from "./preflight.js";
 
@@ -675,6 +676,15 @@ async function _runProjectBody(
     custom_metrics: {},
     worktrees,
     security: securityLedger,
+    // Identité du run (#164) : consommée par writeReport pour nommer le rapport
+    // par run_id, l'écrire aussi dans le runDir, et poser l'en-tête d'identité.
+    identity: {
+      run_id: runId,
+      run_dir: runDir,
+      base_sha: workspace.baseSha,
+      coordinator_url: effectiveCoordinatorUrl,
+      version: getVersion(),
+    },
   };
 }
 

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -108,14 +108,20 @@ export function uniqueReportBase(dir: string, prefix: string, extensions: string
 }
 
 export function writeReport(results: RunResult[], outputDir: string): string {
-  fs.mkdirSync(outputDir, { recursive: true });
-  const base = uniqueReportBase(outputDir, `report-${Date.now()}`, [".json", ".md"]);
+  // Identité du run (#164) : nomme le rapport par run_id, l'écrit AUSSI dans le
+  // runDir, et porte un en-tête d'identité — le rapport se suffit (DF5). Absente
+  // (appelant legacy), on retombe sur l'horodatage et le seul outputDir.
+  const identity = results[0]?.identity;
+  const slug = (s: string) => s.replace(/[^A-Za-z0-9._-]+/g, "-");
+  const prefix = identity ? `report-${slug(identity.run_id)}` : `report-${Date.now()}`;
 
-  const jsonPath = path.join(outputDir, `${base}.json`);
-  fs.writeFileSync(jsonPath, JSON.stringify(results, null, 2));
-
-  const mdPath = path.join(outputDir, `${base}.md`);
   let md = `# Mini-projet Report\n\n*${new Date().toISOString()}*\n\n`;
+  if (identity) {
+    md += `> **run** \`${identity.run_id}\``
+      + ` · **baseSha** \`${identity.base_sha ?? "N/A"}\``
+      + ` · **essaim** v${identity.version}`
+      + ` · **coordinator** ${identity.coordinator_url}\n\n`;
+  }
 
   for (const r of results) {
     md += `## ${r.project_name} (${r.mode})\n\n`;
@@ -262,9 +268,24 @@ export function writeReport(results: RunResult[], outputDir: string): string {
     md += "\n---\n\n";
   }
 
-  fs.writeFileSync(mdPath, md);
-  console.log(`Report: ${mdPath}`);
-  return mdPath;
+  // reports/ TOUJOURS ; et AUSSI le runDir quand on le connaît (#164), pour que
+  // le rapport vive à côté des artefacts du run. Chaque dossier a son propre nom
+  // libre (uniqueReportBase) : deux runs dans la même ms ne s'écrasent pas.
+  const targets = [outputDir];
+  if (identity?.run_dir && path.resolve(identity.run_dir) !== path.resolve(outputDir)) {
+    targets.push(identity.run_dir);
+  }
+  let primaryMd = "";
+  for (const dir of targets) {
+    fs.mkdirSync(dir, { recursive: true });
+    const base = uniqueReportBase(dir, prefix, [".json", ".md"]);
+    fs.writeFileSync(path.join(dir, `${base}.json`), JSON.stringify(results, null, 2));
+    const mdPath = path.join(dir, `${base}.md`);
+    fs.writeFileSync(mdPath, md);
+    if (!primaryMd) primaryMd = mdPath;
+  }
+  console.log(`Report: ${primaryMd}`);
+  return primaryMd;
 }
 
 function fmtTokens(n: number): string {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -124,6 +124,17 @@ export interface RunResult {
   custom_metrics: Record<string, unknown>;
   worktrees?: { agent_id: string; path: string; branch: string }[];
   security?: SecurityRunLedger; // present only for security runs; rendered by the reporter
+  // Identité du run (#164) : le rapport est nommé par run_id, écrit AUSSI dans le
+  // runDir, et porte un en-tête d'identité — pour qu'un lecteur qui n'a pas vu le
+  // terminal sache de quel run il s'agit (DF5). Optionnel : un appelant legacy de
+  // writeReport sans identité retombe sur l'horodatage + le seul dossier reports/.
+  identity?: {
+    run_id: string;
+    run_dir: string;
+    base_sha?: string;
+    coordinator_url: string;
+    version: string;
+  };
 }
 
 export interface AgentResult {

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/minors.test.ts — minors différés du pilote
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -212,5 +212,47 @@ describe('reporter honnête (#165)', () => {
     dropHarness(dir); // SEUL le harnais est présent
     const { diff } = collectAgentResults(worktreeAt(dir, baseSha))[0];
     expect(countDiffLines(diff)).toBe(0);
+  });
+});
+
+// #164 — le rapport se suffit : nommé par run_id, écrit AUSSI dans le runDir,
+// avec un en-tête d'identité (run_id, baseSha, version, coordinator).
+describe('rapport : identité + copie dans le runDir (#164)', () => {
+  let reportsDir: string, runDir: string;
+  afterEach(() => {
+    rmSync(reportsDir, { recursive: true, force: true });
+    if (runDir && runDir !== reportsDir) rmSync(runDir, { recursive: true, force: true });
+  });
+
+  it('nom contient run_id, copie dans le runDir, en-tête porte run_id/baseSha/version/coordinator', () => {
+    reportsDir = mkdtempSync(join(tmpdir(), 'reports164-'));
+    runDir = mkdtempSync(join(tmpdir(), 'runDir164-'));
+    const r: RunResult = {
+      ...runResult(),
+      identity: {
+        run_id: 'raid-abcd1234', run_dir: runDir, base_sha: 'deadbeef',
+        coordinator_url: 'http://127.0.0.1:3100', version: '9.9.9',
+      },
+    };
+    const mdPath = writeReport([r], reportsDir);
+    // 1) le nom contient le run_id
+    expect(mdPath).toContain('raid-abcd1234');
+    // 2) le rapport vit AUSSI dans le runDir (md ET json)
+    const inRunDir = readdirSync(runDir);
+    expect(inRunDir.some((f) => f.includes('raid-abcd1234') && f.endsWith('.md'))).toBe(true);
+    expect(inRunDir.some((f) => f.includes('raid-abcd1234') && f.endsWith('.json'))).toBe(true);
+    // 3) en-tête d'identité
+    const md = readFileSync(mdPath, 'utf8');
+    expect(md).toContain('raid-abcd1234');
+    expect(md).toContain('deadbeef');
+    expect(md).toContain('v9.9.9');
+    expect(md).toContain('http://127.0.0.1:3100');
+  });
+
+  it('sans identité (appelant legacy) : nom horodaté, un seul dossier', () => {
+    reportsDir = mkdtempSync(join(tmpdir(), 'reports164b-'));
+    runDir = reportsDir;
+    const mdPath = writeReport([runResult()], reportsDir);
+    expect(mdPath).toMatch(/report-\d+\.md$/);
   });
 });


### PR DESCRIPTION
## Le compteur (P1)

- Le **nom** du rapport contient le `run_id`.
- `ls <runDir>` contient le rapport (`.md` **et** `.json`).
- L'**en-tête** porte `run_id · baseSha · essaim vX · coordinator URL`.

Fixes #164.

## Changement

- **`RunResult.identity`** (optionnel) : `{ run_id, run_dir, base_sha?, coordinator_url, version }`, peuplé par l'orchestrateur au retour (tout est déjà en portée + `getVersion()`).
- **`writeReport`** : nomme `report-<run_id>` au lieu de l'horodatage, écrit dans `reports/` **ET** dans le `runDir`, pose l'en-tête d'identité. Sans `identity` (appelant legacy / tests), retombe **exactement** sur l'ancien comportement.

## Choix

`runDir` reste unique via `Date.now()` (pas renommé en `run_id`) : un `ESSAIM_RUN_ID` pré-positionné par un parent/pipeline est partagé entre étapes → un `runDir = run_id` collisionnerait. Le rapport y est simplement copié, nommé par `run_id`.

## Tests

2 cas : identité présente ⇒ nom + copie runDir (md+json) + en-tête ; legacy (sans identité) ⇒ nom horodaté, un seul dossier.

`pnpm test` (885) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)