### PR TITLE
fix(agent-loop): honorer les overrides model/thinking de phase-execute (#169)

### DIFF
--- a/src/agent-loop/agent-loop.ts
+++ b/src/agent-loop/agent-loop.ts
@@ -1334,7 +1334,20 @@ export async function runAgentLoop(
               );
               const severity = parseSeverity(task.description);
               const upgraded = upgradeEffort(baseLevel, { severity });
-              const execProfile = EFFORT_PROFILES[upgraded];
+              // #169 — HONORER les overrides model/thinking de phase-execute. Le
+              // levier documenté ne marchait que sur discover/review (via
+              // phaseEffortProfile) ; execute prenait le profil BRUT, donc
+              // `--set phase-execute.model=X` était ignoré sur la phase la plus
+              // chère. Le maxTurns reste piloté par le profil/sévérité (cf. note
+              // ci-dessus), seuls model/thinking sont surchargés.
+              const baseProfile = EFFORT_PROFILES[upgraded];
+              const execProfile = {
+                ...baseProfile,
+                model: phase.model && phase.model !== "" ? phase.model : baseProfile.model,
+                thinking: phase.thinking && phase.thinking !== "" && isThinkingLevel(phase.thinking)
+                  ? phase.thinking
+                  : baseProfile.thinking,
+              };
               if (upgraded !== baseLevel) {
                 logger.info(`Effort upgrade: ${baseLevel} → ${upgraded} (severity=${severity})`);
               } else {

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -816,6 +816,37 @@ describe("runAgentLoop — phased mode", () => {
     expect(result.exitReason).not.toBe("done"); // faux vert banni (#184)
   });
 
+  it("honore l'override model de phase-execute (--set phase-execute.model=X) — le send de la tâche l'utilise (#169)", async () => {
+    vi.useFakeTimers();
+    const config = makePhasedConfig({
+      phases: [
+        { name: "discover", prompt: "Scan", toolsMode: "read_only", loop: false },
+        { name: "execute", prompt: "Fix: {{params.current_task}}", toolsMode: "full", loop: true, model: "custom-exec-model" },
+      ],
+    });
+    mockSend.mockResolvedValueOnce({
+      content: "DISCOVERY:\nsrc/a.ts | 10 | Bug A | major",
+      toolCalls: [], costUsd: 0.01, durationMs: 200, sessionId: "s1",
+    });
+    mockParseDiscoveries.mockReturnValue([{ id: "", description: "Bug A", file: "src/a.ts", line: 10, severity: "major" }]);
+    mockPostDiscoveries.mockResolvedValue([{ id: "t-1", description: "Bug A", file: "src/a.ts" }]);
+    let claimCall = 0;
+    mockClaimNextTask.mockImplementation(async () => {
+      claimCall++;
+      return claimCall === 1 ? { id: "t-1", description: "Bug A", file: "src/a.ts", severity: undefined } : null;
+    });
+    mockSend.mockResolvedValueOnce({ content: "DONE: fixed", toolCalls: [], costUsd: 0.02, durationMs: 300, sessionId: "s1" });
+
+    const loop = runAgentLoop(config, silentLogger);
+    for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(10_000);
+    await loop;
+
+    // Le send de la tâche execute doit porter le model SURCHARGÉ, pas le profil
+    // brut d'effort — sinon `--set phase-execute.model=X` est un levier mort.
+    const execCall = mockSend.mock.calls.find((c) => (c[1] as { model?: string } | undefined)?.model === "custom-exec-model");
+    expect(execCall, "un send de tâche avec model=custom-exec-model").toBeDefined();
+  });
+
   it("claims and executes tasks in work-stealing loop", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Le compteur (P1)

`--set phase-execute.model=X` ⇒ `turn_details[].model === X`. Fixes #169.

## Cause

Les overrides `model`/`thinking` étaient honorés sur discover/review (via `phaseEffortProfile`) mais **pas** dans la boucle execute, qui prenait le profil d'effort **brut** (`EFFORT_PROFILES[upgraded]`). Résultat : le levier documenté était mort sur la phase la plus chère.

## Correctif

Surcharger `model`/`thinking` d'`execProfile` avec `phase.model`/`phase.thinking` quand fournis. Le `maxTurns` reste piloté par le profil/sévérité (le signal d'upgrade par sévérité ne doit pas être masqué).

Test : `phase-execute` avec `model:"custom-exec-model"` ⇒ le send de la tâche porte ce model.

`pnpm build` + 57 tests agent-loop verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)