### PR TITLE
feat(run): gitignorer les artefacts essaim — git status propre après un run (#174)

### DIFF
--- a/cli/run-core.ts
+++ b/cli/run-core.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path";
 import { rmSync } from "fs";
 import { resolveEffort, EFFORT_PROFILES, type EffortLevel } from "../src/agent-loop/effort.js";
+import { ensureEssaimGitignore } from "../src/orchestrator/gitignore.js";
 import { scanProject } from "../src/orchestrator/scanner.js";
 import { buildProject, listTemplates } from "../src/orchestrator/template-engine.js";
 import { getCatalogRoots } from "./bce-resolver.js";
@@ -163,6 +164,9 @@ Catalogues consultés : ${roots}`,
     return undefined;
   }
 
+  // Garde le dépôt cible propre : gitignore runs/reports/.claude/.mcp.json AVANT
+  // qu'ils apparaissent (#174). Après le dry-run (qui n'écrit rien).
+  ensureEssaimGitignore(projectPath);
   const result = await runProject(project, "with_coordinator", opts.cleanup, {
     maxQuotaPct: opts.maxQuotaPct,
     coordinatorUrl: resolvedCoordinatorUrl,

--- a/src/orchestrator/gitignore.ts
+++ b/src/orchestrator/gitignore.ts
@@ -1,0 +1,32 @@
+// src/orchestrator/gitignore.ts — garde le dépôt cible propre après un run (#174).
+import { existsSync, readFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+const MARKER = "# --- essaim (managed) ---";
+const BLOCK = [
+  MARKER,
+  "runs/",       // worktrees + artefacts par run (ancrés sur -p depuis #158)
+  "reports/",    // rapports par run
+  ".claude/",    // hooks / settings assemblés par run
+  ".mcp.json",   // config MCP déposée par run
+  "# --- end essaim ---",
+].join("\n");
+
+/**
+ * Ajoute (idempotent, via marqueur) au `.gitignore` du dépôt les artefacts
+ * qu'essaim écrit lors d'un run — runs/, reports/, .claude/, .mcp.json. Sans ça,
+ * un run sur un dépôt neuf laissait `git status` sale (#174, corollaire de #158
+ * qui ancre runs/reports sur -p). Best-effort : une écriture qui échoue (ou un
+ * répertoire hors dépôt git) ne bloque JAMAIS le run.
+ */
+export function ensureEssaimGitignore(projectPath: string): void {
+  try {
+    const giPath = join(projectPath, ".gitignore");
+    const existing = existsSync(giPath) ? readFileSync(giPath, "utf8") : "";
+    if (existing.includes(MARKER)) return; // déjà patché
+    const prefix = existing && !existing.endsWith("\n") ? "\n" : "";
+    appendFileSync(giPath, `${prefix}${BLOCK}\n`);
+  } catch {
+    /* best-effort : ne pas faire échouer un run sur une écriture .gitignore */
+  }
+}

--- a/tests/unit/gitignore.test.ts
+++ b/tests/unit/gitignore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "fs";
+import { execSync } from "child_process";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ensureEssaimGitignore } from "../../src/orchestrator/gitignore.js";
+
+// #174 — après un run sur un dépôt neuf, `git status` ne doit pas être sali par
+// les artefacts essaim (runs/, reports/, .claude/, .mcp.json), ancrés sur le
+// dépôt cible depuis #158.
+describe("ensureEssaimGitignore (#174)", () => {
+  let dir: string;
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("les artefacts d'un run ne salissent PAS git status", () => {
+    dir = mkdtempSync(join(tmpdir(), "gi174-"));
+    execSync("git init -q && git config user.email t@t && git config user.name t", { cwd: dir });
+    writeFileSync(join(dir, "src.ts"), "export const a = 1;\n");
+    execSync("git add . && git commit -qm init", { cwd: dir });
+
+    ensureEssaimGitignore(dir);
+
+    // essaim dépose ses artefacts
+    mkdirSync(join(dir, "runs", "r1"), { recursive: true }); writeFileSync(join(dir, "runs", "r1", "x"), "w");
+    mkdirSync(join(dir, "reports"), { recursive: true }); writeFileSync(join(dir, "reports", "rep.md"), "r");
+    mkdirSync(join(dir, ".claude"), { recursive: true }); writeFileSync(join(dir, ".claude", "settings.json"), "{}");
+    writeFileSync(join(dir, ".mcp.json"), "{}");
+
+    const status = execSync("git status --porcelain", { cwd: dir, encoding: "utf8" })
+      .trim().split("\n").filter(Boolean);
+    // aucune ligne ne mentionne un artefact essaim (le .gitignore lui-même, lui,
+    // est un changement légitime que l'utilisateur commite)
+    expect(status.some((l) => /runs\/|reports\/|\.claude\/|\.mcp\.json/.test(l))).toBe(false);
+  });
+
+  it("idempotent : deux appels ⇒ un seul bloc, couvrant les artefacts", () => {
+    dir = mkdtempSync(join(tmpdir(), "gi174b-"));
+    ensureEssaimGitignore(dir);
+    ensureEssaimGitignore(dir);
+    const gi = readFileSync(join(dir, ".gitignore"), "utf8");
+    expect(gi.match(/essaim \(managed\)/g)?.length).toBe(1);
+    expect(gi).toContain("runs/");
+    expect(gi).toContain("reports/");
+    expect(gi).toContain(".mcp.json");
+  });
+
+  it("préserve un .gitignore existant (append, pas écrasement)", () => {
+    dir = mkdtempSync(join(tmpdir(), "gi174c-"));
+    writeFileSync(join(dir, ".gitignore"), "node_modules/\ndist/\n");
+    ensureEssaimGitignore(dir);
+    const gi = readFileSync(join(dir, ".gitignore"), "utf8");
+    expect(gi).toContain("node_modules/"); // l'existant survit
+    expect(gi).toContain("runs/");
+  });
+});


### PR DESCRIPTION
## Le compteur (P1)

`git status` propre après un run sur un dépôt neuf. Fixes #174.

## Correctif

Corollaire de #158 (runs/reports ancrés sur `-p`) : un run déposait `runs/`, `reports/`, `.claude/`, `.mcp.json` dans le dépôt cible, salissant `git status`. `ensureEssaimGitignore` ajoute un bloc géré (idempotent via marqueur ; **append**, jamais écrasement) au `.gitignore`, appelé au début d'un vrai run (après le dry-run). Best-effort : une écriture qui échoue ne bloque pas le run.

`jq` est déjà vérifié par `essaim doctor` (#148).

## Tests

Artefacts créés ⇒ `git status` ne les montre pas ; idempotent (un seul bloc) ; `.gitignore` existant préservé.

`pnpm build` + test verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)