### PR TITLE
feat(reporter): registre par tâche (id, agent, verdict, motif) au rapport (#162)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -112,10 +112,22 @@ export interface TurnDetail {
   compactionPostTokens: number;
 }
 
+// Registre d'UNE tâche réclamée (#162) : chaque thread réclamé finit en done,
+// refused (garde-fou de falsifiabilité) ou aborted (pas de DONE:). Le `reason`
+// porte le résumé (done) ou le MOTIF du refus/abandon — pour que le rapport dise
+// POURQUOI, au lieu d'un log.warn volatil et d'un post dans un thread éphémère.
+export interface TaskRecord {
+  threadId: string;
+  verdict: "done" | "refused" | "aborted";
+  reason: string;
+}
+
 export interface AgentLoopResult {
   agentId: string;
   exitReason: ExitReason;
   summary: string;
+  // Une entrée par tâche réclamée : id, verdict, motif (#162).
+  taskRecords: TaskRecord[];
   totalCostUsd: number;
   turnsCount: number;
   mqttMessagesProcessed: number;
@@ -577,6 +589,9 @@ export async function runAgentLoop(
   // semis totalement perdu suffit à teindre le run en rouge. Le garde #151
   // (unreachableStreak) ne le voit pas — il ne surveille que le chemin de CLAIM.
   let seedWriteFailed = false;
+  // Registre par tâche (#162) : rempli aux points de règlement (settleDone) et
+  // d'abandon (pas de DONE:), remonté dans AgentLoopResult puis au rapport.
+  const taskRecords: TaskRecord[] = [];
   let summary = "";
   // ── Token + cost diagnostics ──────────────────────────────────────────
   const totalTokens = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
@@ -1416,10 +1431,12 @@ export async function runAgentLoop(
                   // test » sur des tâches reprises en boucle.
                   await postRefusal(config, task.id, verdict.reason);
                   await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
+                  taskRecords.push({ threadId: task.id, verdict: "refused", reason: verdict.reason });
                   return;
                 }
                 logger.info(`Work-stealing: completed${after} — "${taskSummary.slice(0, 80)}"`);
                 await completeTask(config.coordinatorUrl, task.id, config.agentId, taskSummary);
+                taskRecords.push({ threadId: task.id, verdict: "done", reason: taskSummary.slice(0, 140) });
                 // La base ne survit PAS à la complétion : elle n'existe que
                 // pour recoller les tentatives d'un thread INACHEVÉ. Sur refus,
                 // au contraire, on la garde — c'est tout l'objet du correctif.
@@ -1480,6 +1497,7 @@ export async function runAgentLoop(
                     logger.warn(`Work-stealing: aborting task after retry (no DONE:) — unclaiming thread=${task.id} subtype=${retryResp.subtype ?? "?"}`);
                     await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
                     claimedThreadIds.delete(task.id);
+                    taskRecords.push({ threadId: task.id, verdict: "aborted", reason: `pas de DONE: après reprise (${retryResp.subtype ?? "?"})` });
                   }
                 } else {
                   logger.error("Work-stealing: still rate limited after wait — stopping");
@@ -1506,6 +1524,7 @@ export async function runAgentLoop(
                 logger.warn(`Work-stealing: aborting task (no DONE: marker) — unclaiming thread=${task.id} subtype=${resp.subtype ?? "?"}`);
                 await unclaimTask(config.coordinatorUrl, task.id, config.agentId);
                 claimedThreadIds.delete(task.id);
+                taskRecords.push({ threadId: task.id, verdict: "aborted", reason: `pas de DONE: (${resp.subtype ?? "?"})` });
               }
             }
             // Réconcilie l'injoignabilité à TOUTE sortie de boucle, pas seulement
@@ -1643,6 +1662,7 @@ export async function runAgentLoop(
     agentId: config.agentId,
     exitReason,
     summary,
+    taskRecords: taskRecords.slice(),
     totalCostUsd: totalCost,
     turnsCount,
     mqttMessagesProcessed,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -614,6 +614,7 @@ async function _runProjectBody(
       agentResults[i].cost_by_model = loopResult.costByModel;
       agentResults[i].turn_details = loopResult.turnDetails;
       agentResults[i].exit_reason = loopResult.exitReason;
+      agentResults[i].task_records = loopResult.taskRecords;
     }
   }
 

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -554,7 +554,17 @@ async function _runProjectBody(
     });
     try {
       await Promise.race([
-        Promise.allSettled(originalPromises.map((p) => p.catch(() => {}))),
+        Promise.allSettled(originalPromises.map((p, i) =>
+          p.then((v) => {
+            // #162 — l'agent a fini de se rabattre DANS la fenêtre de grâce : on
+            // RÉCUPÈRE son AgentLoopResult (taskRecords, tokens, exit_reason) au
+            // lieu de le jeter. Sans ça, un refus enregistré avant le timeout
+            // global disparaissait du rapport et exit_reason retombait à « N/A ».
+            // On n'écrase JAMAIS un résultat déjà capté par la course ci-dessus.
+            const agentId = entries[i][0];
+            if (!agentLoopResults.has(agentId)) agentLoopResults.set(agentId, v);
+          }).catch(() => {}),
+        )),
         gracePromise,
       ]);
     } finally {

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -181,6 +181,29 @@ export function writeReport(results: RunResult[], outputDir: string): string {
       md += `| ${a.agent_name} | ${a.exit_code} | ${a.exit_reason ?? "N/A"} | ${a.compilation_ok === undefined ? "N/A" : a.compilation_ok ? "OK" : "FAIL"} | ${diffCell} |\n`;
     }
 
+    // Registre des tâches (#162) : POURQUOI chaque thread réclamé a fini
+    // done/refused/aborted. Le motif d'un refus du garde-fou de falsifiabilité
+    // n'était jusqu'ici qu'un log.warn volatil + un post dans un thread éphémère,
+    // jamais dans le rapport — un run avec ≥1 refus n'en gardait aucune trace
+    // lisible. DF5 : le rapport se suffit.
+    const taskRows = r.agent_results.flatMap((a) =>
+      (a.task_records ?? []).map((t) => ({ agent: a.agent_name, ...t })),
+    );
+    if (taskRows.length > 0) {
+      const refused = taskRows.filter((t) => t.verdict === "refused").length;
+      md += `\n### Registre des tâches\n\n`;
+      if (refused > 0) {
+        md += `> ⚠️ ${refused} tâche(s) refusée(s) par le garde-fou de falsifiabilité — motif dans la colonne ci-dessous.\n\n`;
+      }
+      md += `| Tâche | Agent | Verdict | Motif |\n|-------|-------|---------|-------|\n`;
+      for (const t of taskRows) {
+        // Le motif peut contenir `|`/retours ligne (message du garde-fou) : on
+        // les neutralise pour ne pas casser le tableau markdown.
+        const motif = t.reason.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").slice(0, 200);
+        md += `| \`${t.threadId}\` | ${t.agent} | ${t.verdict} | ${motif} |\n`;
+      }
+    }
+
     // Token + cost breakdown (populated from agent-loop runs)
     const agentsWithTokens = r.agent_results.filter((a) => a.tokens);
     if (agentsWithTokens.length > 0) {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -1,7 +1,7 @@
 // src/types.ts
 import type { ChildProcess } from "child_process";
 import type { MiniProjectSecurity, SecurityRunLedger } from "../security/types.js";
-import type { TurnDetail, ExitReason } from "../agent-loop/agent-loop.js";
+import type { TurnDetail, ExitReason, TaskRecord } from "../agent-loop/agent-loop.js";
 
 export interface AgentConfig {
   id: string;
@@ -165,6 +165,10 @@ export interface AgentResult {
   // Why the loop stopped. exit_code alone cannot tell "died before spending
   // anything" from "spent, then died".
   exit_reason?: ExitReason;
+  // Registre par tâche réclamée (#162) : id, verdict (done/refused/aborted) et
+  // motif. Porte au rapport les refus du garde-fou, aujourd'hui seulement logués
+  // et postés dans un thread éphémère — ni l'un ni l'autre n'atteint le rapport.
+  task_records?: TaskRecord[];
 }
 
 export interface ProjectContext {

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -256,3 +256,34 @@ describe('rapport : identité + copie dans le runDir (#164)', () => {
     expect(mdPath).toMatch(/report-\d+\.md$/);
   });
 });
+
+// #162 — le registre par tâche atteint le rapport : un refus du garde-fou de
+// falsifiabilité porte son MOTIF dans reports/<run_id>.md (DF5), au lieu d'un
+// log.warn volatil + un post dans un thread éphémère.
+describe('registre des tâches au rapport (#162)', () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('un refus ⇒ id, agent, verdict ET motif dans le rapport', () => {
+    dir = mkdtempSync(join(tmpdir(), 'rep162-'));
+    const agent: AgentResult = {
+      agent_id: 'a1', agent_name: 'Alpha', exit_code: 0, diff: '', stdout_length: 0,
+      task_records: [
+        { threadId: 't-42', verdict: 'refused', reason: 'aucun fichier de test modifié' },
+        { threadId: 't-43', verdict: 'done', reason: 'corrigé le null check' },
+      ],
+    };
+    const md = readFileSync(writeReport([runResult({}, [agent])], dir), 'utf8');
+    expect(md).toContain('Registre des tâches');
+    expect(md).toContain('t-42');                          // id
+    expect(md).toContain('Alpha');                         // agent
+    expect(md).toContain('refused');                       // verdict
+    expect(md).toContain('aucun fichier de test modifié'); // LE compteur : le MOTIF
+  });
+
+  it('aucun task_records ⇒ pas de section (pas de bruit)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'rep162b-'));
+    const md = readFileSync(writeReport([runResult()], dir), 'utf8');
+    expect(md).not.toContain('Registre des tâches');
+  });
+});

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -544,3 +544,39 @@ describe("runProject — turn details et exit reason dans le rapport", () => {
     expect(agent.turn_details![1].outputTokens).toBe(220);
   });
 });
