### PR TITLE
feat(reporter): section « Récupérer » + suppression de la recette destructrice (#163)

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -652,14 +652,16 @@ async function _runProjectBody(
     for (const [agentId, wsPath] of workspace.paths) {
       log.info(`  ${agentId}: ${wsPath}  (branch: ${workspace.branches.get(agentId) ?? ""})`);
     }
-    // Preserving costs one branch + one worktree PER AGENT PER RUN, forever.
-    // The recipe belongs here rather than in the README because this is the
-    // moment the pile grows, in front of the person who just grew it, right
-    // under the list of what was kept — no doc lookup between the cost and the
-    // cure. Safe by construction: git refuses `branch -D` on a branch still
-    // checked out in a live worktree, so only orphans go.
+    // Le travail des agents EST ces branches. L'ancienne recette de nettoyage
+    // proposait `git worktree prune && … | xargs -r git branch -D`, qui les
+    // EFFACE (le `prune` en tête retire les worktrees, plus rien ne protège les
+    // branches du `branch -D`), et dont le `xargs -r` n'existe pas sous
+    // PowerShell : la seule commande copiable qu'essaim offrait effaçait le
+    // livrable. On ne propose donc AUCUNE commande destructrice ici — le rapport
+    // porte une section « Récupérer » (git log/diff/cherry-pick) pour inspecter
+    // et rejouer le travail sans risque (#163).
     log.info(
-      "  Cleanup when done: git worktree prune && git branch --list 'mini-project-*' --format='%(refname:short)' | xargs -r git branch -D",
+      "  Travail préservé sur ces branches — voir la section « Récupérer » du rapport (git log/diff/cherry-pick) pour l'inspecter ou le rejouer sur ta branche.",
     );
   }
 

--- a/src/orchestrator/reporter.ts
+++ b/src/orchestrator/reporter.ts
@@ -269,6 +269,23 @@ export function writeReport(results: RunResult[], outputDir: string): string {
       for (const wt of r.worktrees) {
         md += `| ${wt.agent_id} | \`${wt.branch}\` | \`${wt.path}\` |\n`;
       }
+
+      // Récupérer (#163) : le travail de chaque agent vit sur SA branche. On
+      // offre les commandes NON DESTRUCTIVES pour l'inspecter et le rejouer sur
+      // sa propre branche — en remplacement de l'ancienne recette
+      // `git branch -D 'mini-project-*'` (qui EFFAÇAIT le livrable, et dont le
+      // `xargs -r` n'existe pas sous PowerShell). Ces commandes sont du git pur,
+      // portables Windows/POSIX.
+      const base = r.identity?.base_sha;
+      if (base) {
+        md += `\n### Récupérer le travail\n\n`;
+        md += `Chaque agent a commité sur sa branche. Pour inspecter puis rejouer son travail :\n\n`;
+        md += `| Agent | Voir les commits | Voir le diff | Rejouer sur ta branche |\n`;
+        md += `|-------|------------------|--------------|------------------------|\n`;
+        for (const wt of r.worktrees) {
+          md += `| ${wt.agent_id} | \`git log ${base}..${wt.branch}\` | \`git diff ${base}..${wt.branch}\` | \`git cherry-pick ${base}..${wt.branch}\` |\n`;
+        }
+      }
     }
 
     if (r.security) {

--- a/tests/unit/minors.test.ts
+++ b/tests/unit/minors.test.ts
@@ -287,3 +287,36 @@ describe('registre des tâches au rapport (#162)', () => {
     expect(md).not.toContain('Registre des tâches');
   });
 });
+
+// #163 — le rapport offre une section « Récupérer » NON DESTRUCTIVE
+// (git log/diff/cherry-pick par branche) à la place de l'ancienne recette
+// `git branch -D 'mini-project-*'` qui effaçait le livrable (xargs -r absent
+// sous PowerShell par-dessus).
+describe('rapport : section « Récupérer » non destructive (#163)', () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('git log/diff/cherry-pick par branche, jamais de commande qui efface', () => {
+    dir = mkdtempSync(join(tmpdir(), 'rep163-'));
+    const r: RunResult = {
+      ...runResult(),
+      worktrees: [{ agent_id: 'a1', path: '/w/a1', branch: 'mini-project-a1' }],
+      identity: { run_id: 'raid-x', run_dir: dir, base_sha: 'base123', coordinator_url: 'http://c', version: '1.0.0' },
+    };
+    const md = readFileSync(writeReport([r], dir), 'utf8');
+    expect(md).toContain('Récupérer le travail');
+    expect(md).toContain('git log base123..mini-project-a1');    // inspecter
+    expect(md).toContain('git diff base123..mini-project-a1');   // voir le diff
+    expect(md).toContain('git cherry-pick base123..mini-project-a1'); // rejouer
+    // AUCUNE recette destructrice ne subsiste dans le rapport
+    expect(md).not.toContain('branch -D');
+    expect(md).not.toContain('xargs');
+  });
+
+  it('sans base_sha (pas d\'identité) : pas de section « Récupérer » (commandes seraient fausses)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'rep163b-'));
+    const r: RunResult = { ...runResult(), worktrees: [{ agent_id: 'a1', path: '/w/a1', branch: 'b1' }] };
+    const md = readFileSync(writeReport([r], dir), 'utf8');
+    expect(md).not.toContain('Récupérer le travail');
+  });
+});


### PR DESCRIPTION
## Le compteur (P1)

Le rapport porte une section « Récupérer » avec `git log`/`git diff`/`git cherry-pick` par branche ; **aucune** occurrence de `branch -D` ni `xargs`. Fixes #163.

## Le danger retiré

La seule commande copiable qu'essaim offrait **effaçait le livrable** : `git worktree prune && git branch --list 'mini-project-*' … | xargs -r git branch -D`. Le `prune` en tête retire les worktrees → plus rien ne protège les branches du `branch -D`, qui supprime donc le travail des agents. Et `xargs -r` n'existe pas sous PowerShell.

## Correctif

- **orchestrator** : recette destructrice retirée du log de fin de run, remplacée par un pointeur non destructif vers la section « Récupérer ».
- **reporter** : section « Récupérer le travail » par worktree — `git log/diff/cherry-pick <baseSha>..<branch>`, du git **pur et portable** (Windows/POSIX), non destructif. Utilise `identity.base_sha` (#164) + `worktrees[].branch` ; rendue seulement si `base_sha` connu.

> Note : `--cleanup` reste destructif pour l'instant (il fait `git branch -D`) — c'est #158 qui lui fera « garder les branches ». Je ne le présente donc pas ici comme une option sûre.

`pnpm test` (890) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)