### PR TITLE
fix(preflight): « quota indisponible » en ligne texte, pas un log.warn JSON (#173)

### DIFF
--- a/src/orchestrator/preflight.ts
+++ b/src/orchestrator/preflight.ts
@@ -60,12 +60,16 @@ export async function preflightQuotaCheck(opts: PreflightOptions): Promise<Prefl
   }
 
   if (resp.status === 503) {
-    let detail = "quota unavailable";
+    let detail = "quota indisponible sur cette plateforme";
     try {
       const body = await resp.json() as { reason?: string };
-      if (body?.reason) detail = `quota unavailable: ${body.reason}`;
+      if (body?.reason) detail = `quota indisponible : ${body.reason}`;
     } catch { /* ignore */ }
-    log.warn(`pre-flight: ${detail} — proceeding without guardrail`);
+    // #173 — une LIGNE TEXTE lisible, pas un log.warn JSON. Ce 503 est le cas
+    // fréquent sous Windows (le jeton d'abonnement n'y est souvent pas lisible) :
+    // au démarrage, `{"level":40,"msg":"…"}` est du bruit. Fail-open : on continue
+    // sans le garde-fou de quota.
+    console.error(`⚠️  ${detail} — le run continue sans le garde-fou de quota.`);
     return { canProceed: true, reason: detail };
   }
 

--- a/tests/unit/preflight.test.ts
+++ b/tests/unit/preflight.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { preflightQuotaCheck } from "../../src/orchestrator/preflight.js";
+
+// #173 — « quota indisponible sur cette plateforme » doit être une LIGNE TEXTE
+// lisible au démarrage (fréquent sous Windows, où le jeton d'abonnement n'est
+// souvent pas lisible → 503), pas un log.warn JSON pino illisible.
+describe("preflightQuotaCheck — quota indisponible en ligne texte (#173)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("503 ⇒ console.error d'une ligne texte (pas du JSON), et fail-open (canProceed)", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchFn = (async () => ({
+      status: 503,
+      ok: false,
+      json: async () => ({ reason: "jeton illisible" }),
+    })) as unknown as typeof fetch;
+
+    const res = await preflightQuotaCheck({ coordinatorUrl: "http://c", maxUtilizationPct: 90, fetchFn });
+
+    expect(res.canProceed).toBe(true); // fail-open : le run continue
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0] as string;
+    expect(typeof line).toBe("string");
+    expect(line).toContain("quota indisponible");
+    expect(line.trim().startsWith("{")).toBe(false); // une vraie ligne, pas du JSON
+  });
+});


### PR DESCRIPTION
## Le compteur (P1)

Sur Windows, « quota indisponible sur cette plateforme » sort en **ligne texte** lisible au démarrage, plus en `log.warn` JSON pino. Fixes #173.

## Correctif

Le 503 du endpoint `/api/quota` (fréquent sous Windows : le jeton d'abonnement n'y est souvent pas lisible) émettait `log.warn` → `{"level":40,"msg":"…"}`. Remplacé par un `console.error` d'une ligne texte. Fail-open **inchangé** (`canProceed: true`).

Test : `503` ⇒ `console.error` avec une `string` (pas du JSON), `canProceed`.

`pnpm build` + test verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)