### PR TITLE
fix(mqtt): backoff exponentiel plafonné sur le reconnect (#33)

### DIFF
--- a/src/agent-loop/mqtt-listener.ts
+++ b/src/agent-loop/mqtt-listener.ts
@@ -234,6 +234,10 @@ export function buildInterrupt(
 // rather than spin. Giving up is announced once, loudly.
 const RECONNECT_PERIOD_MS = 5_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
+// #33 — backoff EXPONENTIEL plafonné entre deux tentatives (5s→10s→20s, cap 30s)
+// plutôt qu'un intervalle fixe : ne pas marteler un ingress (Tailscale/Envoy) qui
+// refuse l'upgrade WS. Le cap 30s garde giveUp() atteignable dans un temps borné.
+const MAX_RECONNECT_PERIOD_MS = 30_000;
 
 export function createMqttListener(options: MqttListenerOptions): MqttListener {
   const { url, agentId, coordinatorUrl } = options;
@@ -407,6 +411,7 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
           hasConnected = true;
           isConnected = true;
           reconnectAttempts = 0; // a successful connect earns a fresh budget
+          if (client?.options) client.options.reconnectPeriod = RECONNECT_PERIOD_MS; // #33 — repart du backoff de base
           void catchUpOpenConsultations();
           const org = orgFromToken(coordinatorToken());
           const topics = topicsForOrg(org);
@@ -455,6 +460,16 @@ export function createMqttListener(options: MqttListenerOptions): MqttListener {
           isConnected = false;
           if (++reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
             giveUp(`${MAX_RECONNECT_ATTEMPTS} reconnect attempts failed`);
+            return;
+          }
+          // #33 — backoff exponentiel plafonné : la PROCHAINE tentative attend
+          // 2× plus longtemps (5s, 10s, 20s… cap 30s). mqtt.js relit
+          // reconnectPeriod entre deux tentatives.
+          if (client?.options) {
+            client.options.reconnectPeriod = Math.min(
+              RECONNECT_PERIOD_MS * 2 ** reconnectAttempts,
+              MAX_RECONNECT_PERIOD_MS,
+            );
           }
         });
       });

--- a/tests/unit/mqtt-backoff.test.ts
+++ b/tests/unit/mqtt-backoff.test.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 // Fake mqtt client — just enough surface for the listener.
 class FakeClient extends EventEmitter {
   ended = false;
+  options = { reconnectPeriod: 5000 }; // mqtt.js relit reconnectPeriod entre deux tentatives (#33)
   subscribe = vi.fn((_topics: unknown, cb: (e?: Error) => void) => cb());
   end = vi.fn((_force?: boolean) => { this.ended = true; });
 }
@@ -91,5 +92,27 @@ describe('mqtt-listener — backoff et abandon (#33)', () => {
     await expect(promise).rejects.toThrow('initial refusal');
     expect(fake.end).toHaveBeenCalled();
     expect(listener.connected).toBe(false);
+  });
+});
+
+// #33 — backoff exponentiel plafonné entre deux tentatives, plutôt qu'un
+// intervalle fixe qui martèle un ingress refusant l'upgrade WS.
+describe('mqtt-listener — backoff exponentiel plafonné (#33)', () => {
+  it('double le délai à chaque reconnexion, plafonné à 30s', () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    listener.connect().catch(() => {});
+    const periods: number[] = [];
+    for (let i = 0; i < 4; i++) { fake.emit('reconnect'); periods.push(fake.options.reconnectPeriod); }
+    // 5s×2^1=10s, ×2^2=20s, ×2^3=40s→cap 30s, ×2^4=80s→cap 30s
+    expect(periods).toEqual([10_000, 20_000, 30_000, 30_000]);
+  });
+
+  it('une connexion réussie remet le délai de base (5s)', () => {
+    const listener = createMqttListener({ url: 'ws://c/mqtt', agentId: 'a1', agentModules: [] });
+    listener.connect().catch(() => {});
+    fake.emit('reconnect'); fake.emit('reconnect'); // délai monté à 20s
+    expect(fake.options.reconnectPeriod).toBe(20_000);
+    fake.emit('connect');
+    expect(fake.options.reconnectPeriod).toBe(5_000); // repart de zéro
   });
 });


### PR DESCRIPTION
## Contexte

Contre un coordinator distant (wss derrière un ingress Tailscale/Envoy), le listener retentait à intervalle **fixe**. Le loop serré infini était déjà géré (`period 5s` + cap 5 + `giveUp`) ; restait le « possibly backoff too » de l'issue. Fixes #33.

## Correctif

**Backoff exponentiel plafonné** : la prochaine tentative attend 2× plus longtemps (5s→10s→20s, cap 30s). Une connexion réussie remet `reconnectPeriod` à 5s. Le cap 30s garde `giveUp()` atteignable dans un temps borné. Guardé sur `client?.options`.

> Le root cause infra (pourquoi l'upgrade WS échoue à travers **cet** ingress) reste à investiguer sur l'environnement distant — non reproductible ici. La dégradation gracieuse (run complet sans push) est intacte.

## Tests

Le délai double et plafonne à 30s ; une connexion réussie le remet à 5s.

`pnpm build` + tests mqtt verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)