### PR TITLE
feat(run): option --max-budget-usd — plafond dollar par agent (#167)

### DIFF
--- a/cli/run-core.ts
+++ b/cli/run-core.ts
@@ -31,6 +31,8 @@ export interface ExecuteRunOptions {
   coordinatorUrl?: string;
   baseRef?: string;
   maxQuotaPct?: number;
+  /** Hard per-agent dollar ceiling, forwarded to `claude --max-budget-usd` (#167). */
+  maxBudgetUsd?: number;
   /** Catalogues externes (--catalog, répétable). */
   catalogs?: string[];
   security?: import("../src/security/types.js").MiniProjectSecurity;
@@ -170,6 +172,7 @@ Catalogues consultés : ${roots}`,
   const result = await runProject(project, "with_coordinator", opts.cleanup, {
     maxQuotaPct: opts.maxQuotaPct,
     coordinatorUrl: resolvedCoordinatorUrl,
+    maxBudgetUsd: opts.maxBudgetUsd,
   });
   // Rapport ancré sur le dépôt CIBLE (-p), pas le cwd (#158).
   writeReport([result], resolve(projectPath, "reports"));

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -68,6 +68,7 @@ export function createRunCommand(): Command {
     )
     .option("--base-ref <ref>", "Git ref for worktree snapshot (tag, branch, sha) — use for sandbox testing against a fixed codebase")
     .option("--max-quota-pct <pct>", "Abort pre-flight if Anthropic quota utilization is at/above this % (default 95, also reads MAX_QUOTA_PCT env)")
+    .option("--max-budget-usd <usd>", "Hard dollar ceiling per agent, forwarded to `claude --max-budget-usd`. An agent that reaches it exits with reason budget_exceeded.")
     .action(
       async (
         template: string | undefined,
@@ -84,6 +85,7 @@ export function createRunCommand(): Command {
           coordinatorUrl?: string;
           baseRef?: string;
           maxQuotaPct?: string;
+          maxBudgetUsd?: string;
           catalog: string[];
         },
       ) => {
@@ -130,6 +132,7 @@ export function createRunCommand(): Command {
             coordinatorUrl: opts.coordinatorUrl ?? opts.url,
             baseRef: opts.baseRef,
             maxQuotaPct: opts.maxQuotaPct ? Number(opts.maxQuotaPct) : undefined,
+            maxBudgetUsd: opts.maxBudgetUsd ? Number(opts.maxBudgetUsd) : undefined,
             catalogs: opts.catalog,
           });
         } catch (e) {

--- a/src/orchestrator/agent-launcher.ts
+++ b/src/orchestrator/agent-launcher.ts
@@ -145,6 +145,10 @@ export interface LaunchAgentLoopOptions {
   // work-stealing tasks. Typically matches the orchestrator's pre-flight
   // threshold so the agent mirrors the raid-level policy.
   maxQuotaPct?: number;
+  // Hard dollar ceiling forwarded to `claude --max-budget-usd`. When the agent
+  // hits it, the CLI ends with result subtype error_max_budget_usd, which the
+  // loop maps to ExitReason=budget_exceeded (#167).
+  maxBudgetUsd?: number;
 }
 
 export async function launchAgentLoop(
@@ -185,6 +189,7 @@ export async function launchAgentLoop(
     deadlineMs: opts.deadlineMs,
     abortSignal: opts.abortSignal,
     maxQuotaPct: opts.maxQuotaPct,
+    maxBudgetUsd: opts.maxBudgetUsd,
     env: {
       COORDINATOR_URL: coordinatorUrl,
       COORDINATOR_AGENT_ID: agent.id,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -118,6 +118,8 @@ export interface RunProjectOptions {
    * in-process and the URL is set to http://localhost:<PORT>.
    */
   coordinatorUrl?: string;
+  /** Hard per-agent dollar ceiling, forwarded to `claude --max-budget-usd` (#167). */
+  maxBudgetUsd?: number;
 }
 
 export async function runProject(
@@ -406,6 +408,7 @@ async function _runProjectBody(
         deadlineMs,
         abortSignal: agentLoopAbort.signal,
         maxQuotaPct: agentLoopMaxQuotaPct,
+        maxBudgetUsd: runOpts.maxBudgetUsd,
       });
       agentLoopPromises.set(agent.id, loopPromise);
       return null; // no ChildProcess to track

--- a/tests/unit/agent-launcher.test.ts
+++ b/tests/unit/agent-launcher.test.ts
@@ -6,6 +6,11 @@ vi.mock("../../src/agent-loop/claude-stream.js", () => ({
   resolveClaudeBin: vi.fn(() => "/resolved/path/to/claude"),
 }));
 
+// ── Mock the loop itself so launchAgentLoop's config is inspectable ─────
+vi.mock("../../src/agent-loop/agent-loop.js", () => ({
+  runAgentLoop: vi.fn(() => Promise.resolve({ exitReason: "done" })),
+}));
+
 function makeMockChild() {
   const stdout = new Readable({ read() {} });
   const stderr = new Readable({ read() {} });
@@ -28,7 +33,8 @@ vi.mock("child_process", () => ({
   }),
 }));
 
-import { waitForProcess, launchAgent } from "../../src/orchestrator/agent-launcher.js";
+import { waitForProcess, launchAgent, launchAgentLoop } from "../../src/orchestrator/agent-launcher.js";
+import { runAgentLoop } from "../../src/agent-loop/agent-loop.js";
 import type { AgentConfig } from "../../src/orchestrator/types.js";
 
 describe("waitForProcess", () => {
@@ -86,5 +92,32 @@ describe("launchAgent", () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     const [bin] = (spawn as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(bin).toBe("/resolved/path/to/claude");
+  });
+});
+
+describe("launchAgentLoop", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // #167 — le plafond dollar (--max-budget-usd de l'option CLI) doit traverser
+  // launchAgentLoop jusqu'au config remis à runAgentLoop. Sans la ligne
+  // maxBudgetUsd: opts.maxBudgetUsd, il tombe à undefined et l'agent dépense sans borne.
+  it("forwards maxBudgetUsd into the agent-loop config", async () => {
+    const agent: AgentConfig = { id: "a1", name: "Agent One", prompt: "do work" } as AgentConfig;
+
+    await launchAgentLoop(agent, "/workspace", "http://localhost:3100", null, undefined, {
+      maxBudgetUsd: 0.05,
+    });
+
+    const config = (runAgentLoop as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(config.maxBudgetUsd).toBe(0.05);
+  });
+
+  it("leaves maxBudgetUsd undefined when the option is absent (no accidental cap)", async () => {
+    const agent: AgentConfig = { id: "a1", name: "Agent One", prompt: "do work" } as AgentConfig;
+
+    await launchAgentLoop(agent, "/workspace", "http://localhost:3100", null);
+
+    const config = (runAgentLoop as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(config.maxBudgetUsd).toBeUndefined();
   });
 });

--- a/tests/unit/claude-stream.test.ts
+++ b/tests/unit/claude-stream.test.ts
@@ -199,6 +199,10 @@ describe("buildArgs", () => {
     expect(args).toContain("Read,Write");
     expect(args).toContain("--session-id");
     expect(args).toContain("abc-123");
+    // #167 — le plafond dollar doit atteindre le CLI claude ; sans la ligne
+    // args.push("--max-budget-usd", …) de buildClaudeArgs, ces deux-là tombent.
+    expect(args).toContain("--max-budget-usd");
+    expect(args).toContain("5");
     expect(args).toContain("--dangerously-skip-permissions");
   });
 


### PR DESCRIPTION
## Le compteur (P1)

`essaim run <template> -p . --max-budget-usd 0.05` ⇒ un agent qui atteint 0,05 \$ sort avec **ExitReason=budget_exceeded**. Closes #167.

## Ce qui manquait

Toute la chaîne agent-loop→claude était **déjà là et testée** : `config.maxBudgetUsd` → flag `claude --max-budget-usd` (claude-stream:252) → subtype `error_max_budget_usd` → `BudgetExceededError` → `exitReason=budget_exceeded` (agent-loop:1638). Mais **rien ne positionnait `config.maxBudgetUsd`** — champ mort, toujours `undefined` en prod, aucune option CLI.

Câblage du drapeau sur les **4 couches**, à l'identique du patron `maxQuotaPct` : `run.ts` → `run-core` (ExecuteRunOptions) → `orchestrator` (RunProjectOptions) → `agent-launcher` (LaunchAgentLoopOptions → AgentLoopConfig).

**Garde Cadrage respectée** : `claude` 2.1.251 accepte bien `--max-budget-usd` (vérifié via `claude --help`) — l'option n'est pas morte.

## Tests falsifiables

- **agent-launcher** : `launchAgentLoop` threade `maxBudgetUsd` dans le config (rouge sans la ligne `maxBudgetUsd: opts.maxBudgetUsd` — vérifié) ; le laisse `undefined` sans option (pas de plafond accidentel).
- **claude-stream** : ferme la feuille non couverte — `maxBudgetUsd:5` était passé au builder mais `--max-budget-usd` n'était jamais asserté.

906 tests verts, build OK, option visible sur `essaim run --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)