### PR TITLE
fix(security): healthCheck avant le scan + « expérimental » au lancement (#170)

### DIFF
--- a/cli/security.ts
+++ b/cli/security.ts
@@ -112,6 +112,9 @@ export function createSecurityCommand(): Command {
     .option("--dry-run", "Preview without launching")
     .option("--coordinator-url <url>", "Coordinator URL (loopback only in v1)")
     .action(async (opts: SecurityCliOpts) => {
+      // #170 — essaim security est EXPÉRIMENTAL (v1, un seul moteur). Le dire une
+      // fois au lancement : les findings demandent une revue humaine.
+      console.error("⚠️  essaim security est EXPÉRIMENTAL (v1, moteur Strix) — relis les findings avant d'agir dessus.");
       const projectPath = resolve(opts.project);
       const { security, triageOnly } = assembleSecurity(opts, projectPath);
       // Comme cli/run.ts : les échecs de préflight (doctor, template inconnu,

--- a/src/security/scan.ts
+++ b/src/security/scan.ts
@@ -28,7 +28,23 @@ export async function runSecurityScan(
   signal: AbortSignal,
 ): Promise<ScanResult> {
   const adapters = registry.resolve(engineIds); // throws on unknown engine (fail-closed config error)
-  const settled = await Promise.allSettled(adapters.map((a) => a.run(scope, signal)));
+  const settled = await Promise.allSettled(adapters.map(async (a): Promise<EngineRunResult> => {
+    // #170 — SANTÉ AVANT SCAN : un moteur absent (Strix non installé, Docker
+    // éteint) doit dire « pip install strix-agent », JAMAIS rapporter « 0
+    // findings » (un faux clean). On sonde healthCheck ; si KO on remonte le
+    // detail en erreur SANS lancer run → degraded → exit rouge + message actionnable.
+    const health = await a.healthCheck().catch((e) => ({ ok: false, detail: (e as Error).message }));
+    if (!health.ok) {
+      const id = a.capabilities.id;
+      log.error(`security: moteur ${id} indisponible — ${health.detail}`);
+      return {
+        engine: id, status: "error", findings: [],
+        startedAt: "", finishedAt: "", durationMs: 0,
+        error: { kind: "unavailable", message: health.detail, retriable: false },
+      };
+    }
+    return a.run(scope, signal);
+  }));
 
   const results: EngineRunResult[] = [];
   const findings: Finding[] = [];

--- a/tests/unit/security-scan.test.ts
+++ b/tests/unit/security-scan.test.ts
@@ -40,6 +40,23 @@ describe("runSecurityScan", () => {
     expect(out.degraded).toBe(true);
   });
 
+  it("moteur indisponible (healthCheck KO) → error/degraded, run() JAMAIS appelé, pas « 0 findings » (#170)", async () => {
+    let runCalled = false;
+    const down: EngineAdapter = {
+      capabilities: { id: "strix" as EngineId, displayName: "strix", modes: ["sast"], requiresRunningTarget: false, supportsDiffScope: true, transport: "process", license: "MIT" },
+      async healthCheck() { return { ok: false, detail: "Strix CLI not found — install with: pip install strix-agent" }; },
+      async run() { runCalled = true; return { engine: "strix" as EngineId, status: "no_vulns", findings: [], startedAt: "", finishedAt: "", durationMs: 0 }; },
+    };
+    const reg = createRegistry();
+    reg.register(down);
+    const out = await runSecurityScan(reg, ["strix"] as EngineId[], scope, new AbortController().signal);
+    expect(runCalled).toBe(false);                       // le scan n'a PAS tourné (sinon « 0 findings » faux clean)
+    expect(out.degraded).toBe(true);                     // degraded → exit rouge, pas un clean
+    expect(out.results[0].status).toBe("error");
+    expect(out.results[0].error?.message).toContain("pip install strix-agent");
+    expect(out.findings).toHaveLength(0);
+  });
+
   it("degraded=true and no throw when an adapter's run() itself rejects", async () => {
     const reg = createRegistry();
     const throwing = adapter("strix", {});


### PR DESCRIPTION
## Le compteur (P1)

Strix absent ⇒ **« pip install strix-agent »**, jamais **« 0 findings »**. Fixes #170.

## Cause

Le message d'installation existait (`strix.ts` `healthCheck`) mais n'était **jamais appelé** : `runSecurityScan` lançait `a.run()` directement → un Strix/Docker absent rapportait « 0 findings » (faux clean).

## Correctif

- `runSecurityScan` sonde `healthCheck` **avant** `run` ; si KO, remonte le detail comme résultat `error` (`kind: unavailable`) **sans** lancer `run` → `degraded` → exit rouge + message actionnable.
- `essaim security` affiche **« EXPÉRIMENTAL (v1) »** une fois au lancement.

Test : `healthCheck` KO ⇒ `run()` jamais appelé, `degraded`, status `error`, message « pip install strix-agent », 0 finding (mais **pas** un clean).

`pnpm build` vert + tests security verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)