### PR TITLE
fix(presets): scopes raid/swarm/melee paramétriques sur source_dirs/test_dirs (#156)

### DIFF
--- a/behaviors/project-context.yaml
+++ b/behaviors/project-context.yaml
@@ -15,6 +15,14 @@ params:
     type: "string[]"
     required: false
     description: "Project modules"
+  source_dirs:
+    type: "string[]"
+    required: false
+    description: "Répertoires de code source du projet (calculés par le scanner)"
+  test_dirs:
+    type: "string[]"
+    required: false
+    description: "Répertoires de tests du projet (calculés par le scanner)"
 
 sections:
   "000-identity":
@@ -23,3 +31,5 @@ sections:
       - Langage: {{params.language}}
       - Commande de test: {{params.test_command}}
       - Modules: {{params.modules}}
+      - Répertoires source: {{params.source_dirs}}
+      - Répertoires de test: {{params.test_dirs}}

--- a/presets/melee.yaml
+++ b/presets/melee.yaml
@@ -19,11 +19,10 @@ params:
       Identifie les fonctions non testées, les branches non couvertes,
       et les edge cases manquants dans les tests existants.
 
-      🎯 SCOPE STRICT — cherche UNIQUEMENT dans `tests/` (les fichiers
-      de test vivent dans `tests/unit/` ; le reste de `tests/` sert de
-      contexte de référence). Le code d'implémentation (server/,
-      client/, bce/, cli/, dashboard/) est HORS-SUJET. Si tu lis
-      ailleurs que `tests/`, tu gaspilles ton budget de tours.
+      🎯 SCOPE STRICT — cherche UNIQUEMENT dans les répertoires de test du
+      projet (listés sous « Contexte du projet »). Le code d'implémentation
+      (les répertoires source) et le reste sont HORS-SUJET. Si tu lis
+      ailleurs, tu gaspilles ton budget de tours.
     effort: low
   phase-review:
     review_mission: >
@@ -36,10 +35,9 @@ params:
       Écris le test manquant. Assure-toi qu'il passe (green test).
       Utilise le framework de test du projet.
 
-      🎯 SCOPE STRICT — tu n'écris QUE dans `tests/unit/` et tu ne lis
-      QUE le fichier cible mentionné dans la tâche. Le reste du dépôt
-      (server/, client/, bce/, cli/, dashboard/, autres fichiers sous
-      tests/) est HORS-SUJET. Ne spawne AUCUN sous-agent.
+      🎯 SCOPE STRICT — tu n'écris QUE dans les répertoires de test du projet
+      (« Contexte du projet ») et tu ne lis QUE le fichier cible mentionné
+      dans la tâche. Le reste est HORS-SUJET. Ne spawne AUCUN sous-agent.
     # Sonnet (mid) est suffisant pour écrire un test manquant — à "high"
     # (Opus), l'agent dépensait son budget en exploration avant d'atteindre
     # DONE. Sonnet + scope strict ci-dessus = moins d'excursions.

--- a/presets/raid.yaml
+++ b/presets/raid.yaml
@@ -20,10 +20,10 @@ params:
       nulles/undefined non gérées, problèmes de concurrence, conditions
       limites dans les boucles, et gestion d'exceptions incorrecte.
 
-      🎯 SCOPE STRICT — cherche UNIQUEMENT dans `tests/sandbox/src/`. Le
-      reste du dépôt (server/, client/, bce/, cli/, dashboard/) est
-      HORS-SUJET. Si tu lis ailleurs que tests/sandbox/, tu gaspilles ton
-      budget de tours.
+      🎯 SCOPE STRICT — cherche UNIQUEMENT dans les répertoires source du
+      projet (listés sous « Contexte du projet »). Le reste (tests,
+      dépendances, config, docs, artefacts de build) est HORS-SUJET. Si tu
+      lis ailleurs, tu gaspilles ton budget de tours.
     # Sonnet + think — plus décisif sur "quand stopper l'exploration" et
     # produit des discoveries mieux ciblées que Haiku pour ce type de chasse aux bugs.
     effort: mid
@@ -39,10 +39,10 @@ params:
       que le bug existe. Inclus un commentaire décrivant le comportement
       attendu vs le comportement actuel.
 
-      🎯 SCOPE STRICT — tu ne lis et ne modifies QUE les fichiers sous
-      `tests/sandbox/` (pour comprendre le bug) et `tests/unit/` (pour
-      y écrire le test). Le reste du dépôt (server/, client/, bce/,
-      cli/, dashboard/) est HORS-SUJET. Ne spawne AUCUN sous-agent.
+      🎯 SCOPE STRICT — tu ne lis QUE les répertoires source du projet (pour
+      comprendre le bug) et tu n'écris le test QUE dans les répertoires de
+      test — tous listés sous « Contexte du projet ». Le reste est HORS-SUJET.
+      Ne spawne AUCUN sous-agent.
     # Sonnet (mid) est suffisant pour écrire un test failing — précédemment
     # à "high" (Opus), l'agent dépensait son budget en exploration avant
     # d'atteindre DONE. Sonnet + scope strict ci-dessus = moins d'excursions.

--- a/presets/swarm.yaml
+++ b/presets/swarm.yaml
@@ -20,10 +20,10 @@ params:
       fonctions trop longues, les violations de principes SOLID, et
       le code mort.
 
