### PR TITLE
fix(scanner): exclusion par segment (+ \) et descente monorepo (#159)

### DIFF
--- a/src/orchestrator/scanner.ts
+++ b/src/orchestrator/scanner.ts
@@ -114,7 +114,13 @@ function findModules(projectPath: string, sourceDirs: string[]): string[] {
       if (entry.isDirectory() && !entry.name.startsWith(".")) modules.push(entry.name);
     }
   }
-  return modules;
+  // DÉDUP obligatoire (#159) : la descente monorepo rend UN source_dir par
+  // paquet (packages/*/src), donc un sous-dossier partagé (components/, utils/)
+  // apparaît une fois PAR paquet. `count: per-module` (migrate-phase2) fabrique
+  // alors deux agents `migrator-components` avec le MÊME id → collision de PK
+  // coordinator + maps id-keyées écrasées + faux « Pre-registration incomplete ».
+  // Couvre aussi le cas pré-existant multi-root (src/ + lib/ avec sous-dossiers homonymes).
+  return [...new Set(modules)];
 }
 
 function computeApplicableTemplates(ctx: Omit<ProjectContext, "applicable_templates">): string[] {

--- a/src/orchestrator/scanner.ts
+++ b/src/orchestrator/scanner.ts
@@ -40,11 +40,46 @@ export function detectLanguage(projectPath: string): LangDetection {
   return { language: "unknown", test_command: "echo 'no test command detected'", extensions: [] };
 }
 
+function isDir(full: string): boolean {
+  try { return fs.statSync(full).isDirectory(); } catch { return false; }
+}
+
 function findDirs(projectPath: string, candidates: string[]): string[] {
-  return candidates.filter(d => {
-    const full = path.join(projectPath, d);
-    return fs.existsSync(full) && fs.statSync(full).isDirectory();
-  });
+  const direct = candidates.filter(d => isDir(path.join(projectPath, d)));
+  if (direct.length > 0) return direct;
+  // #159 — descente d'UN niveau pour les monorepos (pnpm/yarn/turbo : packages/*,
+  // apps/*, libs/*). Le src/ vit dans les paquets, pas à la racine — sans ça un
+  // monorepo pnpm rendait source_dirs VIDE et l'agent ne voyait aucun code.
+  const nested: string[] = [];
+  for (const w of ["packages", "apps", "libs"]) {
+    const wroot = path.join(projectPath, w);
+    if (!isDir(wroot)) continue;
+    let pkgs: fs.Dirent[] = [];
+    try { pkgs = fs.readdirSync(wroot, { withFileTypes: true }); } catch { continue; }
+    for (const pkg of pkgs) {
+      if (!pkg.isDirectory() || pkg.name.startsWith(".")) continue;
+      for (const c of candidates) {
+        const rel = path.join(w, pkg.name, c);
+        if (isDir(path.join(projectPath, rel))) nested.push(rel);
+      }
+    }
+  }
+  return nested;
+}
+
+/**
+ * Un chemin de SUPPORT DE TEST (à écarter du source montré aux agents), par
+ * SEGMENT et non par substring (#159). `rel.includes("test")` écartait
+ * `latest.ts` (la·test) et `inspector.ts` (in·spec·tor) — du code de production
+ * rendu invisible. On écarte si un SEGMENT de répertoire est test/tests/spec/
+ * __tests__, ou si le BASENAME est un test (séparateur exigé : `.test.`,
+ * `_test.`, `-spec.`, `test_…` — jamais « test » collé dans un mot).
+ */
+function isTestPath(rel: string): boolean {
+  const segs = rel.replace(/\\/g, "/").split("/");
+  const base = segs.pop() ?? "";
+  if (segs.some(s => s === "test" || s === "tests" || s === "spec" || s === "__tests__")) return true;
+  return /[._-](test|spec)s?\.[^.]+$/.test(base) || /^test[._-]/.test(base);
 }
 
 function listSourceFiles(projectPath: string, sourceDirs: string[], extensions: string[], max: number): string[] {
@@ -58,7 +93,7 @@ function listSourceFiles(projectPath: string, sourceDirs: string[], extensions: 
         if (entry.isDirectory()) walk(full);
         else if (extensions.length === 0 || extensions.some(ext => entry.name.endsWith(ext))) {
           const rel = path.relative(projectPath, full);
-          if (!rel.includes("test") && !rel.includes("spec") && !rel.includes("_test.")) {
+          if (!isTestPath(rel)) {
             try { files.push({ path: rel, mtime: fs.statSync(full).mtimeMs }); } catch {}
           }
         }

--- a/tests/unit/scanner.test.ts
+++ b/tests/unit/scanner.test.ts
@@ -107,3 +107,31 @@ describe("scanProject — is_clean ignore les artefacts essaim (#158)", () => {
     expect(scanProject(dir).is_clean).toBe(false);
   });
 });
+
+describe("scanner — exclusion par segment + descente monorepo (#159)", () => {
+  it("source_files : latest.ts/inspector.ts VISIBLES (exclusion par segment, pas substring)", () => {
+    const dir = makeProject({
+      "src/latest.ts": "export const a = 1;\n",      // « la·test » : PAS un test
+      "src/inspector.ts": "export const b = 2;\n",   // « in·spec·tor » : PAS un test
+      "src/foo.test.ts": "// vrai test\n",           // écarté (basename .test.)
+      "tests/helper.ts": "export const h = 1;\n",    // écarté (segment tests/)
+    });
+    const files = scanProject(dir).source_files.map(f => f.replace(/\\/g, "/"));
+    expect(files).toContain("src/latest.ts");
+    expect(files).toContain("src/inspector.ts");
+    expect(files).not.toContain("src/foo.test.ts");
+    expect(files.some(f => f.startsWith("tests/"))).toBe(false);
+  });
+
+  it("monorepo pnpm : descente d'UN niveau ⇒ source_dirs non vide", () => {
+    const dir = makeProject({
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+      "packages/pkg-a/src/index.ts": "export const a = 1;\n",
+      "packages/pkg-b/src/main.ts": "export const b = 2;\n",
+    });
+    const dirs = scanProject(dir).source_dirs.map(d => d.replace(/\\/g, "/"));
+    expect(dirs.length).toBeGreaterThan(0);
+    expect(dirs).toContain("packages/pkg-a/src");
+    expect(dirs).toContain("packages/pkg-b/src");
+  });
+});

--- a/tests/unit/scanner.test.ts
+++ b/tests/unit/scanner.test.ts
@@ -134,4 +134,15 @@ describe("scanner — exclusion par segment + descente monorepo (#159)", () => {
     expect(dirs).toContain("packages/pkg-a/src");
     expect(dirs).toContain("packages/pkg-b/src");
   });
+
+  it("modules DÉDUPLIQUÉS sur un monorepo (sous-dossier partagé) — sinon collision d'IDs", () => {
+    // Deux paquets ayant chacun un `components/` : sans dédup, context.modules
+    // aurait deux « components » → per-module fabrique deux agents au même id.
+    const dir = makeProject({
+      "packages/pkg-a/src/components/a.ts": "export const a = 1;\n",
+      "packages/pkg-b/src/components/b.ts": "export const b = 2;\n",
+    });
+    const modules = scanProject(dir).modules;
+    expect(modules.filter(m => m === "components")).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Le compteur (P1)

- `latest.ts` / `inspector.ts` **visibles** dans `source_files`.
- Monorepo pnpm ⇒ `source_dirs` **non vide**.

Fixes #159.

## A — exclusion par segment (+ normalisation `\`)

`rel.includes("test")` écartait `latest.ts` (**la·test**) et `inspector.ts` (**in·spec·tor**) — du code de production rendu invisible. Désormais un fichier est écarté seulement si un **segment de répertoire** est `test`/`tests`/`spec`/`__tests__`, ou si le **basename** est un test (séparateur exigé : `.test.`, `_test.`, `-spec.`, `test_…`).

## B — descente monorepo

Quand `src`/`lib`/… sont absents à la racine, `findDirs` descend d'**un** niveau dans `packages/*`, `apps/*`, `libs/*`. Un monorepo pnpm ne rendait plus `source_dirs` vide.

`pnpm test` (895) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)