+
+// ── #162 — le registre des tâches survit au timeout global ──────────────────
+describe("runProject — task_records survit au timeout global (#162)", () => {
+  it("un refus enregistré AVANT le timeout reste dans task_records du rapport", async () => {
+    const stop = vi.fn(async () => {});
+    vi.mocked(startServer).mockResolvedValue({ port: 5556, stop } as never);
+
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent, _ws, _url, _mcp, _prompt, opts) => {
+      return new Promise<AgentLoopResult>((resolve) => {
+        // Ne se résout QUE sur abort : se rabat 50 ms après (dans la fenêtre de
+        // grâce), en portant un refus déjà enregistré avant le timeout global.
+        opts?.abortSignal?.addEventListener("abort", () => {
+          setTimeout(() => resolve({
+            ...makeLoopResult(agent.id, "aborted"),
+            taskRecords: [{ threadId: "t-9", verdict: "refused", reason: "aucun fichier de test modifié" }],
+          }), 50);
+        });
+      });
+    });
+
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "none", base: TMP_DIR },
+      timeout_minutes: 0.0025, // ~150ms — timeout bien avant que l'agent ne finisse seul
+    });
+
+    const result = await runProject(project, "with_coordinator", false, {});
+    const a1 = result.agent_results.find((a) => a.agent_id === "a1");
+    // Sans la capture en fenêtre de grâce, l'AgentLoopResult drainé était jeté →
+    // aucun task_records, exit_reason « N/A ». Le refus disparaissait du rapport.
+    expect(a1?.task_records).toEqual([{ threadId: "t-9", verdict: "refused", reason: "aucun fichier de test modifié" }]);
+    expect(a1?.exit_reason).toBe("aborted");
+  });
+});

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -89,6 +89,7 @@ function makeLoopResult(agentId: string, exitReason: AgentLoopResult["exitReason
     agentId,
     exitReason,
     summary: "ok",
+    taskRecords: [],
     totalCostUsd: 0,
     turnsCount: 1,
     mqttMessagesProcessed: 0,


### PR DESCRIPTION
## Le compteur (P1)

Un run avec **≥1 refus** du garde-fou de falsifiabilité ⇒ le **motif** est dans `reports/<run_id>.md` (avec id, agent, verdict). Fixes #162.

Jusqu'ici le motif d'un refus n'était qu'un `log.warn` volatil + un post dans un thread éphémère — **ni l'un ni l'autre n'atteignait le rapport**. DF5 : le rapport se suffit.

## Changement

- **agent-loop** : `TaskRecord { threadId, verdict: done|refused|aborted, reason }` accumulé aux **4** points de règlement d'un thread réclamé — `settleDone` (done | refused avec le motif du garde-fou) et les deux abandons « pas de DONE: » (aborted). Remonté dans `AgentLoopResult.taskRecords`.
- **orchestrator** : recopié dans `AgentResult.task_records` (à côté d'`exit_reason`).
- **reporter** : section « Registre des tâches » `| Tâche | Agent | Verdict | Motif |` quand il y a des enregistrements ; bandeau ⚠️ sur les refus ; motif échappé (`|`/retours ligne).

## Portée

Les abandons par rate-limit/budget ne produisent pas d'entrée (loggés à part) — le registre couvre done/refused/aborted-no-DONE, ce que vise le compteur. Champs optionnels ⇒ aucun appelant legacy cassé.

## Tests

`pnpm test` (887) + `pnpm build` verts. 2 cas : refus ⇒ motif au rapport ; aucun enregistrement ⇒ pas de section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)