### PR TITLE
feat(orchestrator): runs/reports ancrés sur -p ; --cleanup garde les branches (#158)

### DIFF
--- a/cli/run-core.ts
+++ b/cli/run-core.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import { rmSync } from "fs";
 import { scanProject } from "../src/orchestrator/scanner.js";
 import { buildProject, listTemplates } from "../src/orchestrator/template-engine.js";
 import { getCatalogRoots } from "./bce-resolver.js";
@@ -146,6 +147,14 @@ Catalogues consultés : ${roots}`,
     maxQuotaPct: opts.maxQuotaPct,
     coordinatorUrl: resolvedCoordinatorUrl,
   });
-  writeReport([result], "reports");
+  // Rapport ancré sur le dépôt CIBLE (-p), pas le cwd (#158).
+  writeReport([result], resolve(projectPath, "reports"));
+  // --cleanup supprime aussi le runDir (worktrees déjà retirés, branches gardées
+  // par cleanupWorkspaces). Fait ICI, APRÈS le rapport : writeReport a copié le
+  // rapport dans le runDir (#164), mais reports/ en garde l'exemplaire — le
+  // runDir entier peut donc partir sans perdre le livrable ni le rapport (#158).
+  if (opts.cleanup && result.identity?.run_dir) {
+    try { rmSync(result.identity.run_dir, { recursive: true, force: true }); } catch { /* déjà parti / course de teardown */ }
+  }
   return result;
 }

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -172,7 +172,10 @@ async function _runProjectBody(
   effectiveCoordinatorUrl: string,
   coordinatorJustSpawned: boolean,
 ): Promise<RunResult> {
-  const runDir = path.resolve("runs", `${project.id}-${mode}-${Date.now()}`);
+  // Ancré sur le dépôt CIBLE (-p), pas le cwd (#158) : `cd /ailleurs && essaim
+  // run -p <dépôt>` ne doit créer AUCUN dossier dans /ailleurs. workspace.base
+  // porte le -p résolu ; à défaut DEFAULT_BASE = cwd (comportement historique).
+  const runDir = path.resolve(project.workspace.base || DEFAULT_BASE, "runs", `${project.id}-${mode}-${Date.now()}`);
   fs.mkdirSync(runDir, { recursive: true });
 
   // Mint the run id BEFORE any agent starts, so every thread this swarm opens

--- a/src/orchestrator/scanner.ts
+++ b/src/orchestrator/scanner.ts
@@ -111,7 +111,14 @@ export function scanProject(projectPath: string): ProjectContext {
     execSync("git rev-parse --is-inside-work-tree", { cwd: absPath, stdio: "pipe" });
     hasGit = true;
     const status = execSync("git status --porcelain", { cwd: absPath, encoding: "utf-8", stdio: "pipe" });
-    isClean = status.trim().length === 0;
+    // Ignore les artefacts qu'essaim écrit LUI-MÊME dans le dépôt cible (#158) :
+    // runs/ (worktrees) et reports/ non suivis ne sont PAS du travail de
+    // l'utilisateur. Sans ce filtre, le 2e run voyait le dépôt « sale » à cause
+    // du run précédent et affichait un faux « uncommitted changes / dirty state »
+    // (trompeur : les worktrees snapshotent HEAD, jamais l'arbre de travail).
+    const ESSAIM_ARTIFACT = /^..\s+"?(runs|reports)\//;
+    const meaningful = status.split("\n").filter((l) => l.trim() && !ESSAIM_ARTIFACT.test(l));
+    isClean = meaningful.length === 0;
   } catch {}
   const sourceFiles = listSourceFiles(absPath, sourceDirs, lang.extensions, 50);
   const modules = findModules(absPath, sourceDirs);

--- a/src/orchestrator/workspace.ts
+++ b/src/orchestrator/workspace.ts
@@ -85,14 +85,13 @@ export function createWorkspaces(
 
 export function cleanupWorkspaces(workspace: WorkspaceResult): void {
   if (workspace.type !== "worktree") return;
-  for (const [agentId, worktreePath] of workspace.paths) {
-    // Le nom vient de la création, il n'est plus recalculé ici : un nettoyage
-    // qui recalcule est un nettoyage libre de viser la mauvaise branche.
-    const branchName = workspace.branches.get(agentId);
+  for (const [, worktreePath] of workspace.paths) {
+    // #158 — retire les WORKTREES mais GARDE les branches : elles SONT le
+    // livrable de l'agent (le rapport « Récupérer » propose `git cherry-pick`
+    // dessus, #163). Les effacer avec un `--cleanup` censé « ranger » détruisait
+    // le travail — l'ancien `git branch -D` est donc retiré. Le runDir, lui, est
+    // supprimé par l'appelant après l'écriture du rapport (run-core, #158).
     try { execSync(`git worktree remove "${worktreePath}" --force`, { cwd: workspace.basePath, stdio: "pipe" }); } catch {}
-    if (branchName) {
-      try { execSync(`git branch -D "${branchName}"`, { cwd: workspace.basePath, stdio: "pipe" }); } catch {}
-    }
   }
 }
 

--- a/tests/unit/orchestrator-run.test.ts
+++ b/tests/unit/orchestrator-run.test.ts
@@ -580,3 +580,32 @@ describe("runProject — task_records survit au timeout global (#162)", () => {
     expect(a1?.exit_reason).toBe("aborted");
   });
 });
+
+// ── #158 — runs/ ancré sur -p (le dépôt cible), jamais le cwd ────────────────
+describe("runProject — runs/ ancré sur -p, pas le cwd (#158)", () => {
+  it("cd /ailleurs && run -p <dépôt> ⇒ runs/ dans <dépôt>, 0 dans le cwd", async () => {
+    // BASE_DIR = dépôt cible (-p), distinct du cwd (TMP_DIR, où le beforeEach a chdir).
+    const BASE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "essaim-base-"));
+    execSync("git init -q && git config user.email 't@t' && git config user.name 't'", { cwd: BASE_DIR });
+    fs.writeFileSync(path.join(BASE_DIR, ".gitkeep"), "");
+    execSync("git add . && git commit -q -m init", { cwd: BASE_DIR });
+
+    vi.stubGlobal("fetch", makeFetchMock({ a1: true }));
+    vi.mocked(launchAgentLoop).mockImplementation(async (agent) => makeLoopResult(agent.id));
+
+    const project = makeProject({
+      agents: [makeAgent({ id: "a1", name: "Agent A" })],
+      workspace: { type: "none", base: BASE_DIR },
+    });
+
+    try {
+      // coordinatorUrl fourni ⇒ pas de coordinator embarqué (comme le test #107).
+      await runProject(project, "with_coordinator", false, { coordinatorUrl: "http://coordinator.test" });
+      // runs/ créé dans le dépôt CIBLE, PAS dans le cwd
+      expect(fs.existsSync(path.join(BASE_DIR, "runs"))).toBe(true);
+      expect(fs.existsSync(path.join(TMP_DIR, "runs"))).toBe(false);
+    } finally {
+      fs.rmSync(BASE_DIR, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/scanner.test.ts
+++ b/tests/unit/scanner.test.ts
@@ -90,3 +90,20 @@ describe("scanProject", () => {
   });
 });
 
+
+describe("scanProject — is_clean ignore les artefacts essaim (#158)", () => {
+  it("runs/ et reports/ non suivis ne salissent PAS le dépôt ; un vrai fichier, si", () => {
+    const dir = makeProject({ "src/a.ts": "export const a = 1;\n" }); // dépôt propre, commité
+    // essaim écrit SES artefacts (non suivis) dans le dépôt cible (#158) — ce ne
+    // sont pas du travail utilisateur, is_clean doit rester vrai.
+    fs.mkdirSync(path.join(dir, "runs", "run1"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "runs", "run1", "w.txt"), "worktree");
+    fs.mkdirSync(path.join(dir, "reports"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "reports", "report-x.md"), "# r");
+    expect(scanProject(dir).is_clean).toBe(true);
+
+    // un VRAI fichier non suivi de l'utilisateur, lui, salit bien le dépôt
+    fs.writeFileSync(path.join(dir, "user-wip.txt"), "en cours");
+    expect(scanProject(dir).is_clean).toBe(false);
+  });
+});

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -212,11 +212,13 @@ describe("createWorkspaces — isolation entre deux runs successifs", () => {
 
     cleanupWorkspaces(ws1);
 
-    // 4. le nettoyage LIT la map au lieu de recalculer le nom. Sans l'étape 4,
-    //    `git branch -D` viserait `mini-project-agent-chasseur-1` — inexistante
-    //    depuis que le runId entre dans le nom — échouerait dans le `try {}
-    //    catch {}` vide, et la branche du run 1 survivrait au nettoyage.
-    expect(localBranches()).not.toContain(ws1.branches.get("agent-chasseur-1"));
+    // 4. #158 — le nettoyage retire le WORKTREE de ws1 mais GARDE sa branche :
+    //    c'est le livrable de l'agent (le rapport « Récupérer » propose un
+    //    `git cherry-pick` dessus, #163). Seul le worktree part ; la branche du
+    //    run 1 survit, et celle du run 2 (jamais nettoyé) aussi.
+    expect(fs.existsSync(worktree1)).toBe(false); // worktree retiré
+    expect(localBranches()).toContain(ws1.branches.get("agent-chasseur-1")!); // branche GARDÉE
+    expect(localBranches()).toContain(ws2.branches.get("agent-chasseur-1")!);
   });
 });
 


### PR DESCRIPTION
## Le compteur (P1)

`cd /ailleurs && essaim run -p <dépôt>` ⇒ **0 dossier créé dans le cwd** ; `runs/` va dans `<dépôt>`. Et `cleanupWorkspaces` retire le worktree mais **garde la branche**. Fixes #158.

## Changement

- **runDir** ancré sur `workspace.base` (le `-p` résolu), à défaut le cwd (comportement historique préservé).
- **rapport** écrit dans `<projectPath>/reports`.
- **`--cleanup`** redéfini :
  - **garde les branches** (retrait du `git branch -D`) — elles SONT le livrable ; le rapport « Récupérer » (#163) propose un `git cherry-pick` dessus. Les effacer pour « ranger » détruisait le travail.
  - **supprime aussi le runDir**, dans `run-core` **après** `writeReport` : le rapport a été copié dans le runDir (#164) mais `reports/` en garde l'exemplaire — le runDir peut donc partir sans perdre ni le livrable ni le rapport.

`data/` n'est jamais créé dans le cwd (déjà sous `~/.mcp-coordinator`).

## Tests

- `runProject` avec `base` ≠ cwd ⇒ `runs/` dans `base`, **absent** du cwd.
- `cleanupWorkspaces` retire le worktree, **garde** la branche (test d'isolation #141 mis à jour).

`pnpm test` (891) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)