-      🎯 SCOPE STRICT — cherche UNIQUEMENT dans le code source sous
-      `src/` (et `lib/` s'il existe). Le reste du dépôt (tests/, docs/,
-      bce/, cli/, dashboard/, bin/) est HORS-SUJET. Si tu lis ailleurs
-      que `src/`/`lib/`, tu gaspilles ton budget de tours.
+      🎯 SCOPE STRICT — cherche UNIQUEMENT dans les répertoires source du
+      projet (listés sous « Contexte du projet »). Le reste (tests,
+      dépendances, config, docs, artefacts de build) est HORS-SUJET. Si tu
+      lis ailleurs, tu gaspilles ton budget de tours.
     effort: low
   phase-review:
     review_mission: >
@@ -36,9 +36,9 @@ params:
       Effectue le refactoring identifié. Vérifie que les tests passent
       après chaque modification. Ne change pas le comportement externe.
 
-      🎯 SCOPE STRICT — tu ne modifies QUE le fichier cible mentionné
-      dans la tâche et le code source associé sous `src/`. Le reste du
-      dépôt (tests/, docs/, bce/, cli/, dashboard/, bin/) est HORS-SUJET.
+      🎯 SCOPE STRICT — tu ne modifies QUE le fichier cible mentionné dans la
+      tâche et le code source associé, sous les répertoires source du projet
+      (« Contexte du projet »). Le reste est HORS-SUJET.
       Ne spawne AUCUN sous-agent.
     # Sonnet (mid) est suffisant pour un refactoring ciblé — à "high"
     # (Opus), l'agent dépensait son budget en exploration avant d'atteindre

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -79,7 +79,7 @@ const AGENT_NAMES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot'];
 
 export function buildProjectFromBce(
   templateId: string,
-  context: { path: string; language: string; test_command: string; modules: string[]; source_files: string[] },
+  context: { path: string; language: string; test_command: string; modules: string[]; source_files: string[]; source_dirs?: string[]; test_dirs?: string[] },
   options?: { agentCount?: number; setParams?: Record<string, Record<string, unknown>>; catalogs?: string[] },
   projectPath?: string,
 ): BceMiniProject {
@@ -153,6 +153,11 @@ export function buildProjectFromBce(
           language: context.language,
           test_command: context.test_command,
           modules: context.modules,
+          // #156 — répertoires source/test réels du dépôt CIBLE (scanner) : les
+          // presets raid/swarm/melee y réfèrent au lieu de coder en dur des
+          // chemins essaim (tests/sandbox/, bce/, dashboard/…).
+          source_dirs: context.source_dirs ?? [],
+          test_dirs: context.test_dirs ?? [],
         },
         ...(agentDef.params ?? {}),
         ...perModuleParams,

--- a/tests/unit/cli-bridge.test.ts
+++ b/tests/unit/cli-bridge.test.ts
@@ -84,3 +84,25 @@ describe("buildSoloPrompt", () => {
   });
 });
 
+
+describe("scope paramétrique sur source_dirs/test_dirs (#156)", () => {
+  const goContext = {
+    path: "/tmp/go", language: "go", test_command: "go test ./...",
+    modules: ["pkg", "cmd"], source_files: ["pkg/x.go"],
+    source_dirs: ["pkg", "cmd"], test_dirs: ["test"],
+  };
+
+  for (const preset of ["raid", "swarm", "melee"]) {
+    it(`${preset} contre un dépôt non-TS : 0 littéral essaim, répertoires réels présents`, () => {
+      const project = buildProjectFromBce(preset, goContext);
+      const allText = project.agents
+        .flatMap((a) => [a.prompt, ...(a.phases ?? []).map((p) => p.prompt)])
+        .join("\n");
+      for (const lit of ["tests/sandbox", "bce/", "dashboard/", "server/", "client/"]) {
+        expect(allText, `${preset} contient encore le littéral essaim ${lit}`).not.toContain(lit);
+      }
+      // le contexte porte les répertoires RÉELS du dépôt cible
+      expect(allText).toContain("pkg");
+    });
+  }
+});


### PR DESCRIPTION
## Le compteur (P1)

Prompt assemblé de raid/swarm/melee contre un fixture Go ⇒ **0 littéral** `tests/sandbox`/`bce/`/`dashboard/`/`server/`/`client/`, et les répertoires réels (`pkg`, `cmd`) apparaissent dans le contexte. **BLOQUANT** (DF2). Fixes #156.

## Cause

Les blocs SCOPE STRICT codaient en dur des chemins essaim. Sur un dépôt tiers, « HORS-SUJET (server/, bce/, dashboard/…) » désignait le vrai code du projet, et « cherche dans tests/sandbox/src/ » n'existait pas.

## Correctif

- **project-context** : params `source_dirs`/`test_dirs` (calculés par le scanner), affichés dans « Contexte du projet ».
- **bridge** : les passe en launchParams.
- **raid/swarm/melee** : les missions SCOPE réfèrent « les répertoires source/de test du projet (voir Contexte) » — plus aucun chemin essaim.

Rendu vérifié (`Répertoires source: pkg,cmd` + SCOPE générique). 3 tests (raid/swarm/melee sur fixture Go).

`pnpm test` (902) + `pnpm build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)